### PR TITLE
ShutDown Smoke tests

### DIFF
--- a/test_scripts/ATF_ShutDown_IGNITION_OFF.lua
+++ b/test_scripts/ATF_ShutDown_IGNITION_OFF.lua
@@ -1,0 +1,80 @@
+-- Requirement summary:
+-- [Data Resumption]:OnExitAllApplications(IGNITION_OFF) in terms of resumption 
+--
+-- Description:
+-- In case SDL receives OnExitAllApplications(IGNITION_OFF), 
+-- SDL must clean up any resumption-related data
+-- Obtained after OnExitAllApplications( SUSPEND). SDL must stop all its processes, 
+-- notify HMI via OnSDLClose and shut down.
+--
+-- 1. Used preconditions
+-- HMI is running
+-- One App is registered and activated on HMI
+-- 
+-- 2. Performed steps
+-- Perform ignition Off
+-- HMI sends OnExitAllApplications(IGNITION_OFF)
+-- 
+-- Expected result:
+-- 1. SDL sends to App OnAppInterfaceUnregistered
+-- 2. SDL sends to HMI OnSDLClose and stops working
+
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+
+--[[ General Settings for configuration ]]
+Test = require('user_modules/dummy_connecttest')
+require('cardinalities')
+require('user_modules/AppTypes')
+
+--[[ Preconditions ]]
+commonFunctions:newTestCasesGroup("Preconditions")
+commonSteps:DeletePolicyTable()
+commonSteps:DeleteLogsFiles()
+
+function Test:Start_SDL_With_One_Activated_App()
+  self:runSDL()
+  commonFunctions:waitForSDLStart(self):Do(function()
+    self:initHMI():Do(function()
+      commonFunctions:userPrint(35, "HMI initialized")
+      self:initHMI_onReady():Do(function ()
+        commonFunctions:userPrint(35, "HMI is ready")
+        self:connectMobile():Do(function ()
+          commonFunctions:userPrint(35, "Mobile Connected")
+          self:startSession():Do(function ()
+            commonSteps:ActivateAppInSpecificLevel(self, 
+              self.applications[config.application1.registerAppInterfaceParams.appName])
+            EXPECT_NOTIFICATION("OnHMIStatus", {hmiLevel = "FULL", systemContext = "MAIN"})
+          end)
+        end)
+      end)
+    end)
+  end)
+end
+
+--[[ Test ]]
+commonFunctions:newTestCasesGroup("Check that SDL finish it's work properly by IGNITION_OFF")
+function Test:ShutDown_IGNITION_OFF()
+  self.hmiConnection:SendNotification("BasicCommunication.OnExitAllApplications",
+    { reason = "SUSPEND" })
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLPersistenceComplete"):Do(function()
+    self.hmiConnection:SendNotification("BasicCommunication.OnExitAllApplications",
+      { reason = "IGNITION_OFF" })
+    EXPECT_NOTIFICATION("OnAppInterfaceUnregistered", { reason = "IGNITION_OFF" })
+  end)
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false }) 
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose"):Do(function ()
+    print("ONSDLClose")
+    StopSDL()
+  end)
+end
+
+--[[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postcondition")
+function Test.Stop_SDL()
+  StopSDL()
+end
+
+return Test

--- a/test_scripts/ATF_ShutDown_MASTER_RESET.lua
+++ b/test_scripts/ATF_ShutDown_MASTER_RESET.lua
@@ -1,0 +1,156 @@
+--  Requirement summary:
+--  [Policies] Master Reset
+--
+-- Description:
+-- On Master Reset, Policy Manager must revert Local Policy Table 
+-- to the Preload Policy Table.
+--
+-- 1. Used preconditions
+-- SDL and HMI are running
+-- App is registered
+--
+-- 2. Performed steps
+-- Perform Master Reset
+-- HMI sends OnExitAllApplications with reason MASTER_RESET
+--
+-- Expected result:
+-- 1. SDL clear all Apps folder, app_info.dat file and shut down
+
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local mobile_session = require('mobile_session')
+
+--[[ Local Variables ]]
+-- Hash id of AddCommand before MASTER_RESET
+local hash_id = nil
+local default_app_name = config.application1.registerAppInterfaceParams.appName
+
+--[[ General Settings for configuration ]]
+Test = require('user_modules/dummy_connecttest')
+require('cardinalities')
+require('user_modules/AppTypes')
+
+--[[ Preconditions ]]
+commonFunctions:newTestCasesGroup("Preconditions")
+commonSteps:DeletePolicyTable()
+commonSteps:DeleteLogsFiles()
+
+function Test:StartSDL_With_One_Registered_App()
+  self:runSDL()
+  commonFunctions:waitForSDLStart(self):Do(function()
+    self:initHMI():Do(function()
+      commonFunctions:userPrint(35, "HMI initialized")
+      self:initHMI_onReady():Do(function ()
+        commonFunctions:userPrint(35, "HMI is ready")
+        self:connectMobile():Do(function ()
+          commonFunctions:userPrint(35, "Mobile Connected")
+          self:startSession():Do(function ()
+            commonFunctions:userPrint(35, "App is registered")
+          end)
+        end)
+      end)
+    end)
+  end)
+end
+
+function Test:Activate_App_And_Put_File()
+  local function addCommand()
+    local cid = self.mobileSession:SendRPC("AddCommand",{ cmdID = 1005, 
+                vrCommands = { "OnlyVRCommand"}
+                })
+    EXPECT_HMICALL("VR.AddCommand", {cmdID = 1005, type = "Command",
+                   vrCommands = {"OnlyVRCommand"}}):Do(function(_,data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+    EXPECT_RESPONSE(cid, { success = true, resultCode = "SUCCESS" })
+    EXPECT_NOTIFICATION("OnHashChange"):Do(function(_, data)
+      hash_id = data.payload.hashID
+    end)
+  end
+
+  commonSteps:ActivateAppInSpecificLevel(self, self.applications[default_app_name])
+  local on_hmi_full = EXPECT_NOTIFICATION("OnHMIStatus", {hmiLevel = "FULL", systemContext = "MAIN"})
+  on_hmi_full:Do(function()
+    local cid = self.mobileSession:SendRPC(
+    "PutFile", {
+      syncFileName = "icon.png",
+      fileType = "GRAPHIC_PNG",
+      persistentFile = true,
+      systemFile = false,
+    }, "files/icon.png")
+    EXPECT_RESPONSE(cid, { success = true, resultCode = "SUCCESS" })
+    addCommand()
+  end)
+end
+
+--[[ Test ]]
+commonFunctions:newTestCasesGroup("Check that SDL finish it's work properly by MASTER_RESET")
+
+function Test:ShutDown_MASTER_RESET()
+  self.hmiConnection:SendNotification("BasicCommunication.OnExitAllApplications", 
+    { reason = "MASTER_RESET" })
+  EXPECT_NOTIFICATION("OnAppInterfaceUnregistered", { reason = "MASTER_RESET" })
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose"):Do(function ()
+    StopSDL()
+  end)
+end
+
+--- Start SDL again then add mobile connection
+function Test:Restart_SDL_And_Add_Mobile_Connection()
+  self:runSDL()
+  commonFunctions:waitForSDLStart(self):Do(function()
+    self:initHMI():Do(function()
+      commonFunctions:userPrint(35, "HMI initialized")
+      self:initHMI_onReady():Do(function ()
+        commonFunctions:userPrint(35, "HMI is ready")
+        self:connectMobile():Do(function ()
+          commonFunctions:userPrint(35, "Mobile Connected")
+        end)
+      end)
+    end)
+  end)
+end
+
+--- Check SDL will not resume application when the same application registers.
+function Test:Check_Application_Not_Resume_When_Register_Again()
+  local mobile_session1 = mobile_session.MobileSession(self, self.mobileConnection)
+  local on_rpc_service_started = mobile_session1:StartRPC()
+
+  on_rpc_service_started:Do(function()
+    local rai_params =  config.application1.registerAppInterfaceParams
+    rai_params.hashID = hash_id
+
+    local cid = self.mobileSession:SendRPC("RegisterAppInterface",rai_params) 
+    local on_app_registered = self.mobileSession:ExpectResponse(cid, { success = true, resultCode = "RESUME_FAILED" })
+
+    EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = {appName = default_app_name} })
+
+    EXPECT_HMICALL("BasicCommunication.UpdateAppList"):Do(function(_,data)
+      self.hmiConnection:SendResponse(data.id, "BasicCommunication.UpdateAppList", "SUCCESS", {})
+    end)
+
+    EXPECT_NOTIFICATION("OnHMIStatus", { systemContext = "MAIN", hmiLevel = "NONE", 
+      audioStreamingState = "NOT_AUDIBLE"})
+
+    on_app_registered:Do(function()
+      local cid1 = self.mobileSession:SendRPC("ListFiles", {})
+      EXPECT_RESPONSE(cid1, { success = true, resultCode = "SUCCESS" }) :ValidIf (function(_,data)
+        return not data.payload.filenames 
+      end)
+      EXPECT_HMICALL("BasicCommunication.ActivateApp"):Times(0)
+      EXPECT_HMICALL("VR.AddCommand"):Times(0)
+      StopSDL()
+    end)
+  end)
+end 
+
+-- [[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postcondition")
+function Test.Stop_SDL()
+  StopSDL()
+end
+
+return Test

--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -1,0 +1,668 @@
+require('atf.util')
+local module = require('testbase')
+local mobile = require("mobile_connection")
+local tcp = require("tcp_connection")
+local file_connection = require("file_connection")
+local mobile_session = require("mobile_session")
+local websocket = require('websocket_connection')
+local hmi_connection = require('hmi_connection')
+local events = require("events")
+local expectations = require('expectations')
+local functionId = require('function_id')
+local SDL = require('SDL')
+local exit_codes = require('exit_codes')
+local load_schema = require('load_schema')
+local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
+local mob_schema = load_schema.mob_schema
+local hmi_schema = load_schema.hmi_schema
+
+local Event = events.Event
+
+local Expectation = expectations.Expectation
+local SUCCESS = expectations.SUCCESS
+local FAILED = expectations.FAILED
+
+module.hmiConnection = hmi_connection.Connection(websocket.WebSocketConnection(config.hmiUrl, config.hmiPort))
+local tcpConnection = tcp.Connection(config.mobileHost, config.mobilePort)
+local fileConnection = file_connection.FileConnection("mobile.out", tcpConnection)
+module.mobileConnection = mobile.MobileConnection(fileConnection)
+event_dispatcher:AddConnection(module.hmiConnection)
+event_dispatcher:AddConnection(module.mobileConnection)
+module.notification_counter = 1
+
+function module.hmiConnection:EXPECT_HMIRESPONSE(id, args)
+  local event = events.Event()
+  event.matches = function(self, data)
+    return  data["method"] == nil and data.id == id
+  end
+  local ret = Expectation("HMI response " .. id, self)
+  ret:ValidIf(function(self, data)
+      local arguments
+      if self.occurences > #args then
+        arguments = args[#args]
+      else
+        arguments = args[self.occurences]
+      end
+      xmlReporter.AddMessage("EXPECT_HMIRESPONSE", {["Id"] = tostring(id),["Type"] = "EXPECTED_RESULT"},arguments)
+      xmlReporter.AddMessage("EXPECT_HMIRESPONSE", {["Id"] = tostring(id),["Type"] = "AVALIABLE_RESULT"},data)
+      local func_name = data.method
+      local results_args = arguments
+      local results_args2 = arguments
+      if(table2str(arguments):match('result')) then
+        results_args = arguments.result
+        results_args2 = arguments.result
+      elseif(table2str(arguments):match('error')) then
+        results_args = arguments.error
+        results_args2 = arguments.error
+      end
+
+      if results_args2 and results_args2.code then
+        results_args2 = table.removeKey(results_args2, 'code')
+      end
+      if results_args2 and results_args2.method then
+        results_args2 = table.removeKey(results_args2, 'method')
+      elseif results_args2 and results_args2.data.method then
+        results_args2 = table.removeKey(results_args2.data, 'method')
+      end
+
+      if func_name == nil and type(data.result) == 'table' then
+        func_name = data.result.method
+      elseif func_name == nil and type(data.error) == 'table' then
+        print_table(data)
+        func_name = data.error.data.method
+      end
+
+      local _res, _err
+      _res = true
+      if not (table2str(arguments):match('error')) then
+        _res, _err = hmi_schema:Validate(func_name, load_schema.response, data.params)
+      end
+      if (not _res) then
+        return _res,_err
+      end
+
+      if func_name and results_args and data.result then
+        return compareValues(results_args, data.result, "result")
+      elseif func_name and results_args and data.error then
+        return compareValues(results_args, data.error, "error")
+      else
+        return compareValues(results_args, data.params, "params")
+      end
+    end)
+  ret.event = event
+  event_dispatcher:AddEvent(module.hmiConnection, event, ret)
+  module:AddExpectation(ret)
+  return ret
+end
+
+function EXPECT_HMIRESPONSE(id,...)
+  local args = table.pack(...)
+  return module.hmiConnection:EXPECT_HMIRESPONSE(id, args)
+end
+
+function EXPECT_HMINOTIFICATION(name,...)
+  local args = table.pack(...)
+  local event = events.Event()
+  event.matches = function(self, data) return data.method == name end
+  local ret = Expectation("HMI notification " .. name, module.hmiConnection)
+  if #args > 0 then
+    ret:ValidIf(function(self, data)
+        local arguments
+        if self.occurences > #args then
+          arguments = args[#args]
+        else
+          arguments = args[self.occurences]
+        end
+        local correlation_id = module.notification_counter
+        module.notification_counter = module.notification_counter + 1
+        xmlReporter.AddMessage("EXPECT_HMINOTIFICATION", {["Id"] = correlation_id, ["name"] = tostring(name),["Type"] = "EXPECTED_RESULT"},arguments)
+        xmlReporter.AddMessage("EXPECT_HMINOTIFICATION", {["Id"] = correlation_id, ["name"] = tostring(name),["Type"] = "AVALIABLE_RESULT"},data)
+        local _res, _err = hmi_schema:Validate(name, load_schema.notification, data.params)
+        if (not _res) then return _res,_err end
+        return compareValues(arguments, data.params, "params")
+      end)
+  end
+  ret.event = event
+  event_dispatcher:AddEvent(module.hmiConnection, event, ret)
+  module:AddExpectation(ret)
+  return ret
+end
+
+function EXPECT_HMICALL(methodName, ...)
+  local args = table.pack(...)
+  -- TODO: Avoid copy-paste
+  local event = events.Event()
+  event.matches =
+  function(self, data) return data.method == methodName end
+  local ret = Expectation("HMI call " .. methodName, module.hmiConnection)
+  if #args > 0 then
+    ret:ValidIf(function(self, data)
+        local arguments
+        if self.occurences > #args then
+          arguments = args[#args]
+        else
+          arguments = args[self.occurences]
+        end
+        xmlReporter.AddMessage("EXPECT_HMICALL", {["Id"] = data.id, ["name"] = tostring(methodName),["Type"] = "EXPECTED_RESULT"},arguments)
+        xmlReporter.AddMessage("EXPECT_HMICALL", {["Id"] = data.id, ["name"] = tostring(methodName),["Type"] = "AVALIABLE_RESULT"},data.params)
+        _res, _err = hmi_schema:Validate(methodName, load_schema.request, data.params)
+        if (not _res) then return _res,_err end
+        return compareValues(arguments, data.params, "params")
+      end)
+  end
+  ret.event = event
+  event_dispatcher:AddEvent(module.hmiConnection, event, ret)
+  module:AddExpectation(ret)
+  return ret
+end
+
+function EXPECT_NOTIFICATION(func,...)
+  local args = table.pack(...)
+  local args_count = 1
+  if #args > 0 then
+    local arguments = {}
+    if #args > 1 then
+      for args_count = 1, #args do
+        if(type( args[args_count])) == 'table' then
+          table.insert(arguments, args[args_count])
+        end
+      end
+    else
+      arguments = args
+    end
+    return module.mobileSession:ExpectNotification(func,arguments)
+  end
+  return module.mobileSession:ExpectNotification(func,args)
+
+end
+
+function EXPECT_ANY_SESSION_NOTIFICATION(funcName, ...)
+  local args = table.pack(...)
+  local event = events.Event()
+  event.matches = function(_, data)
+    return data.rpcFunctionId == functionId[funcName]
+  end
+  local ret = Expectation(funcName .. " notification", module.mobileConnection)
+  if #args > 0 then
+    ret:ValidIf(function(self, data)
+        local arguments
+        if self.occurences > #args then
+          arguments = args[#args]
+        else
+          arguments = args[self.occurences]
+        end
+        local _res, _err = mob_schema:Validate(funcName, load_schema.notification, data.payload)
+        xmlReporter.AddMessage("EXPECT_ANY_SESSION_NOTIFICATION", {["name"] = tostring(funcName),["Type"]= "EXPECTED_RESULT"}, arguments)
+        xmlReporter.AddMessage("EXPECT_ANY_SESSION_NOTIFICATION", {["name"] = tostring(funcName),["Type"]= "AVALIABLE_RESULT"}, data.payload)
+        if (not _res) then return _res,_err end
+        return compareValues(arguments, data.payload, "payload")
+      end)
+  end
+  ret.event = event
+  event_dispatcher:AddEvent(module.mobileConnection, event, ret)
+  module.expectations_list:Add(ret)
+  return ret
+end
+
+module.timers = { }
+
+function RUN_AFTER(func, timeout, funcName)
+  func_name_str = "noname"
+  if funcName then
+    func_name_str = funcName
+  end
+  xmlReporter.AddMessage(debug.getinfo(1, "n").name, func_name_str,
+    {["functionLine"] = debug.getinfo(func, "S").linedefined, ["Timeout"] = tostring(timeout)})
+  local d = qt.dynamic()
+  d.timeout = function(self)
+    func()
+    module.timers[self] = nil
+  end
+  local timer = timers.Timer()
+  module.timers[timer] = true
+  qt.connect(timer, "timeout()", d, "timeout()")
+  timer:setSingleShot(true)
+  timer:start(timeout)
+end
+
+function EXPECT_RESPONSE(correlationId, ...)
+  xmlReporter.AddMessage(debug.getinfo(1, "n").name, "EXPECTED_RESULT", ... )
+  return module.mobileSession:ExpectResponse(correlationId, ...)
+end
+
+function EXPECT_ANY_SESSION_RESPONSE(correlationId, ...)
+  xmlReporter.AddMessage(debug.getinfo(1, "n").name, {["CorrelationId"] = tostring(correlationId)})
+  local args = table.pack(...)
+  local event = events.Event()
+  event.matches = function(_, data)
+    return data.rpcCorrelationId == correlationId
+  end
+  local ret = Expectation("response to " .. correlationId, module.mobileConnection)
+  if #args > 0 then
+    ret:ValidIf(function(self, data)
+        local arguments
+        if self.occurences > #args then
+          arguments = args[#args]
+        else
+          arguments = args[self.occurences]
+        end
+        xmlReporter.AddMessage("EXPECT_ANY_SESSION_RESPONSE", "EXPECTED_RESULT", arguments)
+        xmlReporter.AddMessage("EXPECT_ANY_SESSION_RESPONSE", "AVALIABLE_RESULT", data.payload)
+        return compareValues(arguments, data.payload, "payload")
+      end)
+  end
+  ret.event = event
+  event_dispatcher:AddEvent(module.mobileConnection, event, ret)
+  module.expectations_list:Add(ret)
+  return ret
+end
+
+function EXPECT_ANY()
+  xmlReporter.AddMessage(debug.getinfo(1, "n").name, '')
+  return module.mobileSession:ExpectAny()
+end
+
+function EXPECT_EVENT(event, name)
+  local ret = Expectation(name, module.mobileConnection)
+  ret.event = event
+  event_dispatcher:AddEvent(module.mobileConnection, event, ret)
+  module:AddExpectation(ret)
+  return ret
+end
+
+function RAISE_EVENT(event, data, eventName)
+  event_str = "noname"
+  if eventName then
+    event_str = eventName
+  end
+  xmlReporter.AddMessage(debug.getinfo(1, "n").name, event_str)
+  event_dispatcher:RaiseEvent(module.mobileConnection, data)
+end
+
+function EXPECT_HMIEVENT(event, name)
+  local ret = Expectation(name, module.hmiConnection)
+  ret.event = event
+  event_dispatcher:AddEvent(module.hmiConnection, event, ret)
+  module:AddExpectation(ret)
+  return ret
+end
+
+function StartSDL(SDLPathName, ExitOnCrash)
+  return SDL:StartSDL(SDLPathName, config.SDL, ExitOnCrash)
+end
+
+function StopSDL()
+  event_dispatcher:ClearEvents()
+  module.expectations_list:Clear()
+  return SDL:StopSDL()
+end
+
+function module:runSDL()
+  if config.autorunSDL ~= true then
+    SDL.autoStarted = false
+    return
+  end
+  local result, errmsg = SDL:StartSDL(config.pathToSDL, config.SDL, config.ExitOnCrash)
+  if not result then
+    SDL:DeleteFile()
+    quit(exit_codes.aborted)
+  end
+  SDL.autoStarted = true
+end
+
+function module:initHMI()
+  local exp_waiter = commonFunctions:createMultipleExpectationsWaiter(module, "HMI initialization")
+  local function registerComponent(name, subscriptions)
+    local rid = module.hmiConnection:SendRequest("MB.registerComponent", { componentName = name })
+    local exp = EXPECT_HMIRESPONSE(rid)
+    exp_waiter:AddExpectation(exp)
+    if subscriptions then
+      for _, s in ipairs(subscriptions) do
+        exp:Do(function(_, data)
+            local rid = module.hmiConnection:SendRequest("MB.subscribeTo", { propertyName = s })
+            local exp = EXPECT_HMIRESPONSE(rid)
+            exp_waiter:AddExpectation(exp)
+          end)
+      end
+    end
+  end
+
+  local web_socket_connected_event = EXPECT_HMIEVENT(events.connectedEvent, "Connected websocket")
+  :Do(function()
+      registerComponent("Buttons", {"Buttons.OnButtonSubscription"})
+      registerComponent("TTS")
+      registerComponent("VR")
+      registerComponent("BasicCommunication",
+        {
+          "BasicCommunication.OnPutFile",
+          "SDL.OnStatusUpdate",
+          "SDL.OnAppPermissionChanged",
+          "BasicCommunication.OnSDLPersistenceComplete",
+          "BasicCommunication.OnFileRemoved",
+          "BasicCommunication.OnAppRegistered",
+          "BasicCommunication.OnAppUnregistered",
+          "BasicCommunication.PlayTone",
+          "BasicCommunication.OnSDLClose",
+          "SDL.OnSDLConsentNeeded",
+          "BasicCommunication.OnResumeAudioSource"
+        })
+      registerComponent("UI",
+        {
+          "UI.OnRecordStart"
+        })
+      registerComponent("VehicleInfo")
+      registerComponent("Navigation",
+        {
+          "Navigation.OnAudioDataStreaming",
+          "Navigation.OnVideoDataStreaming"
+        })
+    end)
+  exp_waiter:AddExpectation(web_socket_connected_event)
+  
+  self.hmiConnection:Connect()
+  return exp_waiter.expectation
+end
+
+function module:initHMI_onReady()
+  local exp_waiter = commonFunctions:createMultipleExpectationsWaiter(module, "HMI on ready")
+  local function ExpectRequest(name, mandatory, params)
+    local event = events.Event()
+    event.level = 2
+    event.matches = function(self, data)
+      return data.method == name
+    end
+    local exp = EXPECT_HMIEVENT(event, name)
+    :Times(mandatory and 1 or AnyNumber())
+    :Do(function(_, data)
+        xmlReporter.AddMessage("hmi_connection","SendResponse",
+          {
+            ["methodName"] = tostring(name),
+            ["mandatory"] = mandatory ,
+            ["params"]= params
+          })
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", params)
+      end)
+    if (mandatory) then 
+     exp_waiter:AddExpectation(exp)
+    end
+   return exp
+  end
+
+  local function ExpectNotification(name, mandatory)
+    xmlReporter.AddMessage(debug.getinfo(1, "n").name, tostring(name))
+    local event = events.Event()
+    event.level = 2
+    event.matches = function(self, data) return data.method == name end
+    local exp = EXPECT_HMIEVENT(event, name)
+    :Times(mandatory and 1 or AnyNumber())
+    exp_waiter:AddExpectation(exp)
+    return exp
+  end
+
+  ExpectRequest("BasicCommunication.MixingAudioSupported",
+    true,
+    { attenuatedSupported = true })
+  ExpectRequest("BasicCommunication.GetSystemInfo", false,
+    {
+      ccpu_version = "ccpu_version",
+      language = "EN-US",
+      wersCountryCode = "wersCountryCode"
+    })
+  ExpectRequest("UI.GetLanguage", true, { language = "EN-US" })
+  ExpectRequest("VR.GetLanguage", true, { language = "EN-US" })
+  ExpectRequest("TTS.GetLanguage", true, { language = "EN-US" })
+  ExpectRequest("UI.ChangeRegistration", false, { }):Pin()
+  ExpectRequest("TTS.SetGlobalProperties", false, { }):Pin()
+  ExpectRequest("BasicCommunication.UpdateDeviceList", false, { }):Pin()
+  ExpectRequest("VR.ChangeRegistration", false, { }):Pin()
+  ExpectRequest("TTS.ChangeRegistration", false, { }):Pin()
+  ExpectRequest("VR.GetSupportedLanguages", true, {
+      languages = {
+        "EN-US","ES-MX","FR-CA","DE-DE","ES-ES","EN-GB","RU-RU",
+        "TR-TR","PL-PL","FR-FR","IT-IT","SV-SE","PT-PT","NL-NL",
+        "ZH-TW","JA-JP","AR-SA","KO-KR","PT-BR","CS-CZ","DA-DK",
+        "NO-NO","NL-BE","EL-GR","HU-HU","FI-FI","SK-SK" }
+    })
+  ExpectRequest("TTS.GetSupportedLanguages", true, {
+      languages = {
+        "EN-US","ES-MX","FR-CA","DE-DE","ES-ES","EN-GB","RU-RU",
+        "TR-TR","PL-PL","FR-FR","IT-IT","SV-SE","PT-PT","NL-NL",
+        "ZH-TW","JA-JP","AR-SA","KO-KR","PT-BR","CS-CZ","DA-DK",
+        "NO-NO","NL-BE","EL-GR","HU-HU","FI-FI","SK-SK" }
+    })
+  ExpectRequest("UI.GetSupportedLanguages", true, {
+      languages = {
+        "EN-US","ES-MX","FR-CA","DE-DE","ES-ES","EN-GB","RU-RU",
+        "TR-TR","PL-PL","FR-FR","IT-IT","SV-SE","PT-PT","NL-NL",
+        "ZH-TW","JA-JP","AR-SA","KO-KR","PT-BR","CS-CZ","DA-DK",
+        "NO-NO","NL-BE","EL-GR","HU-HU","FI-FI","SK-SK" }
+    })
+  ExpectRequest("VehicleInfo.GetVehicleType", true, {
+      vehicleType =
+      {
+        make = "Ford",
+        model = "Fiesta",
+        modelYear = "2013",
+        trim = "SE"
+      }
+    })
+  ExpectRequest("VehicleInfo.GetVehicleData", true, { vin = "52-452-52-752" })
+  
+  local function button_capability(name, shortPressAvailable, longPressAvailable, upDownAvailable)
+    return
+    {
+      name = name,
+      shortPressAvailable = shortPressAvailable == nil and true or shortPressAvailable,
+      longPressAvailable = longPressAvailable == nil and true or longPressAvailable,
+      upDownAvailable = upDownAvailable == nil and true or upDownAvailable
+    }
+  end
+
+  local buttons_capabilities =
+  {
+    capabilities =
+    {
+      button_capability("PRESET_0"),
+      button_capability("PRESET_1"),
+      button_capability("PRESET_2"),
+      button_capability("PRESET_3"),
+      button_capability("PRESET_4"),
+      button_capability("PRESET_5"),
+      button_capability("PRESET_6"),
+      button_capability("PRESET_7"),
+      button_capability("PRESET_8"),
+      button_capability("PRESET_9"),
+      button_capability("OK", true, false, true),
+      button_capability("SEEKLEFT"),
+      button_capability("SEEKRIGHT"),
+      button_capability("TUNEUP"),
+      button_capability("TUNEDOWN")
+    },
+    presetBankCapabilities = { onScreenPresetsAvailable = true }
+  }
+  ExpectRequest("Buttons.GetCapabilities", true, buttons_capabilities)
+  ExpectRequest("VR.GetCapabilities", true, { vrCapabilities = { "TEXT" } })
+  ExpectRequest("TTS.GetCapabilities", true, {
+      speechCapabilities = { "TEXT", "PRE_RECORDED" },
+      prerecordedSpeechCapabilities =
+      {
+        "HELP_JINGLE",
+        "INITIAL_JINGLE",
+        "LISTEN_JINGLE",
+        "POSITIVE_JINGLE",
+        "NEGATIVE_JINGLE"
+      }
+    })
+
+  local function text_field(name, characterSet, width, rows)
+    return
+    {
+      name = name,
+      characterSet = characterSet or "TYPE2SET",
+      width = width or 500,
+      rows = rows or 1
+    }
+  end
+  local function image_field(name, width, height)
+    return
+    {
+      name = name,
+      imageTypeSupported =
+      {
+        "GRAPHIC_BMP",
+        "GRAPHIC_JPEG",
+        "GRAPHIC_PNG"
+      },
+      imageResolution =
+      {
+        resolutionWidth = width or 64,
+        resolutionHeight = height or 64
+      }
+    }
+
+  end
+
+  ExpectRequest("UI.GetCapabilities", true, {
+      displayCapabilities =
+      {
+        displayType = "GEN2_8_DMA",
+        textFields =
+        {
+          text_field("mainField1"),
+          text_field("mainField2"),
+          text_field("mainField3"),
+          text_field("mainField4"),
+          text_field("statusBar"),
+          text_field("mediaClock"),
+          text_field("mediaTrack"),
+          text_field("alertText1"),
+          text_field("alertText2"),
+          text_field("alertText3"),
+          text_field("scrollableMessageBody"),
+          text_field("initialInteractionText"),
+          text_field("navigationText1"),
+          text_field("navigationText2"),
+          text_field("ETA"),
+          text_field("totalDistance"),
+          text_field("navigationText"),
+          text_field("audioPassThruDisplayText1"),
+          text_field("audioPassThruDisplayText2"),
+          text_field("sliderHeader"),
+          text_field("sliderFooter"),
+          text_field("notificationText"),
+          text_field("menuName"),
+          text_field("secondaryText"),
+          text_field("tertiaryText"),
+          text_field("timeToDestination"),
+          text_field("turnText"),
+          text_field("menuTitle"),
+          text_field("locationName"),
+          text_field("locationDescription"),
+          text_field("addressLines"),
+          text_field("phoneNumber")
+        },
+        imageFields =
+        {
+          image_field("softButtonImage"),
+          image_field("choiceImage"),
+          image_field("choiceSecondaryImage"),
+          image_field("vrHelpItem"),
+          image_field("turnIcon"),
+          image_field("menuIcon"),
+          image_field("cmdIcon"),
+          image_field("showConstantTBTIcon"),
+          image_field("locationImage")
+        },
+        mediaClockFormats =
+        {
+          "CLOCK1",
+          "CLOCK2",
+          "CLOCK3",
+          "CLOCKTEXT1",
+          "CLOCKTEXT2",
+          "CLOCKTEXT3",
+          "CLOCKTEXT4"
+        },
+        graphicSupported = true,
+        imageCapabilities = { "DYNAMIC", "STATIC" },
+        templatesAvailable = { "TEMPLATE" },
+        screenParams =
+        {
+          resolution = { resolutionWidth = 800, resolutionHeight = 480 },
+          touchEventAvailable =
+          {
+            pressAvailable = true,
+            multiTouchAvailable = true,
+            doublePressAvailable = false
+          }
+        },
+        numCustomPresetsAvailable = 10
+      },
+      audioPassThruCapabilities =
+      {
+        samplingRate = "44KHZ",
+        bitsPerSample = "8_BIT",
+        audioType = "PCM"
+      },
+      hmiZoneCapabilities = "FRONT",
+      softButtonCapabilities =
+      {
+        {
+          shortPressAvailable = true,
+          longPressAvailable = true,
+          upDownAvailable = true,
+          imageSupported = true
+        }
+      }
+    })
+
+  ExpectRequest("VR.IsReady", true, { available = true })
+  ExpectRequest("TTS.IsReady", true, { available = true })
+  ExpectRequest("UI.IsReady", true, { available = true })
+  ExpectRequest("Navigation.IsReady", true, { available = true })
+  ExpectRequest("VehicleInfo.IsReady", true, { available = true })
+
+  self.applications = { }
+  ExpectRequest("BasicCommunication.UpdateAppList", false, { })
+  :Pin()
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", { })
+      self.applications = { }
+      for _, app in pairs(data.params.applications) do
+        self.applications[app.appName] = app.appID
+      end
+    end)
+  self.hmiConnection:SendNotification("BasicCommunication.OnReady")
+  return exp_waiter.expectation
+end
+
+function module:connectMobile()
+  -- Disconnected expectation
+  EXPECT_EVENT(events.disconnectedEvent, "Disconnected")
+  :Pin()
+  :Times(AnyNumber())
+  :Do(function()
+      print("Disconnected!!!")
+    end)
+  self.mobileConnection:Connect()
+  return EXPECT_EVENT(events.connectedEvent, "Connected")
+end
+
+function module:startSession()
+  self.mobileSession = mobile_session.MobileSession(
+    self,
+    self.mobileConnection,
+    config.application1.registerAppInterfaceParams)
+  self.mobileSession:Start()
+  local mobile_connected = EXPECT_HMICALL("BasicCommunication.UpdateAppList")
+  mobile_connected:Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", { })
+      self.applications = { }
+      for _, app in pairs(data.params.applications) do
+        self.applications[app.appName] = app.appID
+      end
+    end)
+  return mobile_connected
+end
+
+return module


### PR DESCRIPTION
# Test cases coverage :
Add tests for ShutDown MASTER_RESET and ShutDown IGNITION_OFF
Add dummy_connecttest and use it instead of connecttest.
Add waitForSDLStart and createMultipleExpectationsWaiter functions to CommonFunctions.
[SDLOPEN-932](https://adc.luxoft.com/jira/browse/SDLOPEN-932)

# Additional functionality and ideas in common steps: 

## dummy_connect test
Is the same connect test that do not add any test cases to script by default. 
You should **run sdl**,  **init hmi**,  **connect mobile** , etc ... in your preconditions. In case if you need to avoid some step or modify it, you is able to redefine any step before call or do not call it at all ( for example if you need to start SDL without HMI)

Also each function like **init_hmi**, **init_hmi_onReady**, etc ..., now returns expectations. Not is is possible to shedule some code, that will be executed when step is done

_Example:_
```
function Test:PreconditionXXX()
Test:init_Hmi():Do(function()
    -- this code will be executed after hmi initialization
  end
end
```
Example is in https://github.com/LitvinenkoIra/sdl_atf_test_scripts/blob/bb1e8f7eaba0b5021fb46dba8f117f740679f105/test_scripts/ATF_ShutDown_IGNITION_OFF.lua#L14 

### ToDo:
- [ ] Create better name (dummy connect test is bad one)
- [ ] Move common steps from connect test to common steps
- [ ] Mark EXPECTATIONS as deprecated and move to some separate file from connecttest

## Multiple expectations waiter
Object that is able to wait multiple expectations and provide some callback when all of them done. 
It provide possibility to avoid splitting some functionality to different test cases. 
Example:
```
function Test:doComplexActivity()
-- app activation, policy update ro so on
on_complex_activity_done = commonFunctions:createMultipleExpectationsWaiter(Test, "Some complex activity")
on_complex_activity_done:AddExpectation(exp1)
on_complex_activity_done:AddExpectation(exp2)
on_complex_activity_done:AddExpectation(exp3)
...
return exp_waiter.expectation
end

function Test:TestCase()
  Test:doComplexActivity():Do(function()
    -- this code will be executed the complex activity is completely done
  end
end
```

Example in code : https://github.com/LitvinenkoIra/sdl_atf_test_scripts/blob/bb1e8f7eaba0b5021fb46dba8f117f740679f105/user_modules/dummy_connecttest.lua#L316 

### ToDo:
- [ ] Implement WaitAnyExpectation that will wait if any of added expectations done

## Wait for start SDL
Function is waiting for opened sockets, that sdl should open after startups

Example : 
```
function Test:TestCase()
  self:runSDL()
  commonFunctions:waitForSDLStart(self):Do(function()
    -- this code will be executed when all required sockets opened by SDL ( sdl completely started) 
  end
end
```
Example in code: 
https://github.com/LitvinenkoIra/sdl_atf_test_scripts/blob/bb1e8f7eaba0b5021fb46dba8f117f740679f105/test_scripts/ATF_ShutDown_IGNITION_OFF.lua#L16

### ToDo: 
- [ ] Move waiting for starting SDL to runSDL
- [ ] avoid printing to console redundant output while waiting for SDL start (netstat calls)

## Concept of testing with Times(0)

We can guarantee that SDL didn't send some notification\request only if SDL was correctly shut downed and didn't sent this notification. 
Here is example of such checking: 
https://github.com/LitvinenkoIra/sdl_atf_test_scripts/blob/bb1e8f7eaba0b5021fb46dba8f117f740679f105/test_scripts/ATF_ShutDown_MASTER_RESET.lua#L115-L116 

### ToDo: 
- [ ] Check assumption that sdl should send all pending notification before ignition off 



**_Note:_** All ToDo issues wan't be done in scope of this PR 

