### PR TITLE
Added script for requirement [GENIVI] [Policy] "Proprietary" flow: SD…

### DIFF
--- a/test_scripts/Polices/build_options/001_ATF_P_TC_SDL_Build_Flag_DEXTENDED_POLICY_PROPRIETARY.lua
+++ b/test_scripts/Polices/build_options/001_ATF_P_TC_SDL_Build_Flag_DEXTENDED_POLICY_PROPRIETARY.lua
@@ -1,0 +1,52 @@
+---------------------------------------------------------------------------------------------
+-- Requirements summary:
+-- [GENIVI] [Policy] "Proprietary" flow:
+-- SDL must be build with "-DEXTENDED_POLICY: PROPRIETARY"
+--
+-- Description:
+-- To "switch on" the "Proprietary" flow of PolicyTableUpdate feature
+-- -> SDL should be built with -DEXTENDED_POLICY: PROPRIETARY flag
+-- 1. Performed steps
+-- Build SDL with flag above
+--
+-- Expected result:
+-- SDL is successfully built
+-- The flag EXTENDED_POLICY is set to ROPRIETARY
+-- PTU passes successfully
+
+---------------------------------------------------------------------------------------------
+
+--[[ General configuration parameters ]]
+config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local testCasesForPolicyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
+
+--[[ General Precondition before ATF start ]]
+commonSteps:DeleteLogsFileAndPolicyTable()
+config.defaultProtocolVersion = 2
+
+--[[ General Settings for configuration ]]
+Test = require('connecttest')
+require('cardinalities')
+require('user_modules/AppTypes')
+
+--[[ Test ]]
+
+function Test:TestStep_Device_Consented()
+  testCasesForPolicyTable:trigger_getting_device_consent(self, config.application1.registerAppInterfaceParams.appName, config.deviceMAC)
+end
+
+function Test:TestStep_SUCCEESS_Flow_EXTERNAL_PROPRIETARY()
+  testCasesForPolicyTable:flow_SUCCEESS_EXTERNAL_PROPRIETARY(self)
+end
+
+--[[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postconditions")
+function Test.Postcondition_Stop_SDL()
+  StopSDL()
+end
+
+return Test

--- a/test_scripts/Polices/build_options/001_ATF_P_TC_SDL_Build_Flag_DEXTENDED_POLICY_PROPRIETARY.lua
+++ b/test_scripts/Polices/build_options/001_ATF_P_TC_SDL_Build_Flag_DEXTENDED_POLICY_PROPRIETARY.lua
@@ -34,11 +34,6 @@ require('cardinalities')
 require('user_modules/AppTypes')
 
 --[[ Test ]]
-
-function Test:TestStep_Device_Consented()
-  testCasesForPolicyTable:trigger_getting_device_consent(self, config.application1.registerAppInterfaceParams.appName, config.deviceMAC)
-end
-
 function Test:TestStep_SUCCEESS_Flow_EXTERNAL_PROPRIETARY()
   testCasesForPolicyTable:flow_SUCCEESS_EXTERNAL_PROPRIETARY(self)
 end


### PR DESCRIPTION
…L must be build with "-DEXTENDED_POLICY: PROPRIETARY"

Common functions should be taken from latest commit of user_modules at branch /external_proprietary_policy

@istoimenova Please review