### PR TITLE
030 Script for Requirement [HMI RPC validation]: SDL behavior: HMI sends request (response, notification) with fake parameters that SDL should transfer to mobile

### DIFF
--- a/test_scripts/API/PerformAudioPassThru/030_ATF_P_PerformAudioPassThru_transfers_request_with_fake_params_after_cutting_them.lua
+++ b/test_scripts/API/PerformAudioPassThru/030_ATF_P_PerformAudioPassThru_transfers_request_with_fake_params_after_cutting_them.lua
@@ -1,0 +1,160 @@
+---------------------------------------------------------------------------------------------
+-- Requirement summary:
+-- [HMI RPC validation]: SDL behavior: HMI sends request (response, notification) with fake parameters that SDL should transfer to mobile
+-- [HMI API] UI.PerformAudioPassThru request/response
+-- [HMI API] TTS.Speak request/response
+-- [Mobile API] PerformAudioPassThru request/response
+-- [HMI_API] [MOBILE_API] The "audioPassThruIcon" param at "ImageFieldName" struct
+--
+-- Description:
+-- In case HMI sends request (response, notification) with fake parameters that SDL should transfer to mobile app
+-- SDL must: validate received response; cut off fake parameters and
+-- transfer this request (response or notification) to mobile app
+--
+-- 1. Used preconditions
+-- 1.1. PerformAudioPassThru RPC is allowed by policy
+-- 1.2. All params used in PerformAudioPassThru_request are present and within bounds
+-- 1.3. AudioPassThruIcon exists at apps sub-directory of AppStorageFolder (value from ini file)
+--
+-- 2. Performed steps
+-- Send PerformAudioPassThru (audioPassThruIcon, other params)
+-- HMI sends response with fake parameters
+--
+-- Expected result:
+-- SDL sends UI.PerformAudioPassThru (audioPassThruIcon, other params) to HMI
+-- SDL sends TTS.Speak to HMI
+-- SDL ignores fake parameter and transfers to mobile PerformAudioPassThru (SUCESS, success: true)
+---------------------------------------------------------------------------------------------
+
+--[[ General configuration parameters ]]
+config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local commonPostconditions = require('user_modules/shared_testcases/commonPreconditions')
+local testCasesForPerformAudioPassThru = require('user_modules/shared_testcases/testCasesForPerformAudioPassThru')
+local testCasesForPolicyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
+
+--[[ General Precondition before ATF start ]]
+commonSteps:DeleteLogsFiles()
+config.defaultProtocolVersion = 2
+
+testCasesForPolicyTable:precondition_updatePolicy_AllowFunctionInHmiLeves({"BACKGROUND", "FULL", "LIMITED"},"PerformAudioPassThru")
+
+--[[ General Settings for configuration ]]
+Test = require('connecttest')
+require('cardinalities')
+require('user_modules/AppTypes')
+
+--[[ Preconditions ]]
+commonFunctions:newTestCasesGroup("Preconditions")
+
+commonSteps:PutFile("Precondition_PutFile_With_Icon", "icon.png")
+
+function Test:Precondition_Check_audioPassThruIcon_Existence()
+  testCasesForPerformAudioPassThru.Check_audioPassThruIcon_Existence(self, "icon.png")
+end
+
+function Test:Precondition_ActivateApp()
+  testCasesForPerformAudioPassThru:ActivateAppDiffPolicyFlag(self, config.application1.registerAppInterfaceParams.appName, config.deviceMAC)
+end
+
+--[[ Test ]]
+commonFunctions:newTestCasesGroup("Test")
+
+function Test:TestStep_PerformAudioPassThru_Fake_Prameter_from_HMI_Cut()
+  local CorIdPerformAudioPassThru= self.mobileSession:SendRPC("PerformAudioPassThru",
+    {
+      initialPrompt = {{text = "Makeyourchoice",type = "TEXT"}},
+      audioPassThruDisplayText1 = "DisplayText1",
+      audioPassThruDisplayText2 = "DisplayText2",
+      samplingRate = "16KHZ",
+      maxDuration = 2000,
+      bitsPerSample = "8_BIT",
+      audioType = "PCM",
+      muteAudio = true,
+      audioPassThruIcon =
+      {
+        value = "icon.png",
+        imageType = "STATIC"
+      }
+    })
+  EXPECT_HMICALL("TTS.Speak",
+    {
+      speakType = "AUDIO_PASS_THRU",
+      ttsChunks = {{text = "Makeyourchoice", type = "TEXT"}},
+      appID = self.applications[config.application1.registerAppInterfaceParams.appName]
+    })
+  :Do(function(_,data)
+      self.hmiConnection:SendNotification("TTS.Started",{})
+
+      local function ttsSpeakResponse()
+        -- :ValidIf (function (_,data)
+        --     if (data.params.fake = true) then
+        --       commonFunctions:printError ("ERROR:SDL transfers fake parameter")
+        --       return false
+        --     else
+        --       return true
+        --     end
+        --   end)
+
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {parameter = invalid_data[i].value})
+        self.hmiConnection:SendNotification("TTS.Stopped")
+      end
+      RUN_AFTER(ttsSpeakResponse, 1000)
+    end)
+
+  EXPECT_HMICALL("UI.PerformAudioPassThru",
+    {
+      appID = self.applications[config.application1.registerAppInterfaceParams.appName],
+      audioPassThruDisplayTexts = {
+        {fieldName = "audioPassThruDisplayText1", fieldText = "DisplayText1"},
+        {fieldName = "audioPassThruDisplayText2", fieldText = "DisplayText2"},
+      },
+      maxDuration = 2000,
+      muteAudio = true,
+      audioPassThruIcon =
+      {
+        imageType = "STATIC",
+        value = "icon.png"
+      }
+    })
+  :Do(function(_,data)
+
+      local function UIPerformAudioResponse()
+        self.hmiConnection:SendResponse(data.id, "UI.PerformAudioPassThru", "SUCCESS", {})
+      end
+      RUN_AFTER(UIPerformAudioResponse, 1500)
+    end)
+
+  if
+  (self.appHMITypes["NAVIGATION"] == true) or
+  (self.appHMITypes["COMMUNICATION"] == true) or
+  (self.isMediaApplication == true) then
+
+    EXPECT_NOTIFICATION("OnHMIStatus",
+      {hmiLevel = "FULL", audioStreamingState = "ATTENUATED", systemContext = "MAIN"},
+      {hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN"})
+    :Times(2)
+  else
+    EXPECT_NOTIFICATION("OnHMIStatus"):Times(0)
+  end
+
+  self.mobileSession:ExpectResponse(CorIdPerformAudioPassThru, {success = false, resultCode = "GENERIC_ERROR", info ="Invalid message received from vehicle" })
+  EXPECT_NOTIFICATION("OnHashChange",{}):Times(0)
+end
+end
+
+--[[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postconditions")
+
+function Test.Postcondition_Restore_preloaded_pt_File()
+commonPostconditions:RestoreFile("sdl_preloaded_pt.json")
+end
+
+function Test.Postcondition_Stop_SDL()
+StopSDL()
+end
+
+return Test


### PR DESCRIPTION
030_ATF_P_PerformAudioPassThru_transfers_request_with_fake_params_after_cutting_them.lua
All common functions used available at #703
Testing coverage available at #643 as well as https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/feature/extended_policy_functionality/test_sets/PAPT_new_param_audioPassThruIcon.txt

@istoimenova Please review