### PR TITLE
Expected result changed due to update in specification

### DIFF
--- a/test_scripts/API/PerformAudioPassThru/011_ATF_P_PerformAudioPassThru_SUCCESS_Valid_Request_Without_audioPassThruIcon.lua
+++ b/test_scripts/API/PerformAudioPassThru/011_ATF_P_PerformAudioPassThru_SUCCESS_Valid_Request_Without_audioPassThruIcon.lua
@@ -105,7 +105,7 @@ function Test:TestStep_ValidRequest_Without_audioPassThruIcon_all_other_params_p
   :Do(function(_,data)
 
       local function UIPerformAudioResponse()
-        self.hmiConnection:SendResponse(data.id, "UI.PerformAudioPassThru", "WARNINGS", {})
+        self.hmiConnection:SendResponse(data.id, "UI.PerformAudioPassThru", "SUCCESS", {})
       end
       RUN_AFTER(UIPerformAudioResponse, 1500)
       
@@ -132,7 +132,7 @@ function Test:TestStep_ValidRequest_Without_audioPassThruIcon_all_other_params_p
     EXPECT_NOTIFICATION("OnHMIStatus"):Times(0)
   end
 
-  self.mobileSession:ExpectResponse(CorIdPerformAudioPassThruAppParVD, {success = true, resultCode = "WARNINGS"})
+  self.mobileSession:ExpectResponse(CorIdPerformAudioPassThruAppParVD, {success = true, resultCode = "SUCCESS"})
   EXPECT_NOTIFICATION("OnHashChange"):Times(0)
   commonTestCases:DelayedExp(1500)
 end

--- a/test_scripts/API/PerformAudioPassThru/012_ATF_P_PerformAudioPassThru_SUCCESS_Mandatory_Only_Without_audioPassThruIcon.lua
+++ b/test_scripts/API/PerformAudioPassThru/012_ATF_P_PerformAudioPassThru_SUCCESS_Mandatory_Only_Without_audioPassThruIcon.lua
@@ -66,7 +66,7 @@ function Test:TestStep_ValidRequest_Without_audioPassThruIcon_Mandatory_Params_P
       samplingRate = "16KHZ",
       maxDuration = 2000,
       bitsPerSample = "8_BIT",
-      audioType = "PCM"
+      audioType = "PCM" 
     })
 
   EXPECT_HMICALL("UI.PerformAudioPassThru",
@@ -76,7 +76,7 @@ function Test:TestStep_ValidRequest_Without_audioPassThruIcon_Mandatory_Params_P
       muteAudio = true
     })
   :Do(function(_,data)
-  self.hmiConnection:SendResponse(data.id, "UI.PerformAudioPassThru", "WARNINGS", {})
+  self.hmiConnection:SendResponse(data.id, "UI.PerformAudioPassThru", "SUCCESS", {})
   end)
     :ValidIf(function(_,data1)
     if data1.params.audioPassThruIcon ~= nil then 
@@ -89,7 +89,7 @@ function Test:TestStep_ValidRequest_Without_audioPassThruIcon_Mandatory_Params_P
   end)
 
   EXPECT_HMICALL("TTS.Speak"):Times(0)
-  self.mobileSession:ExpectResponse(CorIdPerfAudioPassThruOnlyMandatory, {success = true, resultCode = "WARNINGS"})
+  self.mobileSession:ExpectResponse(CorIdPerfAudioPassThruOnlyMandatory, {success = true, resultCode = "SUCCESS"})
   EXPECT_NOTIFICATION("OnHashChange"):Times(0)
 end
 


### PR DESCRIPTION
@istoimenova Please check changes in scripts 011_ATF_P_PerformAudioPassThru_SUCCESS_Valid_Request_Without_audioPassThruIcon.lua  and 012_ATF_P_PerformAudioPassThru_SUCCESS_Mandatory_Only_Without_audioPassThruIcon.lua 
Due to change in specification the expected result is not SUCCESS instead of WARNINGS