### PR TITLE
[WIP] 024,025,026,027 Scripts for requirement [Policies] External UCS: externalConsentStatus change for the whole functional_group

### DIFF
--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/024_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_01.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/024_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_01.lua
@@ -1,0 +1,223 @@
+--------------------------------------Requirement summary---------------------------------------------
+--[Policies] External UCS: externalConsentStatus change for the whole "functional_group"
+--[Policies] External UCS: "OFF" - userDisallowed RPCs
+
+------------------------------------General Settings for Configuration--------------------------------
+require('user_modules/all_common_modules')
+local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_steps = require('user_modules/common_steps')
+local common_functions = require ('user_modules/common_functions')
+
+---------------------------------------Common Variables-----------------------------------------------
+local policy_file = config.pathToSDL .. "storage/policy.sqlite"
+
+---------------------------------------Preconditions--------------------------------------------------
+-- Start SDL and register application
+common_functions_external_consent:PreconditonSteps("mobileConnection","mobileSession")
+-- Activate application
+common_steps:ActivateApplication("Activate_Application_1", config.application1.registerAppInterfaceParams.appName)
+
+------------------------------------------Tests-------------------------------------------------------
+-- TEST 11:
+-- In case
+-- SDL received SDL.OnAppPermissionConsent (externalConsentStatus) with {entityType [];entityID []}
+-- and in Policy Table "functional_groupings" -> "functional_group" with "disallowed_by_external_consent_entities_on/off" param has a few pairs of {entityType; entityID}
+-- and if at least one pair of {entityType[]; entityID[]} from "disallowed_by_external_consent_entities_on/off" param matches with the received one in "externalConsentStatus"
+-- and this status disallows "functional_grouping"
+-- SDL must
+-- apply externalConsentStatus for the whole "functional_group" that contains pair of {entityType []; entityID []} received with On.AppPermissionsConsent (externalConsentStatus)
+-- and disallow RPCs from such functional grouping
+--------------------------------------------------------------------------
+-- Test 11.01:
+-- Description: There are 2 pairs of entities in 1 group.
+-- HMI -> SDL: OnAppPermissionConsent(externalConsentStatus OFF) with entities pair only match one entities pair in group.
+-- Expected Result: externalConsentStatus can find and apply for right group.
+--------------------------------------------------------------------------
+-- Precondition:
+-- Prepare JSON file with consent groups. Add all consent group names into app_polices of applications
+-- Request Policy Table Update.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_Update_Policy_Table"] = function(self)
+  -- create PTU from localPT
+  local data = common_functions_external_consent:ConvertPreloadedToJson()
+  -- insert Group001 into "functional_groupings"
+  data.policy_table.functional_groupings.Group001 = {
+    user_consent_prompt = "ConsentGroup001",
+    disallowed_by_external_consent_entities_off = {
+      {entityType = 1, entityID = 1},
+      {entityType = 2, entityID = 2},
+      {entityType = 3, entityID = 3}
+    },
+    rpcs = {
+      SubscribeVehicleData = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  -- insert Group002 into "functional_groupings"
+  data.policy_table.functional_groupings.Group002 = {
+    user_consent_prompt = "ConsentGroup002",
+    disallowed_by_external_consent_entities_on = {
+      {entityType = 4, entityID = 4},
+      {entityType = 5, entityID = 5},
+      {entityType = 6, entityID = 6}
+    },
+    rpcs = {
+      SubscribeWayPoints = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  -- insert Group003 into "functional_groupings"
+  data.policy_table.functional_groupings.Group003 = {
+    user_consent_prompt = "ConsentGroup003",
+    disallowed_by_external_consent_entities_on = {
+      {entityType = 7, entityID = 7}
+    },
+    disallowed_by_external_consent_entities_off = {
+      {entityType = 8, entityID = 8}
+    },
+    rpcs = {
+      SendLocation = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  -- insert Group004 into "functional_groupings"
+  data.policy_table.functional_groupings.Group004 = {
+    user_consent_prompt = "ConsentGroup004",
+    disallowed_by_external_consent_entities_off = {
+      {entityType = 1, entityID = 2}
+    },
+    rpcs = {
+      UnsubscribeWayPoints = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  -- insert Group005 into "functional_groupings"
+  data.policy_table.functional_groupings.Group005 = {
+    user_consent_prompt = "ConsentGroup005",
+    disallowed_by_external_consent_entities_on = {
+      {entityType = 2, entityID = 1}
+    },
+    rpcs = {
+      UnsubscribeVehicleData = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  --insert application "0000001" into "app_policies"
+  data.policy_table.app_policies["0000001"] = {
+    keep_context = false,
+    steal_focus = false,
+    priority = "NONE",
+    default_hmi = "NONE",
+    groups = {"Base-4", "Group001", "Group002", "Group003", "Group004", "Group005"}
+  }
+  -- create json file for Policy Table Update
+  common_functions_external_consent:CreateJsonFileForPTU(data, "/tmp/ptu_update.json")
+  -- remove preload_pt from json file
+  local parent_item = {"policy_table","module_config"}
+  local removed_json_items = {"preloaded_pt"}
+  common_functions:RemoveItemsFromJsonFile("/tmp/ptu_update.json", parent_item, removed_json_items)
+  -- update policy table
+  common_functions_external_consent:UpdatePolicy(self, "/tmp/ptu_update.json")
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- Check GetListOfPermissions response with empty externalConsentStatus array list.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_GetListOfPermissions"] = function(self)
+  --hmi side: sending SDL.GetListOfPermissions request to SDL
+  local request_id = self.hmiConnection:SendRequest("SDL.GetListOfPermissions")
+  -- hmi side: expect SDL.GetListOfPermissions response
+  EXPECT_HMIRESPONSE(request_id,{
+      result = {
+        code = 0,
+        method = "SDL.GetListOfPermissions",
+        allowedFunctions = {
+          {name = "ConsentGroup001", allowed = nil},
+          {name = "ConsentGroup002", allowed = nil},
+          {name = "ConsentGroup003", allowed = nil},
+          {name = "ConsentGroup004", allowed = nil},
+          {name = "ConsentGroup005", allowed = nil}
+        },
+        externalConsentStatus = {}
+      }
+  })
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- HMI sends OnAppPermissionConsent
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_Precondition_HMI_sends_OnAppPermissionConsent"] = function(self)
+  -- hmi side: sending SDL.OnAppPermissionConsent for applications
+  self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent", {
+      source = "GUI",
+      externalConsentStatus = {
+        {entityType = 1, entityID = 1, status = "OFF"},
+        {entityType = 6, entityID = 6, status = "OFF"},
+        {entityType = 7, entityID = 7, status = "OFF"},
+        {entityType = 9, entityID = 9, status = "OFF"}
+      }
+  })
+  self.mobileSession:ExpectNotification("OnPermissionsChange")
+  :ValidIf(function(_,data)
+      local validate_result_1 = common_functions_external_consent:ValidateHMIPermissions(data,
+        "SubscribeVehicleData", {allowed = {}, userDisallowed = {"BACKGROUND","FULL","LIMITED"}})
+      local validate_result_2 = common_functions_external_consent:ValidateHMIPermissions(data,
+        "SubscribeWayPoints", {allowed = {"BACKGROUND","FULL","LIMITED"}, userDisallowed = {}})
+      local validate_result_3 = common_functions_external_consent:ValidateHMIPermissions(data,
+        "SendLocation", {allowed = {"BACKGROUND","FULL","LIMITED"}, userDisallowed = {}})
+      return (validate_result_1 and validate_result_2 and validate_result_3)
+  end)
+end
+
+--------------------------------------------------------------------------
+-- Main check:
+-- RPC of Group001 is disallowed to process.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_MainCheck_RPC_of_Group001_is_disallowed"] = function(self)
+  local corid = self.mobileSession:SendRPC("SubscribeVehicleData",{rpm = true})
+  self.mobileSession:ExpectResponse(corid, {success = false, resultCode = "USER_DISALLOWED"})
+  EXPECT_NOTIFICATION("OnHashChange")
+  :Times(0)
+end
+
+--------------------------------------------------------------------------
+-- Main check:
+-- RPC of Group002 is allowed to process.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_MainCheck_RPC_of_Group002_is_allowed"] = function(self)
+  self.mobileSession:SendRPC("SubscribeWayPoints",{})
+  EXPECT_HMICALL("Navigation.SubscribeWayPoints")
+  :Do(function(_,data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",{})
+  end)
+  EXPECT_RESPONSE("SubscribeWayPoints", {success = true , resultCode = "SUCCESS"})
+  EXPECT_NOTIFICATION("OnHashChange")
+end
+
+--------------------------------------------------------------------------
+-- Main check:
+-- RPC of Group003 is allowed to process.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_MainCheck_RPC_of_Group003_is_allowed"] = function(self)
+  self.mobileSession:SendRPC("SendLocation", {
+      longitudeDegrees = 1.1,
+      latitudeDegrees = 1.1
+    })
+  EXPECT_HMICALL("Navigation.SendLocation")
+  :Do(function(_,data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",{})
+  end)
+  EXPECT_RESPONSE("SendLocation", {success = true , resultCode = "SUCCESS"})
+end
+
+--------------------------------------Postcondition------------------------------------------
+Test["Stop_SDL"] = function()
+  StopSDL()
+end

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/024_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_01.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/024_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_01.lua
@@ -4,7 +4,7 @@
 
 ------------------------------------General Settings for Configuration--------------------------------
 require('user_modules/all_common_modules')
-local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')
 local common_functions = require ('user_modules/common_functions')
 

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/025_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_02.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/025_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_02.lua
@@ -5,7 +5,7 @@
 
 ------------------------------------General Settings for Configuration--------------------------------
 require('user_modules/all_common_modules')
-local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')
 local common_functions = require ('user_modules/common_functions')
 

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/025_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_02.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/025_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_02.lua
@@ -1,0 +1,137 @@
+--------------------------------------Requirement summary---------------------------------------------
+--[Policies] External UCS: externalConsentStatus change for the whole "functional_group"
+--[Policies] External UCS: "ON" - user_disallowed RPCs
+--[Policies] External UCS: "OFF" - userDisallowed RPCs
+
+------------------------------------General Settings for Configuration--------------------------------
+require('user_modules/all_common_modules')
+local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_steps = require('user_modules/common_steps')
+local common_functions = require ('user_modules/common_functions')
+
+---------------------------------------Common Variables-----------------------------------------------
+local policy_file = config.pathToSDL .. "storage/policy.sqlite"
+
+---------------------------------------Preconditions--------------------------------------------------
+-- Start SDL and register application
+common_functions_external_consent:PreconditonSteps("mobileConnection","mobileSession")
+-- Activate application
+common_steps:ActivateApplication("Activate_Application_1", config.application1.registerAppInterfaceParams.appName)
+
+------------------------------------------Tests-------------------------------------------------------
+-- TEST 11:
+-- In case
+-- SDL received SDL.OnAppPermissionConsent (externalConsentStatus) with {entityType [];entityID []}
+-- and in Policy Table "functional_groupings" -> "functional_group" with "disallowed_by_external_consent_entities_on/off" param has a few pairs of {entityType; entityID}
+-- and if at least one pair of {entityType[]; entityID[]} from "disallowed_by_external_consent_entities_on/off" param matches with the received one in "externalConsentStatus"
+-- and this status disallows "functional_grouping"
+-- SDL must
+-- apply externalConsentStatus for the whole "functional_group" that contains pair of {entityType []; entityID []} received with On.AppPermissionsConsent (externalConsentStatus)
+-- and disallow RPCs from such functional grouping
+--------------------------------------------------------------------------
+-- Test 11.02:
+-- Description: disallowed_by_external_consent_entities_off exist with 2 pairs of entities. 
+-- HMI -> SDL: OnAppPermissionConsent(externalConsentStatus ON + OFF)
+-- Expected Result: requested RPC is disallowed by External Consent
+--------------------------------------------------------------------------
+-- Precondition:
+-- Prepare JSON file with consent groups. Add all consent group names into app_polices of applications
+-- Request Policy Table Update.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_Update_Policy_Table"] = function(self)
+  -- create PTU from localPT
+  local data = common_functions_external_consent:ConvertPreloadedToJson()
+  -- insert Group001 into "functional_groupings"
+  data.policy_table.functional_groupings.Group001 = {
+    user_consent_prompt = "ConsentGroup001",
+    disallowed_by_external_consent_entities_off = {
+      {entityType = 1, entityID = 2},
+      {entityType = 3, entityID = 4}
+    },
+    rpcs = {
+      SubscribeWayPoints = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  --insert application "0000001" into "app_policies"
+  data.policy_table.app_policies["0000001"] = {
+    keep_context = false,
+    steal_focus = false,
+    priority = "NONE",
+    default_hmi = "NONE",
+    groups = {"Base-4", "Group001"}
+  }
+  --insert "ConsentGroup001" into "consumer_friendly_messages"
+  data.policy_table.consumer_friendly_messages.messages["ConsentGroup001"] = {languages = {}}
+  data.policy_table.consumer_friendly_messages.messages.ConsentGroup001.languages["en-us"] = {
+    tts = "tts_test",
+    label = "label_test",
+    textBody = "textBody_test"
+  }
+  -- create json file for Policy Table Update
+  common_functions_external_consent:CreateJsonFileForPTU(data, "/tmp/ptu_update.json")
+  -- remove preload_pt from json file
+  local parent_item = {"policy_table","module_config"}
+  local removed_json_items = {"preloaded_pt"}
+  common_functions:RemoveItemsFromJsonFile("/tmp/ptu_update.json", parent_item, removed_json_items)
+  -- update policy table
+  common_functions_external_consent:UpdatePolicy(self, "/tmp/ptu_update.json")
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- Check GetListOfPermissions response with empty externalConsentStatus array list.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_GetListOfPermissions"] = function(self)
+  --hmi side: sending SDL.GetListOfPermissions request to SDL
+  local request_id = self.hmiConnection:SendRequest("SDL.GetListOfPermissions")
+  -- hmi side: expect SDL.GetListOfPermissions response
+  EXPECT_HMIRESPONSE(request_id,{
+      result = {
+        code = 0,
+        method = "SDL.GetListOfPermissions",
+        allowedFunctions = {{name = "ConsentGroup001", allowed = nil}},
+        externalConsentStatus = {}
+      }
+  })
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- HMI sends OnAppPermissionConsent
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_Precondition_HMI_sends_OnAppPermissionConsent"] = function(self)
+  -- hmi side: sending SDL.OnAppPermissionConsent for applications
+  self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent", {
+      source = "GUI",
+      externalConsentStatus = {
+        {entityType = 1, entityID = 2, status = "OFF"},
+        {entityType = 3, entityID = 4, status = "ON"}
+      }
+    })
+  self.mobileSession:ExpectNotification("OnPermissionsChange")
+  :ValidIf(function(_,data)
+      local validate_result = common_functions_external_consent:ValidateHMIPermissions(data,
+        "SubscribeWayPoints", {allowed = {}, userDisallowed = {"BACKGROUND","FULL","LIMITED"}})
+      return validate_result
+  end)
+end
+
+--------------------------------------------------------------------------
+-- Main check:
+-- RPC is disallowed to process.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_MainCheck_RPC_is_disallowed"] = function(self)
+  --mobile side: send SubscribeWayPoints request
+  self.mobileSession:SendRPC("SubscribeWayPoints",{})
+  --mobile side: SubscribeWayPoints response
+  EXPECT_RESPONSE("SubscribeWayPoints", {success = false , resultCode = "USER_DISALLOWED"})
+  EXPECT_NOTIFICATION("OnHashChange")
+  :Times(0)
+end
+
+--------------------------------------Postcondition------------------------------------------
+Test["Stop_SDL"] = function()
+  StopSDL()
+end

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/026_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_03.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/026_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_03.lua
@@ -1,0 +1,138 @@
+--------------------------------------Requirement summary---------------------------------------------
+--[Policies] External UCS: externalConsentStatus change for the whole "functional_group"
+--[Policies] External UCS: "ON" - user_disallowed RPCs
+
+------------------------------------General Settings for Configuration--------------------------------
+require('user_modules/all_common_modules')
+local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_steps = require('user_modules/common_steps')
+local common_functions = require ('user_modules/common_functions')
+
+---------------------------------------Common Variables-----------------------------------------------
+local policy_file = config.pathToSDL .. "storage/policy.sqlite"
+
+---------------------------------------Preconditions--------------------------------------------------
+-- Start SDL and register application
+common_functions_external_consent:PreconditonSteps("mobileConnection","mobileSession")
+-- Activate application
+common_steps:ActivateApplication("Activate_Application_1", config.application1.registerAppInterfaceParams.appName)
+
+------------------------------------------Tests-------------------------------------------------------
+-- TEST 11:
+-- In case
+-- SDL received SDL.OnAppPermissionConsent (externalConsentStatus) with {entityType [];entityID []}
+-- and in Policy Table "functional_groupings" -> "functional_group" with "disallowed_by_external_consent_entities_on/off" param has a few pairs of {entityType; entityID}
+-- and if at least one pair of {entityType[]; entityID[]} from "disallowed_by_external_consent_entities_on/off" param matches with the received one in "externalConsentStatus"
+-- and this status disallows "functional_grouping"
+-- SDL must
+-- apply externalConsentStatus for the whole "functional_group" that contains pair of {entityType []; entityID []} received with On.AppPermissionsConsent (externalConsentStatus)
+-- and disallow RPCs from such functional grouping
+--------------------------------------------------------------------------
+-- Test 11.03:
+-- Description: Both disallowed_by_external_consent_entities_off and disallowed_by_external_consent_entities_on exist.
+-- HMI -> SDL: OnAppPermissionConsent(externalConsentStatus ON) match with some entities pairs. One of them make the group become disallowed.
+-- Expected Result: requested RPC is disallowed by External Consent
+--------------------------------------------------------------------------
+-- Precondition:
+-- Prepare JSON file with consent groups. Add all consent group names into app_polices of applications
+-- Request Policy Table Update.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_Update_Policy_Table"] = function(self)
+  -- create PTU from localPT
+  local data = common_functions_external_consent:ConvertPreloadedToJson()
+  -- insert Group001 into "functional_groupings"
+  data.policy_table.functional_groupings.Group001 = {
+    user_consent_prompt = "ConsentGroup001",
+    disallowed_by_external_consent_entities_on = {
+      {entityType = 1, entityID = 2}
+    },
+    disallowed_by_external_consent_entities_off = {
+      {entityType = 3, entityID = 4}
+    },
+    rpcs = {
+      SubscribeWayPoints = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  --insert application "0000001" into "app_policies"
+  data.policy_table.app_policies["0000001"] = {
+    keep_context = false,
+    steal_focus = false,
+    priority = "NONE",
+    default_hmi = "NONE",
+    groups = {"Base-4", "Group001"}
+  }
+  --insert "ConsentGroup001" into "consumer_friendly_messages"
+  data.policy_table.consumer_friendly_messages.messages["ConsentGroup001"] = {languages = {}}
+  data.policy_table.consumer_friendly_messages.messages.ConsentGroup001.languages["en-us"] = {
+    tts = "tts_test",
+    label = "label_test",
+    textBody = "textBody_test"
+  }
+  -- create json file for Policy Table Update
+  common_functions_external_consent:CreateJsonFileForPTU(data, "/tmp/ptu_update.json")
+  -- remove preload_pt from json file
+  local parent_item = {"policy_table","module_config"}
+  local removed_json_items = {"preloaded_pt"}
+  common_functions:RemoveItemsFromJsonFile("/tmp/ptu_update.json", parent_item, removed_json_items)
+  -- update policy table
+  common_functions_external_consent:UpdatePolicy(self, "/tmp/ptu_update.json")
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- Check GetListOfPermissions response with empty externalConsentStatus array list.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_GetListOfPermissions"] = function(self)
+  --hmi side: sending SDL.GetListOfPermissions request to SDL
+  local request_id = self.hmiConnection:SendRequest("SDL.GetListOfPermissions")
+  -- hmi side: expect SDL.GetListOfPermissions response
+  EXPECT_HMIRESPONSE(request_id,{
+      result = {
+        code = 0,
+        method = "SDL.GetListOfPermissions",
+        allowedFunctions = {{name = "ConsentGroup001", allowed = nil}},
+        externalConsentStatus = {}
+      }
+  })
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- HMI sends OnAppPermissionConsent
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_Precondition_HMI_sends_OnAppPermissionConsent"] = function(self)
+  -- hmi side: sending SDL.OnAppPermissionConsent for applications
+  self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent", {
+      source = "GUI",
+      externalConsentStatus = {
+        {entityType = 1, entityID = 2, status = "OFF"},
+        {entityType = 3, entityID = 4, status = "OFF"}
+      }
+  })
+  self.mobileSession:ExpectNotification("OnPermissionsChange")
+  :ValidIf(function(_,data)
+      local validate_result = common_functions_external_consent:ValidateHMIPermissions(data,
+        "SubscribeWayPoints", {allowed = {}, userDisallowed = {"BACKGROUND","FULL","LIMITED"}})
+      return validate_result
+  end)
+end
+
+--------------------------------------------------------------------------
+-- Main check:
+-- RPC is disallowed to process.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_MainCheck_RPC_is_disallowed"] = function(self)
+  --mobile side: send SubscribeWayPoints request
+  self.mobileSession:SendRPC("SubscribeWayPoints",{})
+  --mobile side: SubscribeWayPoints response
+  EXPECT_RESPONSE("SubscribeWayPoints", {success = false , resultCode = "USER_DISALLOWED"})
+  EXPECT_NOTIFICATION("OnHashChange")
+  :Times(0)
+end
+
+--------------------------------------Postcondition------------------------------------------
+Test["Stop_SDL"] = function()
+  StopSDL()
+end

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/026_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_03.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/026_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_03.lua
@@ -4,7 +4,7 @@
 
 ------------------------------------General Settings for Configuration--------------------------------
 require('user_modules/all_common_modules')
-local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')
 local common_functions = require ('user_modules/common_functions')
 

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/027_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_04.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/027_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_04.lua
@@ -1,0 +1,137 @@
+--------------------------------------Requirement summary---------------------------------------------
+--[Policies] External UCS: externalConsentStatus change for the whole "functional_group"
+--[Policies] External UCS: "ON" - user_disallowed RPCs
+
+------------------------------------General Settings for Configuration--------------------------------
+require('user_modules/all_common_modules')
+local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_steps = require('user_modules/common_steps')
+local common_functions = require ('user_modules/common_functions')
+
+---------------------------------------Common Variables-----------------------------------------------
+local policy_file = config.pathToSDL .. "storage/policy.sqlite"
+
+---------------------------------------Preconditions--------------------------------------------------
+-- Start SDL and register application
+common_functions_external_consent:PreconditonSteps("mobileConnection","mobileSession")
+-- Activate application
+common_steps:ActivateApplication("Activate_Application_1", config.application1.registerAppInterfaceParams.appName)
+
+------------------------------------------Tests-------------------------------------------------------
+-- TEST 11:
+-- In case
+-- SDL received SDL.OnAppPermissionConsent (externalConsentStatus) with {entityType [];entityID []}
+-- and in Policy Table "functional_groupings" -> "functional_group" with "disallowed_by_external_consent_entities_on/off" param has a few pairs of {entityType; entityID}
+-- and if at least one pair of {entityType[]; entityID[]} from "disallowed_by_external_consent_entities_on/off" param matches with the received one in "externalConsentStatus"
+-- and this status disallows "functional_grouping"
+-- SDL must
+-- apply externalConsentStatus for the whole "functional_group" that contains pair of {entityType []; entityID []} received with On.AppPermissionsConsent (externalConsentStatus)
+-- and disallow RPCs from such functional grouping
+--------------------------------------------------------------------------
+-- Test 11.04:
+-- Description: Both disallowed_by_external_consent_entities_off and disallowed_by_external_consent_entities_on exist with same pair of entities.
+-- HMI -> SDL: OnAppPermissionConsent(externalConsentStatus ON) match that entities pair.
+-- Expected Result: requested RPC is disallowed by External Consent
+--------------------------------------------------------------------------
+-- Precondition:
+-- Prepare JSON file with consent groups. Add all consent group names into app_polices of applications
+-- Request Policy Table Update.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_Update_Policy_Table"] = function(self)
+  -- create PTU from localPT
+  local data = common_functions_external_consent:ConvertPreloadedToJson()
+  -- insert Group001 into "functional_groupings"
+  data.policy_table.functional_groupings.Group001 = {
+    user_consent_prompt = "ConsentGroup001",
+    disallowed_by_external_consent_entities_on = {
+      {entityType = 1, entityID = 2}
+    },
+    disallowed_by_external_consent_entities_off = {
+      {entityType = 1, entityID = 2}
+    },
+    rpcs = {
+      SubscribeWayPoints = {
+        hmi_levels = {"BACKGROUND", "FULL", "LIMITED"}
+      }
+    }
+  }
+  --insert application "0000001" into "app_policies"
+  data.policy_table.app_policies["0000001"] = {
+    keep_context = false,
+    steal_focus = false,
+    priority = "NONE",
+    default_hmi = "NONE",
+    groups = {"Base-4", "Group001"}
+  }
+  --insert "ConsentGroup001" into "consumer_friendly_messages"
+  data.policy_table.consumer_friendly_messages.messages["ConsentGroup001"] = {languages = {}}
+  data.policy_table.consumer_friendly_messages.messages.ConsentGroup001.languages["en-us"] = {
+    tts = "tts_test",
+    label = "label_test",
+    textBody = "textBody_test"
+  }
+  -- create json file for Policy Table Update
+  common_functions_external_consent:CreateJsonFileForPTU(data, "/tmp/ptu_update.json")
+  -- remove preload_pt from json file
+  local parent_item = {"policy_table","module_config"}
+  local removed_json_items = {"preloaded_pt"}
+  common_functions:RemoveItemsFromJsonFile("/tmp/ptu_update.json", parent_item, removed_json_items)
+  -- update policy table
+  common_functions_external_consent:UpdatePolicy(self, "/tmp/ptu_update.json")
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- Check GetListOfPermissions response with empty externalConsentStatus array list.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF".."_Precondition_GetListOfPermissions"] = function(self)
+  --hmi side: sending SDL.GetListOfPermissions request to SDL
+  local request_id = self.hmiConnection:SendRequest("SDL.GetListOfPermissions")
+  -- hmi side: expect SDL.GetListOfPermissions response
+  EXPECT_HMIRESPONSE(request_id,{
+      result = {
+        code = 0,
+        method = "SDL.GetListOfPermissions",
+        allowedFunctions = {{name = "ConsentGroup001", allowed = nil}},
+        externalConsentStatus = {}
+      }
+  })
+end
+
+--------------------------------------------------------------------------
+-- Precondition:
+-- HMI sends OnAppPermissionConsent
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_Precondition_HMI_sends_OnAppPermissionConsent"] = function(self)
+  -- hmi side: sending SDL.OnAppPermissionConsent for applications
+  self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent", {
+      source = "GUI",
+      externalConsentStatus = {
+        {entityType = 1, entityID = 2, status = "OFF"}
+      }
+  })
+  self.mobileSession:ExpectNotification("OnPermissionsChange")
+  :ValidIf(function(_,data)
+      local validate_result = common_functions_external_consent:ValidateHMIPermissions(data,
+        "SubscribeWayPoints", {allowed = {}, userDisallowed = {"BACKGROUND","FULL","LIMITED"}})
+      return validate_result
+  end)
+end
+
+--------------------------------------------------------------------------
+-- Main check:
+-- RPC is disallowed to process.
+--------------------------------------------------------------------------
+Test["TEST_NAME_OFF" .. "_MainCheck_RPC_is_disallowed"] = function(self)
+  --mobile side: send SubscribeWayPoints request
+  self.mobileSession:SendRPC("SubscribeWayPoints",{})
+  --mobile side: SubscribeWayPoints response
+  EXPECT_RESPONSE("SubscribeWayPoints", {success = false , resultCode = "USER_DISALLOWED"})
+  EXPECT_NOTIFICATION("OnHashChange")
+  :Times(0)
+end
+
+--------------------------------------Postcondition------------------------------------------
+Test["Stop_SDL"] = function()
+  StopSDL()
+end

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/027_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_04.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/027_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_04.lua
@@ -4,7 +4,7 @@
 
 ------------------------------------General Settings for Configuration--------------------------------
 require('user_modules/all_common_modules')
-local common_functions_external_consent = require('user_modules/ATF_Policies_External_Consent_common_functions')
+local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')
 local common_functions = require ('user_modules/common_functions')
 


### PR DESCRIPTION
024_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_01.lua 
025_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_02.lua 
026_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_03.lua 
027_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_04.lua 

Test set is available in #1219
User modules should be taken from #1211

@dboltovskyi @vvvakulenko @ttdong
Please review as this is task for transferring scripts I am helping @istoimenova with it