### PR TITLE
015 Script for requirement [Policies] [External UCS] SDL informs HMI about <externalConsentStatus> via GetListOfPermissions response

### DIFF
--- a/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
@@ -108,7 +108,6 @@ function Test:Preconditon_RegisterSecondApplication()
   :Do(function(_,data) 
     self.applications[config.application2.registerAppInterfaceParams.appName] = data.params.application.appID 
     hmi_appid = self.applications[config.application2.registerAppInterfaceParams.appName]
-    hmi_appid = self.applications[config.application2.registerAppInterfaceParams.appName]
   end)
   self.mobileSession1:ExpectResponse(CorIdRegister, { success=true, resultCode = "SUCCESS"})
   self.mobileSession1:ExpectNotification("OnHMIStatus", { systemContext = "MAIN", hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE"})

--- a/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
@@ -103,11 +103,11 @@ end
 
 function Test:Preconditon_RegisterSecondApplication()
   local CorIdRegister = self.mobileSession1:SendRPC("RegisterAppInterface", config.application2.registerAppInterfaceParams)
-
-  hmi_appid = self.applications[config.application2.registerAppInterfaceParams.appName]
+  
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config.application2.registerAppInterfaceParams.appName }})
   :Do(function(_,data) self.applications[config.application2.registerAppInterfaceParams.appName] = data.params.application.appID end)
-
+  
+  hmi_appid = self.applications[config.application2.registerAppInterfaceParams.appName]
   self.mobileSession1:ExpectResponse(CorIdRegister, { success=true, resultCode = "SUCCESS"})
   self.mobileSession1:ExpectNotification("OnHMIStatus", { systemContext = "MAIN", hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE"})
 end

--- a/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
@@ -1,0 +1,143 @@
+---------------------------------------------------------------------------------------------
+-- Requirement summary:
+-- [Policies] [External UCS] SDL informs HMI about <externalConsentStatus> via GetListOfPermissions response
+-- [HMI API] GetListOfPermissions request/response
+-- [HMI API] ExternalConsentStatus struct & EntityStatus enum
+--
+-- Description:
+-- For Genivi applicable ONLY for 'EXTERNAL_PROPRIETARY' Polcies
+-- Upon GetListOfPermissions_request, SDL must inform "externalConsentStatus" setting to HMI
+--
+-- 1. Used preconditions
+-- SDL is built with External_Proprietary flag
+-- SDL and HMI are running
+-- Application is registered and activated
+-- PTU file is updated and application is assigned to functional groups: Base-4, user-consent groups: Location-1 and Notifications
+-- PTU has passed successfully
+-- HMI sends empty <externalConsentStatus> to SDl via OnAppPermissionConsent
+-- Second application is registered and then unregistered
+--
+-- 2. Performed steps
+-- HMI sends to SDL GetListOfPermissions (appID of the unregistered application)
+--
+-- Expected result:
+-- SDL invalidates the appID and cuts it off, the GetListOfPermissions request is treated as if sent without appID
+-- SDL sends to HMI empty <externalConsentStatus> array
+---------------------------------------------------------------------------------------------
+
+--[[ General configuration parameters ]]
+config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
+
+--[[ Required Shared libraries ]]
+local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
+local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local testCasesForPolicyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
+local mobile_session = require('mobile_session')
+
+--[[ General Precondition before ATF start ]]
+commonSteps:DeleteLogsFileAndPolicyTable()
+
+--[[ General Settings for configuration ]]
+Test = require('connecttest')
+require('cardinalities')
+require('user_modules/AppTypes')
+
+--[[ Preconditions ]]
+commonFunctions:newTestCasesGroup("Preconditions")
+
+function Test:Precondition_trigger_getting_device_consent()
+  testCasesForPolicyTable:trigger_getting_device_consent(self, config.application1.registerAppInterfaceParams.appName, config.deviceMAC)
+end
+
+function Test:Precondition_PTU_and_OnAppPermissionConsent_Empty_First_Application()
+  local ptu_file_path = "files/jsons/Policies/Related_HMI_API/"
+  local ptu_file = "OnAppPermissionConsent_ptu.json"
+
+  testCasesForPolicyTable:flow_SUCCEESS_EXTERNAL_PROPRIETARY(self, nil, nil, nil, ptu_file_path, nil, ptu_file)
+
+  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged",{ appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
+  :Do(function(_,data)
+      if (data.params.appPermissionsConsentNeeded== true) then
+        local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
+        EXPECT_HMIRESPONSE(RequestIdListOfPermissions,{result = {code = 0, method = "SDL.GetListOfPermissions",
+              -- allowed: If ommited - no information about User Consent is yet found for app.
+              allowedFunctions = {
+                { name = "Location", id = 156072572},
+                { name = "Notifications", id = 1809526495}
+              },
+              externalConsentStatus = {}
+            }
+          })
+        :Do(function()
+            local ReqIDGetUserFriendlyMessage = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage",
+              {language = "EN-US", messageCodes = {"AppPermissions"}})
+
+            EXPECT_HMIRESPONSE(ReqIDGetUserFriendlyMessage,
+              {result = {code = 0, messages = {{messageCode = "AppPermissions"}}, method = "SDL.GetUserFriendlyMessage"}})
+            :Do(function(_,_)
+                self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent",
+                  {
+                    appID = self.applications[config.application1.registerAppInterfaceParams.appName],
+                    consentedFunctions = {
+                      { allowed = true, id = 156072572, name = "Location"},
+                      { allowed = true, id = 1809526495, name = "Notifications"}
+                    },
+                    externalConsentStatus = {},
+                    source = "GUI"
+                  })
+                EXPECT_NOTIFICATION("OnPermissionsChange")
+              end)
+          end)
+      else
+        commonFunctions:userPrint(31, "Wrong SDL bahavior: there are app permissions for consent, isPermissionsConsentNeeded should be true")
+        return false
+      end
+  end)
+end
+
+function Test:Precondition_StartSecondSession()
+  self.mobileSession1 = mobile_session.MobileSession(self, self.mobileConnection)
+  self.mobileSession1:StartService(7)
+end
+
+function Test:Preconditon_RegisterSecondApplication()
+  local CorIdRegister = self.mobileSession1:SendRPC("RegisterAppInterface", config.application2.registerAppInterfaceParams)
+
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config.application2.registerAppInterfaceParams.appName }})
+  :Do(function(_,data) self.applications[config.application2.registerAppInterfaceParams.appName] = data.params.application.appID end)
+
+  self.mobileSession1:ExpectResponse(CorIdRegister, { success=true, resultCode = "SUCCESS"})
+  self.mobileSession1:ExpectNotification("OnHMIStatus", { systemContext = "MAIN", hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE"})
+end
+
+function Test:Precondition_Unregister_Second_Application()
+  self.mobileSession1:SendRPC("UnregisterAppInterface", {})
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered",
+    {appID = self.applications[config.application2.registerAppInterfaceParams.appName], unexpectedDisconnect = false})
+  self.mobileSession1:ExpectResponse("UnregisterAppInterface", {success = true , resultCode = "SUCCESS"})
+end
+
+--[[ Test ]]
+commonFunctions:newTestCasesGroup("Test")
+
+function Test:TestStep_GetListofPermissions_appID_Unregistered_App_Empty_ecs()
+  local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application2.registerAppInterfaceParams.appName]})
+
+  EXPECT_HMIRESPONSE(RequestIdListOfPermissions,{code = "0",
+      allowedFunctions = {
+        { name = "Location", id = 156072572, allowed = true},
+        { name = "Notifications", id = 1809526495, allowed = true}
+      },
+      externalConsentStatus = {}
+    })
+end
+
+--[[ Postconditions ]]
+commonFunctions:newTestCasesGroup("Postconditions")
+
+function Test.Postcondition_Stop_SDL()
+
+  StopSDL()
+end
+
+return Test

--- a/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
@@ -105,9 +105,11 @@ function Test:Preconditon_RegisterSecondApplication()
   local CorIdRegister = self.mobileSession1:SendRPC("RegisterAppInterface", config.application2.registerAppInterfaceParams)
   
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config.application2.registerAppInterfaceParams.appName }})
-  :Do(function(_,data) self.applications[config.application2.registerAppInterfaceParams.appName] = data.params.application.appID end)
-  
-  hmi_appid = self.applications[config.application2.registerAppInterfaceParams.appName]
+  :Do(function(_,data) 
+    self.applications[config.application2.registerAppInterfaceParams.appName] = data.params.application.appID 
+    hmi_appid = self.applications[config.application2.registerAppInterfaceParams.appName]
+    hmi_appid = self.applications[config.application2.registerAppInterfaceParams.appName]
+  end)
   self.mobileSession1:ExpectResponse(CorIdRegister, { success=true, resultCode = "SUCCESS"})
   self.mobileSession1:ExpectNotification("OnHMIStatus", { systemContext = "MAIN", hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE"})
 end

--- a/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
+++ b/test_scripts/Polices/External_UCS_Informing_HMI/015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua
@@ -33,6 +33,7 @@ local commonFunctions = require ('user_modules/shared_testcases/commonFunctions'
 local commonSteps = require('user_modules/shared_testcases/commonSteps')
 local testCasesForPolicyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
 local mobile_session = require('mobile_session')
+local hmi_appid
 
 --[[ General Precondition before ATF start ]]
 commonSteps:DeleteLogsFileAndPolicyTable()
@@ -103,6 +104,7 @@ end
 function Test:Preconditon_RegisterSecondApplication()
   local CorIdRegister = self.mobileSession1:SendRPC("RegisterAppInterface", config.application2.registerAppInterfaceParams)
 
+  hmi_appid = self.applications[config.application2.registerAppInterfaceParams.appName]
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config.application2.registerAppInterfaceParams.appName }})
   :Do(function(_,data) self.applications[config.application2.registerAppInterfaceParams.appName] = data.params.application.appID end)
 
@@ -121,7 +123,7 @@ end
 commonFunctions:newTestCasesGroup("Test")
 
 function Test:TestStep_GetListofPermissions_appID_Unregistered_App_Empty_ecs()
-  local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = self.applications[config.application2.registerAppInterfaceParams.appName]})
+  local RequestIdListOfPermissions = self.hmiConnection:SendRequest("SDL.GetListOfPermissions", {appID = hmi_appid})
 
   EXPECT_HMIRESPONSE(RequestIdListOfPermissions,{code = "0",
       allowedFunctions = {
@@ -129,14 +131,13 @@ function Test:TestStep_GetListofPermissions_appID_Unregistered_App_Empty_ecs()
         { name = "Notifications", id = 1809526495, allowed = true}
       },
       externalConsentStatus = {}
-    })
+  })
 end
 
 --[[ Postconditions ]]
 commonFunctions:newTestCasesGroup("Postconditions")
 
 function Test.Postcondition_Stop_SDL()
-
   StopSDL()
 end
 


### PR DESCRIPTION
015_ATF_N_GetListofPermissions_no_appID_app_unregistered_not_stored_ecs.lua 

Test set available in #1165
Applicable json available at files/jsons/Policies/Related_HMI_API/OnAppPermissionConsent_ptu.json

@istoimenova Please review