### PR TITLE
Updated test script with AtLeast function

### DIFF
--- a/test_scripts/Polices/Validation_of_PolicyTables/277_ATF_Store_wers_country_code_in_PT.lua
+++ b/test_scripts/Polices/Validation_of_PolicyTables/277_ATF_Store_wers_country_code_in_PT.lua
@@ -1,20 +1,20 @@
 ---------------------------------------------------------------------------------------------
 -- Requirement summary:
---    [Policies] "wers_country_code" storage into PolicyTable
+-- [Policies] "wers_country_code" storage into PolicyTable
 --
 -- Description:
---     Getting "wers_country_code" from HMI and storing it by PolicyManager
---     1. Used preconditions:
---      Stop SDL
---      Delete log file and policy table if any
---      Start SDL
+-- Getting "wers_country_code" from HMI and storing it by PolicyManager
+-- 1. Used preconditions:
+-- Stop SDL
+-- Delete log file and policy table if any
+-- Start SDL
 --
---     2. Performed steps
---      Check policy table for 'wers_country_code'
+-- 2. Performed steps
+-- Check policy table for 'wers_country_code'
 --
 -- Expected result:
---     SDL must send GetSystemInfo to HMI;
---     SDL must set received value to "wers_country_code" section of "module_meta" section in PolicyTable
+-- SDL must send GetSystemInfo to HMI;
+-- SDL must set received value to "wers_country_code" section of "module_meta" section in PolicyTable
 ---------------------------------------------------------------------------------------------
 --[[ General configuration parameters ]]
 config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
@@ -55,11 +55,11 @@ commonFunctions:newTestCasesGroup("Test")
 
 function Test:TestStep1_SDL_requests_systemInfo_on_InitHMI()
   self:initHMI_onReady()
-  EXPECT_HMICALL("BasicCommunication.GetSystemInfo"):Times(1)
+  EXPECT_HMICALL("BasicCommunication.GetSystemInfo"):Times(AtLeast(1))
   :Do(function(_,data)
-    self.hmiConnection:SendResponse(data.id, "BasicCommunication.GetSystemInfo", "SUCCESS",
-      {ccpu_version ="OpenS", language ="EN-US",wersCountryCode = "open_wersCountryCode"})
-  end)
+      self.hmiConnection:SendResponse(data.id, "BasicCommunication.GetSystemInfo", "SUCCESS",
+        {ccpu_version ="OpenS", language ="EN-US",wersCountryCode = "open_wersCountryCode"})
+    end)
 end
 
 function Test:TestStep2_Check_wers_country_code_stored_in_PT()

--- a/test_scripts/Polices/Validation_of_PolicyTables/278_ATF_Store_language_in_PT.lua
+++ b/test_scripts/Polices/Validation_of_PolicyTables/278_ATF_Store_language_in_PT.lua
@@ -1,20 +1,20 @@
 ---------------------------------------------------------------------------------------------
 -- Requirement summary:
---   [Policies] "language" storage into PolicyTable
+-- [Policies] "language" storage into PolicyTable
 --
 -- Description:
---     Getting "language" from HMI and storing it by PolicyManager
---     1. Used preconditions:
---      Stop SDL
---      Delete log file and policy table if any
---      Start SDL
+-- Getting "language" from HMI and storing it by PolicyManager
+-- 1. Used preconditions:
+-- Stop SDL
+-- Delete log file and policy table if any
+-- Start SDL
 --
---     2. Performed steps
---      Check policy table for 'language'
+-- 2. Performed steps
+-- Check policy table for 'language'
 --
 -- Expected result:
---     SDL must send GetSystemInfo to HMI;
---     SDL must set received value to "language" section of "module_meta" section in PolicyTable
+-- SDL must send GetSystemInfo to HMI;
+-- SDL must set received value to "language" section of "module_meta" section in PolicyTable
 ---------------------------------------------------------------------------------------------
 --[[ General configuration parameters ]]
 config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
@@ -54,11 +54,11 @@ end
 commonFunctions:newTestCasesGroup("Test")
 function Test:TestStep1_SDL_requests_systemInfo_on_InitHMI()
   self:initHMI_onReady()
-  EXPECT_HMICALL("BasicCommunication.GetSystemInfo"):Times(1)
+  EXPECT_HMICALL("BasicCommunication.GetSystemInfo"):Times(AtLeast(1))
   :Do(function(_,data)
-  self.hmiConnection:SendResponse(data.id, "BasicCommunication.GetSystemInfo", "SUCCESS", {ccpu_version ="OpenS",
-  language ="EN-US",wersCountryCode = "open_wersCountryCode"})
-  end)
+      self.hmiConnection:SendResponse(data.id, "BasicCommunication.GetSystemInfo", "SUCCESS", {ccpu_version ="OpenS",
+          language ="EN-US",wersCountryCode = "open_wersCountryCode"})
+    end)
 end
 
 function Test:TestStep2_Check_language_stored_in_PT()

--- a/test_scripts/Polices/Validation_of_PolicyTables/279_ATF_RAI_ccpu_version_via_GetSystemInfo.lua
+++ b/test_scripts/Polices/Validation_of_PolicyTables/279_ATF_RAI_ccpu_version_via_GetSystemInfo.lua
@@ -1,18 +1,18 @@
 ---------------------------------------------------------------------------------------------
 -- Requirement summary:
---    [RegisterAppInterface] "ccpu_version" obtaining via GetSystemInfo
+-- [RegisterAppInterface] "ccpu_version" obtaining via GetSystemInfo
 --
 -- Description:
---     Getting "ccpu_version" via GetSystemInfo on each SDL starts
---     1. Used preconditions:
---      SDL and HMI are running
+-- Getting "ccpu_version" via GetSystemInfo on each SDL starts
+-- 1. Used preconditions:
+-- SDL and HMI are running
 --
---     2. Performed steps
---      Check policy table for 'ccpu_version'
+-- 2. Performed steps
+-- Check policy table for 'ccpu_version'
 --
 -- Expected result:
---     SDL must request 'ccpu_version' parameter from HMI via GetSystemInfo HMI API;
---     SDL must request 'ccpu_version' ONLY once in ign cycle
+-- SDL must request 'ccpu_version' parameter from HMI via GetSystemInfo HMI API;
+-- SDL must request 'ccpu_version' ONLY once in ign cycle
 ---------------------------------------------------------------------------------------------
 --[[ General configuration parameters ]]
 config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
@@ -51,11 +51,11 @@ commonFunctions:newTestCasesGroup("Test")
 
 function Test:TestStep1_SDL_sends_GetSystemInfo_on_InitHMI()
   self:initHMI_onReady()
-  EXPECT_HMICALL("BasicCommunication.GetSystemInfo"):Times(1)
+  EXPECT_HMICALL("BasicCommunication.GetSystemInfo"):Times(AtLeast(1))
   :Do(function(_,data)
-  self.hmiConnection:SendResponse(data.id, "BasicCommunication.GetSystemInfo", "SUCCESS", {ccpu_version ="OpenS",
-  language ="EN-US",wersCountryCode = "open_wersCountryCode"})
-  end)
+      self.hmiConnection:SendResponse(data.id, "BasicCommunication.GetSystemInfo", "SUCCESS", {ccpu_version ="OpenS",
+          language ="EN-US",wersCountryCode = "open_wersCountryCode"})
+    end)
 end
 
 function Test:TestStep2_Check_ccpu_version_stored_in_PT()
@@ -89,13 +89,13 @@ function Test:TestStep3_Check_ccpu_version_sent_on_RAI()
   self.mobileSession = mobile_session.MobileSession(self, self.mobileConnection)
   self.mobileSession:StartService(7)
   :Do(function()
-    local correlationId = self.mobileSession:SendRPC("RegisterAppInterface", config.application1.registerAppInterfaceParams)
-    EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered")
-    :Do(function(_,data)
-      self.HMIAppID = data.params.application.appID
+      local correlationId = self.mobileSession:SendRPC("RegisterAppInterface", config.application1.registerAppInterfaceParams)
+      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered")
+      :Do(function(_,data)
+          self.HMIAppID = data.params.application.appID
+        end)
+      self.mobileSession:ExpectResponse(correlationId, { success = true, resultCode = "SUCCESS", systemSoftwareVersion = "OpenS"})
     end)
-    self.mobileSession:ExpectResponse(correlationId, { success = true, resultCode = "SUCCESS", systemSoftwareVersion = "OpenS"})
-  end)
 end
 
 --[[ Postconditions ]]


### PR DESCRIPTION
Function AtLeast() was used to method Times() because script does not handle all HMI <-> SDL communications, first occurrence of BasicCommunication.GetSystemInfo is enough for reach goal of test