### PR TITLE
029 Script for requirements covering invalid HMI response in gerneral and due to fake params

### DIFF
--- a/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
+++ b/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
@@ -75,7 +75,6 @@ end
 
 --[[ Test ]]
 commonFunctions:newTestCasesGroup("Test")
---UI invalid HMI response: HMI->SDL, resultcode - invalid
 for i =1, #invalid_data do
   Test["TestStep_GENERIC_ERROR_PerformAudioPassThru_UI_HMI_replies_" .. invalid_data[i].descr] = function(self)
       local CorIdPerformAudioPassThru= self.mobileSession:SendRPC("PerformAudioPassThru",
@@ -126,7 +125,7 @@ for i =1, #invalid_data do
 	      }
 	    })
 	  :Do(function(_,data) 
-		self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"available":true,"method":"UI.PerformAudioPassThru", "code":'..tostring(invalid_data[i].value)..'}}')	
+		self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"UI.PerformAudioPassThru", "code":'..tostring(invalid_data[i].value)..'}}')	
       end)
 
   if
@@ -172,11 +171,12 @@ for i =1, #invalid_data do
 	      appID = self.applications[config.application1.registerAppInterfaceParams.appName]
 	    })
 	  :Do(function(_,data)
-	      self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"available":true,"method":"UI.PerformAudioPassThru", "code":'..tostring(invalid_data[i].value)..'}}')
-	      
+	  	self.hmiConnection:SendNotification("TTS.Started",{})
+	      	      
 	      local function ttsSpeakResponse()
-	        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS")
+	        self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"TTS.Started", "code":'..tostring(invalid_data[i].value)..'}}')
 	        self.hmiConnection:SendNotification("TTS.Stopped")
+
 	      end
 	      RUN_AFTER(ttsSpeakResponse, 1000)
 	  end)

--- a/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
+++ b/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
@@ -9,9 +9,9 @@
 --
 -- Description:
 -- In case HMI sends invalid response by any reason that SDL must transfer it to mobile app
--- (possible reasons to invalidate response include: mandatory params are missing, params out of bounds, invalid json, incorrect combination of params or 
+-- (possible reasons to invalidate response include: mandatory params are missing, params out of bounds, invalid json, incorrect combination of params or
 -- SDL has cut fake parameters from response)
--- SDL must: respond GENERIC_ERROR (success:false, <info>) to mobile app 
+-- SDL must: respond GENERIC_ERROR (success:false, <info>) to mobile app
 -- (info: "Invalid message received from vehicle" - if invalid response sent from HMI)
 --
 -- 1. Used preconditions
@@ -48,7 +48,6 @@ local invalid_data = {
 
 --[[Local functions]]
 
-
 --[[ General Precondition before ATF start ]]
 commonSteps:DeleteLogsFiles()
 config.defaultProtocolVersion = 2
@@ -77,152 +76,152 @@ end
 commonFunctions:newTestCasesGroup("Test")
 for i =1, #invalid_data do
   Test["TestStep_GENERIC_ERROR_PerformAudioPassThru_UI_HMI_replies_" .. invalid_data[i].descr] = function(self)
-      local CorIdPerformAudioPassThru= self.mobileSession:SendRPC("PerformAudioPassThru",
-	    {
-	      initialPrompt = {{text = "Makeyourchoice",type = "TEXT"}},
-	      audioPassThruDisplayText1 = "DisplayText1",
-	      audioPassThruDisplayText2 = "DisplayText2",
-	      samplingRate = "16KHZ",
-	      maxDuration = 2000,
-	      bitsPerSample = "8_BIT",
-	      audioType = "PCM",
-	      muteAudio = true,
-	      audioPassThruIcon =
-		    { 
-		      value = "icon.png",
-		      imageType = "STATIC"
-		    }
-	    })
-	  EXPECT_HMICALL("TTS.Speak",
-	    {
-	      speakType = "AUDIO_PASS_THRU",
-	      ttsChunks = {{text = "Makeyourchoice", type = "TEXT"}},
-	      appID = self.applications[config.application1.registerAppInterfaceParams.appName]
-	    })
-	  :Do(function(_,data)
-	      self.hmiConnection:SendNotification("TTS.Started",{})
-	      
-	      local function ttsSpeakResponse()
-	        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS")
-	        self.hmiConnection:SendNotification("TTS.Stopped")
-	      end
-	      RUN_AFTER(ttsSpeakResponse, 1000)
-	  end)
+    local CorIdPerformAudioPassThru= self.mobileSession:SendRPC("PerformAudioPassThru",
+      {
+        initialPrompt = {{text = "Makeyourchoice",type = "TEXT"}},
+        audioPassThruDisplayText1 = "DisplayText1",
+        audioPassThruDisplayText2 = "DisplayText2",
+        samplingRate = "16KHZ",
+        maxDuration = 2000,
+        bitsPerSample = "8_BIT",
+        audioType = "PCM",
+        muteAudio = true,
+        audioPassThruIcon =
+        {
+          value = "icon.png",
+          imageType = "STATIC"
+        }
+      })
+    EXPECT_HMICALL("TTS.Speak",
+      {
+        speakType = "AUDIO_PASS_THRU",
+        ttsChunks = {{text = "Makeyourchoice", type = "TEXT"}},
+        appID = self.applications[config.application1.registerAppInterfaceParams.appName]
+      })
+    :Do(function(_,data)
+        self.hmiConnection:SendNotification("TTS.Started",{})
 
-	  EXPECT_HMICALL("UI.PerformAudioPassThru",
-	    {
-	      appID = self.applications[config.application1.registerAppInterfaceParams.appName],
-	      audioPassThruDisplayTexts = {
-	        {fieldName = "audioPassThruDisplayText1", fieldText = "DisplayText1"},
-	        {fieldName = "audioPassThruDisplayText2", fieldText = "DisplayText2"},
-	      },
-	      maxDuration = 2000,
-	      muteAudio = true,
-	      audioPassThruIcon = 
-	      { 
-	        imageType = "STATIC", 
-	        value = "icon.png"
-	      }
-	    })
-	  :Do(function(_,data) 
-		self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"UI.PerformAudioPassThru", "code":'..tostring(invalid_data[i].value)..'}}')	
+        local function ttsSpeakResponse()
+          self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS")
+          self.hmiConnection:SendNotification("TTS.Stopped")
+        end
+        RUN_AFTER(ttsSpeakResponse, 1000)
       end)
 
-  if
-	  (self.appHMITypes["NAVIGATION"] == true) or
-	  (self.appHMITypes["COMMUNICATION"] == true) or
-	  (self.isMediaApplication == true) then
+    EXPECT_HMICALL("UI.PerformAudioPassThru",
+      {
+        appID = self.applications[config.application1.registerAppInterfaceParams.appName],
+        audioPassThruDisplayTexts = {
+          {fieldName = "audioPassThruDisplayText1", fieldText = "DisplayText1"},
+          {fieldName = "audioPassThruDisplayText2", fieldText = "DisplayText2"},
+        },
+        maxDuration = 2000,
+        muteAudio = true,
+        audioPassThruIcon =
+        {
+          imageType = "STATIC",
+          value = "icon.png"
+        }
+      })
+    :Do(function(_,data)
+        self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"UI.PerformAudioPassThru", "code":'..tostring(invalid_data[i].value)..'}}')
+      end)
 
-	  EXPECT_NOTIFICATION("OnHMIStatus",
-      {hmiLevel = "FULL", audioStreamingState = "ATTENUATED", systemContext = "MAIN"},
-      {hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN"})
-    :Times(2)
-  else
-    EXPECT_NOTIFICATION("OnHMIStatus"):Times(0)
+    if
+    (self.appHMITypes["NAVIGATION"] == true) or
+    (self.appHMITypes["COMMUNICATION"] == true) or
+    (self.isMediaApplication == true) then
+
+      EXPECT_NOTIFICATION("OnHMIStatus",
+        {hmiLevel = "FULL", audioStreamingState = "ATTENUATED", systemContext = "MAIN"},
+        {hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN"})
+      :Times(2)
+    else
+      EXPECT_NOTIFICATION("OnHMIStatus"):Times(0)
+    end
+
+    self.mobileSession:ExpectResponse(CorIdPerformAudioPassThru, {success = false, resultCode = "GENERIC_ERROR", info ="Invalid message received from vehicle" })
+    EXPECT_NOTIFICATION("OnHashChange",{}):Times(0)
   end
-
-  self.mobileSession:ExpectResponse(CorIdPerformAudioPassThru, {success = false, resultCode = "GENERIC_ERROR", info ="Invalid message received from vehicle" })
-  EXPECT_NOTIFICATION("OnHashChange",{}):Times(0)
-  end 
 end
 
 for i =1, #invalid_data do
   Test["TestStep_GENERIC_ERROR_PerformAudioPassThru_TTS_HMI_replies_" .. invalid_data[i].descr] = function(self)
-      local CorIdPerformAudioPassThru= self.mobileSession:SendRPC("PerformAudioPassThru",
-	    {
-	      initialPrompt = {{text = "Makeyourchoice",type = "TEXT"}},
-	      audioPassThruDisplayText1 = "DisplayText1",
-	      audioPassThruDisplayText2 = "DisplayText2",
-	      samplingRate = "16KHZ",
-	      maxDuration = 2000,
-	      bitsPerSample = "8_BIT",
-	      audioType = "PCM",
-	      muteAudio = true,
-	      audioPassThruIcon =
-		    { 
-		      value = "icon.png",
-		      imageType = "STATIC"
-		    }
-	    })
-	  EXPECT_HMICALL("TTS.Speak",
-	    {
-	      speakType = "AUDIO_PASS_THRU",
-	      ttsChunks = {{text = "Makeyourchoice", type = "TEXT"}},
-	      appID = self.applications[config.application1.registerAppInterfaceParams.appName]
-	    })
-	  :Do(function(_,data)
-	  	self.hmiConnection:SendNotification("TTS.Started",{})
-	      	      
-	      local function ttsSpeakResponse()
-	        self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"TTS.Started", "code":'..tostring(invalid_data[i].value)..'}}')
-	        self.hmiConnection:SendNotification("TTS.Stopped")
+    local CorIdPerformAudioPassThru= self.mobileSession:SendRPC("PerformAudioPassThru",
+      {
+        initialPrompt = {{text = "Makeyourchoice",type = "TEXT"}},
+        audioPassThruDisplayText1 = "DisplayText1",
+        audioPassThruDisplayText2 = "DisplayText2",
+        samplingRate = "16KHZ",
+        maxDuration = 2000,
+        bitsPerSample = "8_BIT",
+        audioType = "PCM",
+        muteAudio = true,
+        audioPassThruIcon =
+        {
+          value = "icon.png",
+          imageType = "STATIC"
+        }
+      })
+    EXPECT_HMICALL("TTS.Speak",
+      {
+        speakType = "AUDIO_PASS_THRU",
+        ttsChunks = {{text = "Makeyourchoice", type = "TEXT"}},
+        appID = self.applications[config.application1.registerAppInterfaceParams.appName]
+      })
+    :Do(function(_,data)
+        self.hmiConnection:SendNotification("TTS.Started",{})
 
-	      end
-	      RUN_AFTER(ttsSpeakResponse, 1000)
-	  end)
+        local function ttsSpeakResponse()
+          self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"TTS.Speak", "code":'..tostring(invalid_data[i].value)..'}}')
+          self.hmiConnection:SendNotification("TTS.Stopped")
+        end
 
-	  EXPECT_HMICALL("UI.PerformAudioPassThru",
-	    {
-	      appID = self.applications[config.application1.registerAppInterfaceParams.appName],
-	      audioPassThruDisplayTexts = {
-	        {fieldName = "audioPassThruDisplayText1", fieldText = "DisplayText1"},
-	        {fieldName = "audioPassThruDisplayText2", fieldText = "DisplayText2"},
-	      },
-	      maxDuration = 2000,
-	      muteAudio = true,
-	      audioPassThruIcon = 
-	      { 
-	        imageType = "STATIC", 
-	        value = "icon.png"
-	      }
-	    })
-	  :Do(function(_,data) 
-		self.hmiConnection:SendResponse(data.id, "UI.PerformAudioPassThru", "SUCCESS", {})
+        RUN_AFTER(ttsSpeakResponse, 1000)
       end)
 
-  if
-	  (self.appHMITypes["NAVIGATION"] == true) or
-	  (self.appHMITypes["COMMUNICATION"] == true) or
-	  (self.isMediaApplication == true) then
+    EXPECT_HMICALL("UI.PerformAudioPassThru",
+      {
+        appID = self.applications[config.application1.registerAppInterfaceParams.appName],
+        audioPassThruDisplayTexts = {
+          {fieldName = "audioPassThruDisplayText1", fieldText = "DisplayText1"},
+          {fieldName = "audioPassThruDisplayText2", fieldText = "DisplayText2"},
+        },
+        maxDuration = 2000,
+        muteAudio = true,
+        audioPassThruIcon =
+        {
+          imageType = "STATIC",
+          value = "icon.png"
+        }
+      })
+    :Do(function(_,data)
+        self.hmiConnection:SendResponse(data.id, "UI.PerformAudioPassThru", "SUCCESS", {})
+      end)
 
-	  EXPECT_NOTIFICATION("OnHMIStatus",
-      {hmiLevel = "FULL", audioStreamingState = "ATTENUATED", systemContext = "MAIN"},
-      {hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN"})
-    :Times(2)
-  else
-    EXPECT_NOTIFICATION("OnHMIStatus"):Times(0)
+    if
+    (self.appHMITypes["NAVIGATION"] == true) or
+    (self.appHMITypes["COMMUNICATION"] == true) or
+    (self.isMediaApplication == true) then
+
+      EXPECT_NOTIFICATION("OnHMIStatus",
+        {hmiLevel = "FULL", audioStreamingState = "ATTENUATED", systemContext = "MAIN"},
+        {hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN"})
+      :Times(2)
+    else
+      EXPECT_NOTIFICATION("OnHMIStatus"):Times(0)
+    end
+
+    self.mobileSession:ExpectResponse(CorIdPerformAudioPassThru, {success = false, resultCode = "GENERIC_ERROR", info ="Invalid message received from vehicle" })
+    EXPECT_NOTIFICATION("OnHashChange",{}):Times(0)
   end
-
-  self.mobileSession:ExpectResponse(CorIdPerformAudioPassThru, {success = false, resultCode = "GENERIC_ERROR", info ="Invalid message received from vehicle" })
-  EXPECT_NOTIFICATION("OnHashChange",{}):Times(0)
-  end 
 end
 
 --[[ Postconditions ]]
 commonFunctions:newTestCasesGroup("Postconditions")
 
 function Test.Postcondition_Restore_preloaded_pt_File()
-	commonPostconditions:RestoreFile("sdl_preloaded_pt.json")
+  commonPostconditions:RestoreFile("sdl_preloaded_pt.json")
 end
 
 function Test.Postcondition_Stop_SDL()

--- a/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
+++ b/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
@@ -1,0 +1,158 @@
+---------------------------------------------------------------------------------------------
+-- Requirement summary:
+-- [GENERIC_ERROR]: SDL behavior in case HMI sends invalid response AND SDL must transfer this response to mobile app
+-- [HMI RPC validation]: SDL must send GENERIC_ERROR to mobile app in case SDL cuts off fake params from RPC and this RPC becomes invalid
+-- [HMI API] UI.PerformAudioPassThru request/response
+-- [HMI API] TTS.Speak request/response
+-- [Mobile API] PerformAudioPassThru request/response
+-- [HMI_API] [MOBILE_API] The "audioPassThruIcon" param at "ImageFieldName" struct
+--
+-- Description:
+-- In case HMI sends invalid response by any reason that SDL must transfer it to mobile app
+-- (possible reasons to invalidate response include: mandatory params are missing, invalid json, incorrect combination of params or 
+-- SDL has cut fake parameters from response)
+-- SDL must: respond GENERIC_ERROR (success:false, <info>) to mobile app 
+-- (info: "Invalid message received from vehicle" - if invalid response sent from HMI)
+--
+-- 1. Used preconditions
+-- 1.1. PerformAudioPassThru RPC is allowed by policy
+-- 1.2. All params used in PerformAudioPassThru_request are present and within bounds
+-- 1.3. AudioPassThruIcon exists at apps sub-directory of AppStorageFolder (value from ini file)
+--
+-- 2. Performed steps
+-- Send PerformAudioPassThru (audioPassThruIcon, other params)
+-- HMI sends invalid response
+--
+-- Expected result:
+-- SDL sends UI.PerformAudioPassThru (audioPassThruIcon, other params) to HMI
+-- SDL sends TTS.Speak to HMI
+-- SDL sends to mobile PerformAudioPassThru (GENERIC_ERROR, success:false, info)
+---------------------------------------------------------------------------------------------
+
+--[[ General configuration parameters ]]
+config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local commonPostconditions = require('user_modules/shared_testcases/commonPreconditions')
+local testCasesForPerformAudioPassThru = require('user_modules/shared_testcases/testCasesForPerformAudioPassThru')
+local testCasesForPolicyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
+
+--[[Local variables]]
+local invalid_data = {
+{descr = "missing mandatory parameter"}, --samplingRate, maxDuration, bitsPerSample, audioType 
+{descr = "invalid json"},
+{descr = "invalid combination of params"},
+{descr = "fake parameters in response"}	
+}
+
+--[[ General Precondition before ATF start ]]
+commonSteps:DeleteLogsFiles()
+config.defaultProtocolVersion = 2
+
+testCasesForPolicyTable:precondition_updatePolicy_AllowFunctionInHmiLeves({"BACKGROUND", "FULL", "LIMITED"},"PerformAudioPassThru")
+
+--[[ General Settings for configuration ]]
+Test = require('connecttest')
+require('cardinalities')
+require('user_modules/AppTypes')
+
+--[[ Preconditions ]]
+commonFunctions:newTestCasesGroup("Preconditions")
+
+commonSteps:PutFile("Precondition_PutFile_With_Icon", "icon.png")
+
+function Test:Precondition_Check_audioPassThruIcon_Existence()
+  testCasesForPerformAudioPassThru.Check_audioPassThruIcon_Existence(self, "icon.png")
+end
+
+function Test:Precondition_ActivateApp()
+  testCasesForPerformAudioPassThru:ActivateAppDiffPolicyFlag(self, config.application1.registerAppInterfaceParams.appName, config.deviceMAC)
+end
+
+--[[ Test ]]
+commonFunctions:newTestCasesGroup("Test")
+
+for i =1, #invalid_data do
+  Test["TestStep_GENERIC_ERROR_PerformAudioPassThru_HMI_replies_" .. invalid_data[i].descr] = function(self)
+      local CorIdPerformAudioPassThru= self.mobileSession:SendRPC("PerformAudioPassThru",
+	    {
+	      initialPrompt = {{text = "Makeyourchoice",type = "TEXT"}},
+	      audioPassThruDisplayText1 = "DisplayText1",
+	      audioPassThruDisplayText2 = "DisplayText2",
+	      samplingRate = "16KHZ",
+	      maxDuration = 2000,
+	      bitsPerSample = "8_BIT",
+	      audioType = "PCM",
+	      muteAudio = true,
+	      audioPassThruIcon =
+		    { 
+		      value = "icon.png",
+		      imageType = "STATIC"
+		    }
+	    })
+	  EXPECT_HMICALL("TTS.Speak",
+	    {
+	      speakType = "AUDIO_PASS_THRU",
+	      ttsChunks = {{text = "Makeyourchoice", type = "TEXT"}},
+	      appID = self.applications[config.application1.registerAppInterfaceParams.appName]
+	    })
+	  :Do(function(_,data)
+	      self.hmiConnection:SendNotification("TTS.Started",{})
+	      
+	      local function ttsSpeakResponse()
+	        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {parameter = invalid_data[i].value})
+	        self.hmiConnection:SendNotification("TTS.Stopped")
+	      end
+	      RUN_AFTER(ttsSpeakResponse, 1000)
+	  end)
+
+	  EXPECT_HMICALL("UI.PerformAudioPassThru",
+	    {
+	      appID = self.applications[config.application1.registerAppInterfaceParams.appName],
+	      audioPassThruDisplayTexts = {
+	        {fieldName = "audioPassThruDisplayText1", fieldText = "DisplayText1"},
+	        {fieldName = "audioPassThruDisplayText2", fieldText = "DisplayText2"},
+	      },
+	      maxDuration = 2000,
+	      muteAudio = true,
+	      audioPassThruIcon = 
+	      { 
+	        imageType = "STATIC", 
+	        value = "icon.png"
+	      }
+	    })
+	  :Do(function() -- No HMI response is sent
+      end)
+
+  if
+	  (self.appHMITypes["NAVIGATION"] == true) or
+	  (self.appHMITypes["COMMUNICATION"] == true) or
+	  (self.isMediaApplication == true) then
+
+	  EXPECT_NOTIFICATION("OnHMIStatus",
+      {hmiLevel = "FULL", audioStreamingState = "ATTENUATED", systemContext = "MAIN"},
+      {hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN"})
+    :Times(2)
+  else
+    EXPECT_NOTIFICATION("OnHMIStatus"):Times(0)
+  end
+
+  self.mobileSession:ExpectResponse(CorIdPerformAudioPassThru, {success = false, resultCode = "GENERIC_ERROR", info ="Invalid message received from vehicle" })
+  EXPECT_NOTIFICATION("OnHashChange",{}):Times(0)
+  end 
+end
+
+--[[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postconditions")
+
+function Test.Postcondition_Restore_preloaded_pt_File()
+	commonPostconditions:RestoreFile("sdl_preloaded_pt.json")
+end
+
+function Test.Postcondition_Stop_SDL()
+  StopSDL()
+end
+
+return Test


### PR DESCRIPTION
Requirements:
[GENERIC_ERROR]: SDL behavior in case HMI sends invalid response AND SDL must transfer this response to mobile app
[HMI RPC validation]: SDL must send GENERIC_ERROR to mobile app in case SDL cuts off fake params from RPC and this RPC becomes invalid

029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
All common functions used available at #703
Testing coverage available at #643 as well as https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/feature/extended_policy_functionality/test_sets/PAPT_new_param_audioPassThruIcon.txt