### PR TITLE
005_ATF_P_TC_default_app_first_StartService_RPC_encrypt_true

### DIFF
--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/005_ATF_P_TC_default_app_first_StartService_RPC_encrypt_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/005_ATF_P_TC_default_app_first_StartService_RPC_encrypt_true.lua
@@ -1,0 +1,128 @@
+---------------------------------------------------------------------------------------------
+-- Requirement summary:
+-- [PTU] [GENIVI] SDL must start PTU for any app except navi right after app successfully request to start first secure service
+--
+-- Description:
+-- In case any app except navigation connects and sucessfully registers on SDL (opens RPC 7 service)
+-- and sends first StartService (<any_serviceType>, encrypted=true) to SDL
+-- and PolicyTable has NO "certificate" at "module_config" section of LocalPolicyTable
+-- SDL must: start PolicyTableUpdate process on sending SDL.OnStatusUpdate(UPDATE_NEEDED) to HMI to get "certificate"
+-- (meaning: SDL will NOT respond to StartService_request from mobile app till PTU will be finished per comment)
+--
+-- 1. Used preconditions:
+-- RPC SetAudioStreamingIndicator is allowed by policy
+-- Default app exists in LP, no certificate in module_config
+--
+-- 2. Performed steps
+-- 2.1. Register and activate application.
+-- 2.2. Send StartService(serviceType = 7 (RPC), RPCfunctionID = 48(SetAudioStreamingIndicator))
+--
+-- Expected result:
+-- 1. Application is registered and activated successfully.
+-- 2. SDL should trigger PTU: SDL.OnStatusUpdate(UPDATE_NEEDED)
+-- 3. SDL should not respond to StartService_request
+-- SDL should not process request to HMI
+---------------------------------------------------------------------------------------------
+
+--[[ General configuration parameters ]]
+config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
+config.application1.registerAppInterfaceParams.appHMIType = {"DEFAULT"}
+config.application1.registerAppInterfaceParams.isMediaApplication = false
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
+local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
+local mobile_session = require('mobile_session')
+local testCasesForPolicyCeritificates = require('user_modules/shared_testcases/testCasesForPolicyCeritificates')
+local events = require('events')
+local Event = events.Event
+
+--[[ General Precondition before ATF start ]]
+testCasesForPolicyCeritificates.update_preloaded_pt(config.application1.registerAppInterfaceParams.appID, false)
+commonSteps:DeletePolicyTable()
+commonSteps:DeleteLogsFiles()
+
+--[[ General Settings for configuration ]]
+Test = require('user_modules/connecttest_resumption')
+require('user_modules/AppTypes')
+
+--[[ Preconditions ]]
+commonFunctions:newTestCasesGroup("Preconditions")
+
+function Test:Precondition_connectMobile()
+  self:connectMobile()
+end
+
+function Test:Precondition_StartSession()
+  self.mobileSession = mobile_session.MobileSession(self, self.mobileConnection)
+  self.mobileSession:StartService(7)
+end
+
+--[[ Test ]]
+commonFunctions:newTestCasesGroup("Test")
+function Test:Precondition_RAI_No_PTU_Trigger()
+  local CorIdRegister = self.mobileSession:SendRPC("RegisterAppInterface", config.application1.registerAppInterfaceParams)
+
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config.application1.registerAppInterfaceParams.appName }})
+  :Do(function(_,data) self.applications[config.application1.registerAppInterfaceParams.appName] = data.params.application.appID end)
+
+  EXPECT_RESPONSE(CorIdRegister, { success = true, resultCode = "SUCCESS" })
+  EXPECT_NOTIFICATION("OnHMIStatus", { systemContext = "MAIN", hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE"})
+
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate"):Times(0)
+  commonTestCases:DelayedExp(10000)
+end
+
+function Test:Precondition_ActivateApp()
+  commonSteps:ActivateAppInSpecificLevel(self, self.applications[config.application1.registerAppInterfaceParams.appName])
+  EXPECT_NOTIFICATION("OnHMIStatus", {systemContext = "MAIN", hmiLevel = "FULL"})
+end
+
+function Test:TestStep_First_StartService()
+  self.mobileSession.correlationId = self.mobileSession.correlationId + 1
+
+  local msg = {
+    serviceType = 7,
+    frameInfo = 0,
+    rpcType = 0,
+    rpcFunctionId = 48,
+    encryption = true,
+    rpcCorrelationId = self.mobileSession.correlationId,
+    payload = '{ "audioStreamingIndicator" : "PAUSE" }'
+  }
+
+  self.mobileSession:Send(msg)
+
+  local startserviceEvent = Event()
+  startserviceEvent.matches =
+  function(_, data)
+    return ( (data.serviceType == 7) and (data.frameInfo == 2 or data.frameInfo == 3) )
+  end
+
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, {status = "UPDATING"}):Times(2)
+  EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
+  :Do(function(_,data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+
+  EXPECT_HMICALL("UI.SetAudioStreamingIndicator"):Times(0)
+
+  self.mobileSession:ExpectEvent(startserviceEvent, "Service 7: RPC SetAudioStreamingIndicator"):Times(0)
+
+  commonTestCases:DelayedExp(10000)
+end
+
+--[[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postconditions")
+
+function Test.Postcondition_Restore_preloaded_pt()
+  commonPreconditions:RestoreFile("sdl_preloaded_pt.json")
+end
+
+function Test.Postcondition_Stop()
+  StopSDL()
+end
+
+return Test


### PR DESCRIPTION
Script is part of TS: #1163
PRs: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1196; https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1197 have common scenario for different type of applications.