### PR TITLE
Scripts updated with new expected path for DYNAMIC images adapted for both ATF and CI

### DIFF
--- a/test_scripts/API/PerformAudioPassThru/009_ATF_P_PerformAudioPassThru_SUCCESS_Dynamic_Image_All_Params.lua
+++ b/test_scripts/API/PerformAudioPassThru/009_ATF_P_PerformAudioPassThru_SUCCESS_Dynamic_Image_All_Params.lua
@@ -117,7 +117,8 @@ function Test:TestStep_PerformAudioPassThru_AllParameters_DYNAMIC_ImageType_SUCC
     end)
    :ValidIf (function(_,data2)
     	if(data2.params.audioPassThruIcon ~= nil) then
-		  	if (string.match(data2.params.audioPassThruIcon.value, "%S*" .. "("..string.sub(storagePath, 2).."icon.png)" .. "$") == nil ) then
+		  	if (string.match(data2.params.audioPassThruIcon.value, "%S*" .. "("..string.sub(storagePath, 2).."icon.png)" .. "$") == nil ) and
+        (data2.params.audioPassThruIcon.value ~= (storagePath.."icon.png") ) then
 					print("\27[31m Invalid path to DYNAMIC image\27[0m")
 					return false 
 				else 

--- a/test_scripts/API/PerformAudioPassThru/010_ATF_P_PerformAudioPassThru_SUCCESS_Dynamic_Image_MandatoryParams_and_audioPassThruIcon.lua
+++ b/test_scripts/API/PerformAudioPassThru/010_ATF_P_PerformAudioPassThru_SUCCESS_Dynamic_Image_MandatoryParams_and_audioPassThruIcon.lua
@@ -89,7 +89,8 @@ function Test:TestStep_PerformAudioPassThru_MandatoryParameters_audioPassThruIco
     end)
    :ValidIf (function(_,data3)
       if(data3.params.audioPassThruIcon ~= nil) then
-        if (string.match(data3.params.audioPassThruIcon.value, "%S*" .. "("..string.sub(storagePath, 2).."icon.png)" .. "$") == nil ) then
+        if (string.match(data3.params.audioPassThruIcon.value, "%S*" .. "("..string.sub(storagePath, 2).."icon.png)" .. "$") == nil )and
+        (data3.params.audioPassThruIcon.value ~= (storagePath.."icon.png") ) then
           print("\27[31m Invalid path to DYNAMIC image\27[0m")
           return false 
         else 

--- a/test_scripts/API/PerformAudioPassThru/021_ATF_P_PerformAudioPassThru_WARNING_Missing_audioPassThruIcon_AllParams_DYNAMIC.lua
+++ b/test_scripts/API/PerformAudioPassThru/021_ATF_P_PerformAudioPassThru_WARNING_Missing_audioPassThruIcon_AllParams_DYNAMIC.lua
@@ -131,7 +131,8 @@ function Test:TestStep_All_Params_Missing_audioPassThruIcon_DYNAMIC()
   end)
    :ValidIf (function(_,data2)
       if(data2.params.audioPassThruIcon ~= nil) then
-        if (string.match(data2.params.audioPassThruIcon.value, "%S*" .. "("..string.sub(storagePath, 2).."icon.png)" .. "$") == nil ) then
+        if (string.match(data2.params.audioPassThruIcon.value, "%S*" .. "("..string.sub(storagePath, 2).."icon.png)" .. "$") == nil ) and
+        (data2.params.audioPassThruIcon.value ~= (storagePath.."icon.png") ) then
           print("\27[31m Invalid path to DYNAMIC image\27[0m")
           return false 
         else 

--- a/test_scripts/API/PerformAudioPassThru/022_ATF_P_PerformAudioPassThru_WARNING_Missing_audioPassThruIcon_MandatoryParams_DYNAMIC.lua
+++ b/test_scripts/API/PerformAudioPassThru/022_ATF_P_PerformAudioPassThru_WARNING_Missing_audioPassThruIcon_MandatoryParams_DYNAMIC.lua
@@ -101,7 +101,8 @@ function Test:TestStep_Mandatory_Params_Missing_audioPassThruIcon_DYNAMIC()
   end)
   :ValidIf (function(_,data2)
     if(data2.params.audioPassThruIcon ~= nil) then
-      if (string.match(data2.params.audioPassThruIcon.value, "%S*" .. "("..string.sub(storagePath, 2).."icon.png)" .. "$") == nil ) then
+      if (string.match(data2.params.audioPassThruIcon.value, "%S*" .. "("..string.sub(storagePath, 2).."icon.png)" .. "$") == nil ) and
+      (data2.params.audioPassThruIcon.value ~= (storagePath.."icon.png") ) then
         print("\27[31m Invalid path to DYNAMIC image\27[0m")
         return false 
       else 


### PR DESCRIPTION
@istoimenova 
Please review the updated paths for scripts:
009_ATF_P_PerformAudioPassThru_SUCCESS_Dynamic_Image_All_Params.lua
010_ATF_P_PerformAudioPassThru_SUCCESS_Dynamic_Image_MandatoryParams_and_audioPassThruIcon.lua
021_ATF_P_PerformAudioPassThru_WARNING_Missing_audioPassThruIcon_AllParams_DYNAMIC.lua
022_ATF_P_PerformAudioPassThru_WARNING_Missing_audioPassThruIcon_MandatoryParams_DYNAMIC.lua