### PR TITLE
Adding quotes to code parameter value to facilitate ATF processing

### DIFF
--- a/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
+++ b/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
@@ -108,7 +108,7 @@ for i =1, #invalid_data do
           self.hmiConnection:SendNotification("TTS.Stopped")
         end
         RUN_AFTER(ttsSpeakResponse, 1000)
-      end)
+    end)
 
     EXPECT_HMICALL("UI.PerformAudioPassThru",
       {
@@ -126,8 +126,8 @@ for i =1, #invalid_data do
         }
       })
     :Do(function(_,data)
-        self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"UI.PerformAudioPassThru", "code":'..tostring(invalid_data[i].value)..'}}')
-      end)
+        self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"UI.PerformAudioPassThru", "code":"'..tostring(invalid_data[i].value)..'"}}')
+    end)
 
     if
     (self.appHMITypes["NAVIGATION"] == true) or
@@ -175,12 +175,12 @@ for i =1, #invalid_data do
         self.hmiConnection:SendNotification("TTS.Started",{})
 
         local function ttsSpeakResponse()
-          self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"TTS.Speak", "code":'..tostring(invalid_data[i].value)..'}}')
+          self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"UI.PerformAudioPassThru", "code":"'..tostring(invalid_data[i].value)..'"}}')
           self.hmiConnection:SendNotification("TTS.Stopped")
         end
 
         RUN_AFTER(ttsSpeakResponse, 1000)
-      end)
+    end)
 
     EXPECT_HMICALL("UI.PerformAudioPassThru",
       {

--- a/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
+++ b/test_scripts/API/PerformAudioPassThru/029_ATF_P_PerformAudioPassThru_GENERIC_ERROR_invalid_HMI_response_fake_params.lua
@@ -175,7 +175,7 @@ for i =1, #invalid_data do
         self.hmiConnection:SendNotification("TTS.Started",{})
 
         local function ttsSpeakResponse()
-          self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"UI.PerformAudioPassThru", "code":"'..tostring(invalid_data[i].value)..'"}}')
+          self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc":"2.0","result":{"method":"TTS.Speak", "code":"'..tostring(invalid_data[i].value)..'"}}')
           self.hmiConnection:SendNotification("TTS.Stopped")
         end
 


### PR DESCRIPTION
Applying fix for [GENIVI] Info parameter not sent for GENERIC_ERROR result code for PerformAudioPassThru when Invalid HMI response receive
Quotes need to be added to code parameter value to facilitate ATF processing of message

@istoimenova Please review 