### PR TITLE
Add posibility to recursively find test scripts in configured directory

### DIFF
--- a/config.py
+++ b/config.py
@@ -46,6 +46,9 @@ atf_build_dir = work_dir + "atf_build/"
 
 scripts_clone_dir = work_dir + "sdl_atf_test_scripts/"
 
+# test_scripts_dir is dir where atomatic tool will search test scripts for running
+test_scripts_dir = scripts_clone_dir + "test_scripts/"
+
 test_run_dir = work_dir + "test_run/"
 reports_dir = test_run_dir + "reports/"
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -154,7 +154,7 @@ def tests_run():
     if not exists(config.test_run_dir):
         print("{} does not exists".format(config.test_run_dir))
     with cd(config.test_run_dir):
-        output = run('ls test_scripts')
+        output = run('find {} -name "*.lua"'.format(config.test_scripts_dir))
         scripts = output.split()
         known_issues = run("cat KnownIssues.md")
         known_issues = get_known_issues(known_issues)
@@ -164,7 +164,7 @@ def tests_run():
             print("Execute {}".format(script))
             with settings(warn_only=True):
                 output = run('''./start.sh --storeFullSDLLogs \
-                             --sdl_core=./SDL_bin/ test_scripts/{} |\
+                             --sdl_core=./SDL_bin/ {} |\
                              tee console_output'''.format(script))
                 script_reports_dir = "{}/{}".format(config.reports_dir, script)
                 run("mkdir -p {}".format(script_reports_dir))


### PR DESCRIPTION
- Added variable with name of directory with test scripts to config.py
- Updated way to find scripts in test directory 

Related task : [APPLINK-25934](https://adc.luxoft.com/jira/browse/APPLINK-25934)