### PR TITLE
[WIP] 028 and 029 Scripts for [Policies] External UCS: externalConsentStatus vs. consentedFunctions priority

### DIFF
--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/028_ATF_Policies_External_Consent_OFF_same_notification_user_consent_allowed_externalConsentStatus_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/028_ATF_Policies_External_Consent_OFF_same_notification_user_consent_allowed_externalConsentStatus_disallowed.lua
@@ -1,0 +1,134 @@
+--------------------------------------Requirement summary---------------------------------------------
+-- [Policies] External UCS: externalConsentStatus vs. consentedFunctions priority
+
+------------------------------------General Settings for Configuration--------------------------------
+require('user_modules/all_common_modules')
+local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_steps = require('user_modules/common_steps')
+local common_functions = require ('user_modules/common_functions')
+
+---------------------------------------Common Variables-----------------------------------------------
+local id_group_1
+local policy_file = config.pathToSDL .. "storage/policy.sqlite"
+
+---------------------------------------Preconditions--------------------------------------------------
+-- Start SDL and register application
+common_functions_external_consent:PreconditonSteps("mobileConnection","mobileSession")
+-- Activate application
+common_steps:ActivateApplication("Activate_Application_1", config.application1.registerAppInterfaceParams.appName)
+
+------------------------------------------Tests-------------------------------------------------------
+-- TEST 04:
+-- In case:
+-- SDL received SDL.OnAppPermissionConsent that contains both (consentedFunctions:allowed, externalConsentStatus)
+-- and according to externalConsentStatus "functional_grouping" for the assigned app is "userDisallowed"
+-- SDL must
+-- change "functional_grouping" status according to externalConsentStatus to "userDisallowed"
+--------------------------------------------------------------------------
+-- Test 04.01:
+-- Description: disallowed_by_external_consent_entities_off exists. HMI -> SDL: OnAppPermissionConsent(externalConsentStatus OFF, function allowed)
+-- Expected Result: requested RPC is disallowed by External Consent
+--------------------------------------------------------------------------
+-- Precondition:
+-- Prepare JSON file with consent groups. Add all consent group names into app_polices of applications
+-- Request Policy Table Update.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_Update_Policy_Table"] = function(self)
+  -- create PTU from localPT
+  local data = common_functions_external_consent:ConvertPreloadedToJson()
+  -- insert Group001 into "functional_groupings"
+  data.policy_table.functional_groupings.Group001 = {
+    user_consent_prompt = "ConsentGroup001",
+    disallowed_by_external_consent_entities_off = {{
+        entityType = 2,
+        entityID = 5
+    }},
+    rpcs = {
+      SubscribeWayPoints = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  --insert application "0000001" which belong to functional group "Group001" into "app_policies"
+  data.policy_table.app_policies["0000001"] = {
+    keep_context = false,
+    steal_focus = false,
+    priority = "NONE",
+    default_hmi = "NONE",
+    groups = {"Base-4", "Group001"}
+  }
+  --insert "ConsentGroup001" into "consumer_friendly_messages"
+  data.policy_table.consumer_friendly_messages.messages["ConsentGroup001"] = {languages = {}}
+  data.policy_table.consumer_friendly_messages.messages.ConsentGroup001.languages["en-us"] = {
+    tts = "tts_test",
+    label = "label_test",
+    textBody = "textBody_test"
+  }
+  -- create json file for Policy Table Update
+  common_functions_external_consent:CreateJsonFileForPTU(data, "/tmp/ptu_update.json")
+  -- remove preload_pt from json file
+  local parent_item = {"policy_table","module_config"}
+  local removed_json_items = {"preloaded_pt"}
+  common_functions:RemoveItemsFromJsonFile("/tmp/ptu_update.json", parent_item, removed_json_items)
+  -- update policy table
+  common_functions_external_consent:UpdatePolicy(self, "/tmp/ptu_update.json")
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- Check GetListOfPermissions response with empty externalConsentStatus array list. Get group id.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_GetListOfPermissions"] = function(self)
+  --hmi side: sending SDL.GetListOfPermissions request to SDL
+  local request_id = self.hmiConnection:SendRequest("SDL.GetListOfPermissions")
+  -- hmi side: expect SDL.GetListOfPermissions response
+  EXPECT_HMIRESPONSE(request_id,{
+      result = {
+        code = 0,
+        method = "SDL.GetListOfPermissions",
+        allowedFunctions = {{name = "ConsentGroup001", allowed = nil}},
+        externalConsentStatus = {}
+      }
+    })
+  :Do(function(_,data)
+      id_group_1 = common_functions_external_consent:GetGroupId(data, "ConsentGroup001")
+  end)
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- HMI sends OnAppPermissionConsent with consented function = allowed and External Consent status = OFF
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_Precondition_HMI_sends_OnAppPermissionConsent"] = function(self)
+  local hmi_app_id_1 = common_functions:GetHmiAppId(config.application1.registerAppInterfaceParams.appName, self)
+  -- hmi side: sending SDL.OnAppPermissionConsent for applications
+  self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent", {
+      appID = hmi_app_id_1, source = "GUI",
+      externalConsentStatus = {{entityType = 2, entityID = 5, status = "OFF"}},
+      consentedFunctions = {{name = "ConsentGroup001", id = id_group_1, allowed = true}}
+    })
+  self.mobileSession:ExpectNotification("OnPermissionsChange")
+  :ValidIf(function(_,data)
+      local validate_result = common_functions_external_consent:ValidateHMIPermissions(data,
+        "SubscribeWayPoints", {allowed = {}, userDisallowed = {"BACKGROUND","FULL","LIMITED"}})
+      return validate_result
+  end)
+end
+
+--------------------------------------------------------------------------
+-- Main check:
+-- RPC is disallowed to process.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_MainCheck_RPC_is_disallowed"] = function(self)
+  --mobile side: send SubscribeWayPoints request
+  self.mobileSession:SendRPC("SubscribeWayPoints",{})
+  --mobile side: SubscribeWayPoints response
+  EXPECT_RESPONSE("SubscribeWayPoints", {success = false , resultCode = "USER_DISALLOWED"})
+  EXPECT_NOTIFICATION("OnHashChange")
+  :Times(0)
+end
+
+--------------------------------------Postcondition------------------------------------------
+Test["Stop_SDL"] = function()
+  StopSDL()
+end

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/028_ATF_Policies_External_Consent_OFF_same_notification_user_consent_allowed_externalConsentStatus_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/028_ATF_Policies_External_Consent_OFF_same_notification_user_consent_allowed_externalConsentStatus_disallowed.lua
@@ -3,7 +3,7 @@
 
 ------------------------------------General Settings for Configuration--------------------------------
 require('user_modules/all_common_modules')
-local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')
 local common_functions = require ('user_modules/common_functions')
 

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/029_ATF_Policies_External_Consent_OFF_same_notification_user_consent_disallowed_externalConsentStatus_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/029_ATF_Policies_External_Consent_OFF_same_notification_user_consent_disallowed_externalConsentStatus_allowed.lua
@@ -1,0 +1,139 @@
+--------------------------------------Requirement summary---------------------------------------------
+-- [Policies] External UCS: externalConsentStatus vs. consentedFunctions priority
+
+------------------------------------General Settings for Configuration--------------------------------
+require('user_modules/all_common_modules')
+local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_steps = require('user_modules/common_steps')
+local common_functions = require ('user_modules/common_functions')
+
+---------------------------------------Common Variables-----------------------------------------------
+local id_group_1
+local policy_file = config.pathToSDL .. "storage/policy.sqlite"
+
+---------------------------------------Preconditions--------------------------------------------------
+-- Start SDL and register application
+common_functions_external_consent:PreconditonSteps("mobileConnection","mobileSession")
+-- Activate application
+common_steps:ActivateApplication("Activate_Application_1", config.application1.registerAppInterfaceParams.appName)
+
+------------------------------------------Tests-------------------------------------------------------
+-- TEST 04:
+-- In case:
+-- SDL received SDL.OnAppPermissionConsent that contains both (consentedFunctions:allowed, externalConsentStatus)
+-- and according to externalConsentStatus "functional_grouping" for the assigned app is "userDisallowed"
+-- SDL must
+-- change "functional_grouping" status according to externalConsentStatus to "userDisallowed"
+--------------------------------------------------------------------------
+-- Test 04.02:
+-- Description: disallowed_by_external_consent_entities_on exists. HMI -> SDL: OnAppPermissionConsent(externalConsentStatus OFF, function disallowed)
+-- Expected Result: requested RPC is allowed by External Consent
+--------------------------------------------------------------------------
+-- Precondition:
+-- Prepare JSON file with consent groups. Add all consent group names into app_polices of applications
+-- Request Policy Table Update.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_Update_Policy_Table"] = function(self)
+  -- create PTU from localPT
+  local data = common_functions_external_consent:ConvertPreloadedToJson()
+  -- insert Group001 into "functional_groupings"
+  data.policy_table.functional_groupings.Group001 = {
+    user_consent_prompt = "ConsentGroup001",
+    disallowed_by_external_consent_entities_on = {{
+        entityType = 2,
+        entityID = 5
+    }},
+    rpcs = {
+      SubscribeWayPoints = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  --insert application "0000001" which belong to functional group "Group001" into "app_policies"
+  data.policy_table.app_policies["0000001"] = {
+    keep_context = false,
+    steal_focus = false,
+    priority = "NONE",
+    default_hmi = "NONE",
+    groups = {"Base-4", "Group001"}
+  }
+  --insert "ConsentGroup001" into "consumer_friendly_messages"
+  data.policy_table.consumer_friendly_messages.messages["ConsentGroup001"] = {languages = {}}
+  data.policy_table.consumer_friendly_messages.messages.ConsentGroup001.languages["en-us"] = {
+    tts = "tts_test",
+    label = "label_test",
+    textBody = "textBody_test"
+  }
+  -- create json file for Policy Table Update
+  common_functions_external_consent:CreateJsonFileForPTU(data, "/tmp/ptu_update.json")
+  -- remove preload_pt from json file
+  local parent_item = {"policy_table","module_config"}
+  local removed_json_items = {"preloaded_pt"}
+  common_functions:RemoveItemsFromJsonFile("/tmp/ptu_update.json", parent_item, removed_json_items)
+  -- update policy table
+  common_functions_external_consent:UpdatePolicy(self, "/tmp/ptu_update.json")
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- Check GetListOfPermissions response with empty externalConsentStatus array list. Get group id.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_GetListOfPermissions"] = function(self)
+  --hmi side: sending SDL.GetListOfPermissions request to SDL
+  local request_id = self.hmiConnection:SendRequest("SDL.GetListOfPermissions")
+  -- hmi side: expect SDL.GetListOfPermissions response
+  EXPECT_HMIRESPONSE(request_id,{
+      result = {
+        code = 0,
+        method = "SDL.GetListOfPermissions",
+        allowedFunctions = {{name = "ConsentGroup001", allowed = nil}},
+        externalConsentStatus = {}
+      }
+    })
+  :Do(function(_,data)
+      id_group_1 = common_functions_external_consent:GetGroupId(data, "ConsentGroup001")
+  end)
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- HMI sends OnAppPermissionConsent with consented function = disallowed and External Consent status = OFF
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_Precondition_HMI_sends_OnAppPermissionConsent"] = function(self)
+  local hmi_app_id_1 = common_functions:GetHmiAppId(config.application1.registerAppInterfaceParams.appName, self)
+  -- hmi side: sending SDL.OnAppPermissionConsent for applications
+  self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent", {
+      appID = hmi_app_id_1, source = "GUI",
+      externalConsentStatus = {{entityType = 2, entityID = 5, status = "OFF"}},
+      consentedFunctions = {{name = "ConsentGroup001", id = id_group_1, allowed = false}}
+    })
+  self.mobileSession:ExpectNotification("OnPermissionsChange")
+  :ValidIf(function(_,data)
+      local validate_result = common_functions_external_consent:ValidateHMIPermissions(data,
+        "SubscribeWayPoints", {allowed = {"BACKGROUND","FULL","LIMITED"}, userDisallowed = {}})
+      return validate_result
+  end)
+end
+
+--------------------------------------------------------------------------
+-- Main check:
+-- RPC is allowed to process.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_MainCheck_RPC_is_allowed"] = function(self)
+  --mobile side: send SubscribeWayPoints request
+  self.mobileSession:SendRPC("SubscribeWayPoints",{})
+  --hmi side: expected SubscribeWayPoints request
+  EXPECT_HMICALL("Navigation.SubscribeWayPoints")
+  :Do(function(_,data)
+      --hmi side: sending Navigation.SubscribeWayPoints response
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",{})
+  end)
+  --mobile side: SubscribeWayPoints response
+  EXPECT_RESPONSE("SubscribeWayPoints", {success = true , resultCode = "SUCCESS"})
+  EXPECT_NOTIFICATION("OnHashChange")
+end
+
+--------------------------------------Postcondition------------------------------------------
+Test["Stop_SDL"] = function()
+  StopSDL()
+end

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/029_ATF_Policies_External_Consent_OFF_same_notification_user_consent_disallowed_externalConsentStatus_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/029_ATF_Policies_External_Consent_OFF_same_notification_user_consent_disallowed_externalConsentStatus_allowed.lua
@@ -3,7 +3,7 @@
 
 ------------------------------------General Settings for Configuration--------------------------------
 require('user_modules/all_common_modules')
-local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')
 local common_functions = require ('user_modules/common_functions')
 


### PR DESCRIPTION
028_ATF_Policies_External_Consent_OFF_same_notification_user_consent_allowed_externalConsentStatus_disallowed.lua
029_ATF_Policies_External_Consent_OFF_same_notification_user_consent_disallowed_externalConsentStatus_allowed.lua

Test set is available in #1219
User modules should be taken from #1211

@dboltovskyi @vvvakulenko @ttdong
Please review as this is task for transferring scripts I am helping @istoimenova with it