### PR TITLE
020 Script for requirement [Policies] [External UCS] SDL informs HMI about <externalConsentStatus> via GetListOfPermissions response

### DIFF
--- a/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
@@ -33,6 +33,20 @@ config.defaultProtocolVersion = 2
 local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
 local commonSteps = require('user_modules/shared_testcases/commonSteps')
 local testCasesForPolicyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
+
+--[[Local Variables]]
+local params_invalid_data =
+{
+  {param_value = "invalidValue", comment = "String"}
+  {param_value = 1.32 comment = "Float"},
+  {param_value = {}, comment = "Empty table" },
+  {param_value = { entityType = 1, entityID = 1 }, comment = "Non-empty table"},
+  {param_value = -1, comment = "OutOfLowerBound"},
+  {param_value = 130, comment = "OutOfUpperBound" },
+  {param_value = "", comment = "Empty" },
+  {param_value = nil, desc = "Null" }
+}
 
 --[[ General Precondition before ATF start ]]
 commonFunctions:SDLForceStop()
@@ -51,53 +65,55 @@ function Test:Precondition_trigger_getting_device_consent()
   testCasesForPolicyTable:trigger_getting_device_consent(self, config.application1.registerAppInterfaceParams.appName, config.deviceMAC)
 end
 
-function Test:Precondition_PTU_and_OnAppPermissionConsent_Invalid_entityID()
-  local ptu_file_path = "files/jsons/Policies/Related_HMI_API/"
-  local ptu_file = "OnAppPermissionConsent_ptu.json"
-  
-  testCasesForPolicyTable:flow_SUCCEESS_EXTERNAL_PROPRIETARY(self, nil, nil, nil, ptu_file_path, nil, ptu_file)
-
-  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged",{ appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
-  :Do(function(_,data)
+for i = 1, #params_invalid_data do
+  Test["Precondition_PTU_and_OnAppPermissionConsent_Invalid_"..params_invalid_data[i]] = function(self)
+    local ptu_file_path = "files/jsons/Policies/Related_HMI_API/"
+    local ptu_file = "OnAppPermissionConsent_ptu.json"
+    
+    testCasesForPolicyTable:flow_SUCCEESS_EXTERNAL_PROPRIETARY(self, nil, nil, nil, ptu_file_path, nil, ptu_file)
+    
+    EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged",{ appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
+    :Do(function(_,data)
       if (data.params.appPermissionsConsentNeeded== true) then
         local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
-        EXPECT_HMIRESPONSE(RequestIdListOfPermissions,{result = {code = 0, method = "SDL.GetListOfPermissions",
-              -- allowed: If ommited - no information about User Consent is yet found for app.
-              allowedFunctions = {
-                { name = "Location", id = 156072572},
-                { name = "Notifications", id = 1809526495}
-              },
-              externalConsentStatus = {}
-            }
-          })
+          EXPECT_HMIRESPONSE(RequestIdListOfPermissions,{result = {code = 0, method = "SDL.GetListOfPermissions",
+            -- allowed: If ommited - no information about User Consent is yet found for app.
+            allowedFunctions = {
+              { name = "Location", id = 156072572},
+              { name = "Notifications", id = 1809526495}
+            },
+            externalConsentStatus = {}
+          }
+        })
         :Do(function()
-            local ReqIDGetUserFriendlyMessage = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage",
-              {language = "EN-US", messageCodes = {"AppPermissions"}})
-
-            EXPECT_HMIRESPONSE(ReqIDGetUserFriendlyMessage,
-              {result = {code = 0, messages = {{messageCode = "AppPermissions"}}, method = "SDL.GetUserFriendlyMessage"}})
-            :Do(function(_,_)
-                self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent",
-                  {
-                    appID = self.applications[config.application1.registerAppInterfaceParams.appName],
-                    consentedFunctions = {
-                      { allowed = true, id = 156072572, name = "Location-1"},
-                      { allowed = true, id = 1809526495, name = "Notifications"}
-                    },
-                    externalConsentStatus = {
-                      {entityType = 13, entityID = "invalidID", status = "ON"}
-                    },
-                    source = "GUI"
-                  })
-                EXPECT_NOTIFICATION("OnPermissionsChange"):Times(0)
-                commonTestCases:DelayedExp(10000)
-              end)
+          local ReqIDGetUserFriendlyMessage = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage",
+          {language = "EN-US", messageCodes = {"AppPermissions"}})
+          
+          EXPECT_HMIRESPONSE(ReqIDGetUserFriendlyMessage,
+          {result = {code = 0, messages = {{messageCode = "AppPermissions"}}, method = "SDL.GetUserFriendlyMessage"}})
+          :Do(function(_,_)
+            self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent",
+            {
+              appID = self.applications[config.application1.registerAppInterfaceParams.appName],
+              consentedFunctions = {
+                { allowed = true, id = 156072572, name = "Location-1"},
+                { allowed = true, id = 1809526495, name = "Notifications"}
+              },
+              externalConsentStatus = {
+                {entityType = 13, entityID = params_invalid_data[i], status = "ON"}
+              },
+              source = "GUI"
+            })
+            EXPECT_NOTIFICATION("OnPermissionsChange"):Times(0)
+            commonTestCases:DelayedExp(10000)
+          end)
         end)
       else
         commonFunctions:userPrint(31, "Wrong SDL bahavior: there are app permissions for consent, isPermissionsConsentNeeded should be true")
         return false
       end
-  end)
+    end)
+  end
 end
 
 --[[ Test ]]
@@ -105,12 +121,12 @@ commonFunctions:newTestCasesGroup("Test")
 
 function Test:TestStep_GetListofPermissions_entityID_invalid()
   local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
-
+  
   EXPECT_HMIRESPONSE(RequestIdListOfPermissions, {
     code = "0",
     allowedFunctions = {
-    { name = "Location-1", id = 156072572},
-    { name = "Notifications", id = 1809526495}
+      { name = "Location", id = 156072572},
+      { name = "Notifications", id = 1809526495}
     },
     externalConsentStatus = {}
   })

--- a/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
@@ -14,7 +14,7 @@
 -- Application is registered and activated
 -- PTU file is updated and application is assigned to functional groups: Base-4, user-consent groups: Location-1 and Notifications
 -- PTU has passed successfully
--- HMI sends <externalConsentStatus> to SDl via OnAppPermissionConsent (parameter entityID has invalid value, rest of params present and within bounds, EntityStatus = 'ON')
+-- HMI sends <externalConsentStatus> to SDl via OnAppPermissionConsent (parameter entityID has invalid value type, rest of params present and within bounds, EntityStatus = 'ON')
 -- SDL doesn't receive updated Permission items and consent status
 --
 -- 2. Performed steps
@@ -85,11 +85,12 @@ function Test:Precondition_PTU_and_OnAppPermissionConsent_Invalid_entityID()
                       { allowed = true, id = 1809526495, name = "Notifications"}
                     },
                     externalConsentStatus = {
-                      {entityType = 13, entityID = "invalidValue", status = "ON"}
+                      {entityType = 13, entityID = "invalidID", status = "ON"}
                     },
                     source = "GUI"
                   })
-                EXPECT_NOTIFICATION("OnPermissionsChange")
+                EXPECT_NOTIFICATION("OnPermissionsChange"):Times(0)
+                commonTestCases:DelayedExp(10000)
               end)
         end)
       else
@@ -108,8 +109,8 @@ function Test:TestStep_GetListofPermissions_entityID_invalid()
   EXPECT_HMIRESPONSE(RequestIdListOfPermissions, {
     code = "0",
     allowedFunctions = {
-    { name = "Location-1", id = 156072572, allowed = true},
-    { name = "Notifications", id = 1809526495, allowed = true}
+    { name = "Location-1", id = 156072572},
+    { name = "Notifications", id = 1809526495}
     },
     externalConsentStatus = {}
   })

--- a/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
@@ -1,0 +1,125 @@
+---------------------------------------------------------------------------------------------
+-- Requirement summary:
+-- [Policies] [External UCS] SDL informs HMI about <externalConsentStatus> via GetListOfPermissions response
+-- [HMI API] GetListOfPermissions request/response
+-- [HMI API] ExternalConsentStatus struct & EntityStatus enum
+--
+-- Description:
+-- For Genivi applicable ONLY for 'EXTERNAL_PROPRIETARY' Polcies
+-- Check that SDL invalidates notification OnAppPermissionConsent due to invalid value type of parameter entityID
+--
+-- 1. Used preconditions
+-- SDL is built with External_Proprietary flag
+-- SDL and HMI are running
+-- Application is registered and activated
+-- PTU file is updated and application is assigned to functional groups: Base-4, user-consent groups: Location-1 and Notifications
+-- PTU has passed successfully
+-- HMI sends <externalConsentStatus> to SDl via OnAppPermissionConsent (parameter entityID has invalid value, rest of params present and within bounds, EntityStatus = 'ON')
+-- SDL doesn't receive updated Permission items and consent status
+--
+-- 2. Performed steps
+-- HMI sends to SDL GetListOfPermissions (appID)
+--
+-- Expected result:
+-- SDL sends to HMI empty array
+---------------------------------------------------------------------------------------------
+
+--[[ General configuration parameters ]]
+config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
+-- ToDo (vvvakulenko): remove after issue "ATF does not stop HB timers by closing session and connection" is resolved
+config.defaultProtocolVersion = 2
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local testCasesForPolicyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
+
+--[[ General Precondition before ATF start ]]
+commonFunctions:SDLForceStop()
+commonSteps:DeleteLogsFiles()
+commonSteps:DeletePolicyTable()
+
+--[[ General Settings for configuration ]]
+Test = require('connecttest')
+require('cardinalities')
+require('user_modules/AppTypes')
+
+--[[ Preconditions ]]
+commonFunctions:newTestCasesGroup("Preconditions")
+
+function Test:Precondition_trigger_getting_device_consent()
+  testCasesForPolicyTable:trigger_getting_device_consent(self, config.application1.registerAppInterfaceParams.appName, config.deviceMAC)
+end
+
+function Test:Precondition_PTU_and_OnAppPermissionConsent_Invalid_entityID()
+  local ptu_file_path = "files/jsons/Policies/Related_HMI_API/"
+  local ptu_file = "OnAppPermissionConsent_ptu.json"
+  
+  testCasesForPolicyTable:flow_SUCCEESS_EXTERNAL_PROPRIETARY(self, nil, nil, nil, ptu_file_path, nil, ptu_file)
+
+  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged",{ appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
+  :Do(function(_,data)
+      if (data.params.appPermissionsConsentNeeded== true) then
+        local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
+        EXPECT_HMIRESPONSE(RequestIdListOfPermissions,{result = {code = 0, method = "SDL.GetListOfPermissions",
+              -- allowed: If ommited - no information about User Consent is yet found for app.
+              allowedFunctions = {
+                { name = "Location", id = 156072572},
+                { name = "Notifications", id = 1809526495}
+              },
+              externalConsentStatus = {}
+            }
+          })
+        :Do(function()
+            local ReqIDGetUserFriendlyMessage = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage",
+              {language = "EN-US", messageCodes = {"AppPermissions"}})
+
+            EXPECT_HMIRESPONSE(ReqIDGetUserFriendlyMessage,
+              {result = {code = 0, messages = {{messageCode = "AppPermissions"}}, method = "SDL.GetUserFriendlyMessage"}})
+            :Do(function(_,_)
+                self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent",
+                  {
+                    appID = self.applications[config.application1.registerAppInterfaceParams.appName],
+                    consentedFunctions = {
+                      { allowed = true, id = 156072572, name = "Location-1"},
+                      { allowed = true, id = 1809526495, name = "Notifications"}
+                    },
+                    externalConsentStatus = {
+                      {entityType = 13, entityID = "invalidValue", status = "ON"}
+                    },
+                    source = "GUI"
+                  })
+                EXPECT_NOTIFICATION("OnPermissionsChange")
+              end)
+        end)
+      else
+        commonFunctions:userPrint(31, "Wrong SDL bahavior: there are app permissions for consent, isPermissionsConsentNeeded should be true")
+        return false
+      end
+  end)
+end
+
+--[[ Test ]]
+commonFunctions:newTestCasesGroup("Test")
+
+function Test:TestStep_GetListofPermissions_entityID_invalid()
+  local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
+
+  EXPECT_HMIRESPONSE(RequestIdListOfPermissions, {
+    code = "0",
+    allowedFunctions = {
+    { name = "Location-1", id = 156072572, allowed = true},
+    { name = "Notifications", id = 1809526495, allowed = true}
+    },
+    externalConsentStatus = {}
+  })
+end
+
+--[[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postconditions")
+
+function Test.Postcondition_Stop_SDL() 
+  StopSDL()
+end
+
+return Test

--- a/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
@@ -12,9 +12,11 @@
 -- SDL is built with External_Proprietary flag
 -- SDL and HMI are running
 -- Application is registered and activated
--- PTU file is updated and application is assigned to functional groups: Base-4, user-consent groups: Location-1 and Notifications
+-- PTU file is updated and application is assigned to functional groups: Base-4, user-consent groups:
+-- Location-1 and Notifications
 -- PTU has passed successfully
--- HMI sends <externalConsentStatus> to SDl via OnAppPermissionConsent (parameter entityID has invalid value type, rest of params present and within bounds, EntityStatus = 'ON')
+-- HMI sends <externalConsentStatus> to SDl via OnAppPermissionConsent (parameter entityID has invalid value type,
+-- rest of params present and within bounds, EntityStatus = 'ON')
 -- SDL doesn't receive updated Permission items and consent status
 --
 -- 2. Performed steps
@@ -38,15 +40,18 @@ local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 --[[Local Variables]]
 local params_invalid_data =
 {
-  {param_value = "invalidValue", comment = "String"}
-  {param_value = 1.32 comment = "Float"},
+  {param_value = "invalidValue", comment = "String"},
+  {param_value = 1.32, comment = "Float"},
   {param_value = {}, comment = "Empty table" },
   {param_value = { entityType = 1, entityID = 1 }, comment = "Non-empty table"},
   {param_value = -1, comment = "OutOfLowerBound"},
   {param_value = 130, comment = "OutOfUpperBound" },
   {param_value = "", comment = "Empty" },
-  {param_value = nil, desc = "Null" }
+  {param_value = nil, comment = "Null" }
 }
+local ptu_file
+local consentedgroups
+local allowed_func
 
 --[[ General Precondition before ATF start ]]
 commonFunctions:SDLForceStop()
@@ -59,48 +64,63 @@ require('cardinalities')
 require('user_modules/AppTypes')
 
 --[[ Preconditions ]]
-commonFunctions:newTestCasesGroup("Preconditions")
-
 function Test:Precondition_trigger_getting_device_consent()
   testCasesForPolicyTable:trigger_getting_device_consent(self, config.application1.registerAppInterfaceParams.appName, config.deviceMAC)
 end
 
 for i = 1, #params_invalid_data do
+  if(i > 1) then
+    commonFunctions:newTestCasesGroup("Preconditions")
+
+    Test["Precondition_trigger_user_request_update_from_HMI_"..params_invalid_data[i].comment] = function(self)
+      testCasesForPolicyTable:trigger_user_request_update_from_HMI(self)
+    end
+  end
+
   Test["Precondition_PTU_and_OnAppPermissionConsent_Invalid_"..params_invalid_data[i]] = function(self)
     local ptu_file_path = "files/jsons/Policies/Related_HMI_API/"
-    local ptu_file = "OnAppPermissionConsent_ptu.json"
-    
+    if ( (i % 2) == 0 ) then
+
+      ptu_file = "OnAppPermissionConsent_ptu1.json"
+      consentedgroups = {{ allowed = true, id = 4734356, name = "DrivingCharacteristics-3"}}
+      allowed_func = { { name = "DrivingCharacteristics", id = 4734356}}
+    else
+      ptu_file = "OnAppPermissionConsent_ptu.json"
+      consentedgroups = {
+        { allowed = true, id = 156072572, name = "Location-1"},
+        { allowed = true, id = 1809526495, name = "Notifications"}
+      }
+      allowed_func = {
+        { name = "Location", id = 156072572},
+        { name = "Notifications", id = 1809526495}
+      }
+    end
+
     testCasesForPolicyTable:flow_SUCCEESS_EXTERNAL_PROPRIETARY(self, nil, nil, nil, ptu_file_path, nil, ptu_file)
-    
+
     EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged",{ appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
     :Do(function(_,data)
       if (data.params.appPermissionsConsentNeeded== true) then
         local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
           EXPECT_HMIRESPONSE(RequestIdListOfPermissions,{result = {code = 0, method = "SDL.GetListOfPermissions",
             -- allowed: If ommited - no information about User Consent is yet found for app.
-            allowedFunctions = {
-              { name = "Location", id = 156072572},
-              { name = "Notifications", id = 1809526495}
-            },
+            allowedFunctions = allowed_func,
             externalConsentStatus = {}
           }
         })
         :Do(function()
           local ReqIDGetUserFriendlyMessage = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage",
           {language = "EN-US", messageCodes = {"AppPermissions"}})
-          
+         
           EXPECT_HMIRESPONSE(ReqIDGetUserFriendlyMessage,
           {result = {code = 0, messages = {{messageCode = "AppPermissions"}}, method = "SDL.GetUserFriendlyMessage"}})
           :Do(function(_,_)
             self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent",
             {
               appID = self.applications[config.application1.registerAppInterfaceParams.appName],
-              consentedFunctions = {
-                { allowed = true, id = 156072572, name = "Location-1"},
-                { allowed = true, id = 1809526495, name = "Notifications"}
-              },
+              consentedFunctions = consentedgroups,
               externalConsentStatus = {
-                {entityType = 13, entityID = params_invalid_data[i], status = "ON"}
+                {entityType = 13, entityID = params_invalid_data[i].param_value, status = "ON"}
               },
               source = "GUI"
             })
@@ -114,28 +134,32 @@ for i = 1, #params_invalid_data do
       end
     end)
   end
-end
 
---[[ Test ]]
-commonFunctions:newTestCasesGroup("Test")
+  --[[ Test ]]
+  commonFunctions:newTestCasesGroup("Test")
 
-function Test:TestStep_GetListofPermissions_entityID_invalid()
-  local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
-  
-  EXPECT_HMIRESPONSE(RequestIdListOfPermissions, {
-    code = "0",
-    allowedFunctions = {
-      { name = "Location", id = 156072572},
-      { name = "Notifications", id = 1809526495}
-    },
-    externalConsentStatus = {}
-  })
+  function Test:TestStep_GetListofPermissions_entityID_invalid()
+    local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
+    if ( (i % 2) == 0 ) then
+      allowed_func = { { name = "DrivingCharacteristics", id = 4734356}}
+    else
+      allowed_func = {
+        { name = "Location", id = 156072572},
+        { name = "Notifications", id = 1809526495}
+      }
+    end
+    EXPECT_HMIRESPONSE(RequestIdListOfPermissions, {
+      code = "0",
+      allowedFunctions = allowed_func,
+      externalConsentStatus = {}
+    })
+  end
 end
 
 --[[ Postconditions ]]
 commonFunctions:newTestCasesGroup("Postconditions")
 
-function Test.Postcondition_Stop_SDL() 
+function Test.Postcondition_Stop_SDL()
   StopSDL()
 end
 

--- a/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
@@ -77,7 +77,7 @@ for i = 1, #params_invalid_data do
     end
   end
 
-  Test["Precondition_PTU_and_OnAppPermissionConsent_Invalid_"..params_invalid_data[i]] = function(self)
+  Test["Precondition_PTU_and_OnAppPermissionConsent_Invalid_"..params_invalid_data[i].comment] = function(self)
     local ptu_file_path = "files/jsons/Policies/Related_HMI_API/"
     if ( (i % 2) == 0 ) then
 


### PR DESCRIPTION
020_ATF_N_GetListofPermissions_empty_due_to_invalid_param_entityID_OnAppPermissionChange.lua
test is a part of TS #1165 
@istoimenova Please review