### PR TITLE
004_ATF_N_TC_existing_navi_app_certificate_exist

### DIFF
--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/004_ATF_N_TC_existing_navi_app_certificate_exist.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/004_ATF_N_TC_existing_navi_app_certificate_exist.lua
@@ -1,0 +1,78 @@
+---------------------------------------------------------------------------------------------
+-- Requirement summary:
+-- [PTU] [GENIVI] SDL must start PTU for navi app right after app successfully registration
+--
+-- Description:
+-- In case navigation app connects and sucessfully registers on SDL (opens RPC 7 service)
+-- and PolicyTable has NO "certificate" at "module_config" section of LocalPolicyTable
+-- SDL must start PolicyTableUpdate process on sending SDL.OnStatusUpdate(UPDATE_NEEDED) to HMI to get "certificate"
+--
+-- 1. Used preconditions:
+-- Navi app exists in LP, certificate is listed in module_config
+--
+-- 2. Performed steps
+-- Register navi application.
+--
+-- Expected result:
+-- Application is registered successfully.
+-- SDL should not trigger PTU. SDL.OnStatusUpdate(UPDATE_NEEDED) should not be sent.
+---------------------------------------------------------------------------------------------
+
+--[[ General configuration parameters ]]
+config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
+config.application1.registerAppInterfaceParams.appHMIType = {"NAVIGATION"}
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
+local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
+local mobile_session = require('mobile_session')
+local testCasesForPolicyCeritificates = require('user_modules/shared_testcases/testCasesForPolicyCeritificates')
+
+--[[ General Precondition before ATF start ]]
+testCasesForPolicyCeritificates.update_preloaded_pt(config.application1.registerAppInterfaceParams.appID, true)
+commonSteps:DeletePolicyTable()
+commonSteps:DeleteLogsFiles()
+
+--[[ General Settings for configuration ]]
+Test = require('user_modules/connecttest_resumption')
+require('user_modules/AppTypes')
+
+--[[ Preconditions ]]
+commonFunctions:newTestCasesGroup("Preconditions")
+
+function Test:Precondition_connectMobile()
+  self:connectMobile()
+end
+
+function Test:Precondition_StartSession()
+  self.mobileSession = mobile_session.MobileSession(self, self.mobileConnection)
+  self.mobileSession:StartService(7)
+end
+
+--[[ Test ]]
+commonFunctions:newTestCasesGroup("Test")
+function Test:TestStep_RAI_No_PTU_Trigger()
+  local CorIdRegister = self.mobileSession:SendRPC("RegisterAppInterface", config.application1.registerAppInterfaceParams)
+
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config.application1.registerAppInterfaceParams.appName }})
+  EXPECT_RESPONSE(CorIdRegister, { success = true, resultCode = "SUCCESS" })
+  EXPECT_NOTIFICATION("OnHMIStatus", { systemContext = "MAIN", hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE"})
+
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate"):Times(0)
+  commonTestCases:DelayedExp(10000)
+end
+
+--[[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postconditions")
+
+function Test.Postcondition_Remove_PTU_file()
+  commonPreconditions:RestoreFile("sdl_preloaded_pt.json")
+end
+
+function Test.Postcondition_Stop()
+  StopSDL()
+end
+
+return Test

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/004_ATF_N_TC_existing_navi_app_certificate_exist.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/004_ATF_N_TC_existing_navi_app_certificate_exist.lua
@@ -4,8 +4,8 @@
 --
 -- Description:
 -- In case navigation app connects and sucessfully registers on SDL (opens RPC 7 service)
--- and PolicyTable has NO "certificate" at "module_config" section of LocalPolicyTable
--- SDL must start PolicyTableUpdate process on sending SDL.OnStatusUpdate(UPDATE_NEEDED) to HMI to get "certificate"
+-- and PolicyTable has "certificate" at "module_config" section of LocalPolicyTable
+-- SDL must not start PolicyTableUpdate process. SDL.OnStatusUpdate(UPDATE_NEEDED) should not be sent.
 --
 -- 1. Used preconditions:
 -- Navi app exists in LP, certificate is listed in module_config
@@ -67,7 +67,7 @@ end
 --[[ Postconditions ]]
 commonFunctions:newTestCasesGroup("Postconditions")
 
-function Test.Postcondition_Remove_PTU_file()
+function Test.Postcondition_Restore_PreloadedPT()
   commonPreconditions:RestoreFile("sdl_preloaded_pt.json")
 end
 


### PR DESCRIPTION
Script is part of TS: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1163
common functions for CRQ: #1175