### PR TITLE
Update 065_ATF_N_HMI_responds_Invalid_Json_SetAudioStreamingIndicator…

### DIFF
--- a/test_scripts/API/SetAudioStreamingIndicator/065_ATF_N_HMI_responds_Invalid_Json_SetAudioStreamingIndicator.lua
+++ b/test_scripts/API/SetAudioStreamingIndicator/065_ATF_N_HMI_responds_Invalid_Json_SetAudioStreamingIndicator.lua
@@ -62,7 +62,7 @@ function Test:TestStep_SetAudioStreamingIndicator_GENERIC_ERROR_audioStreamingIn
 	  self.hmiConnection:Send('{"id":'..tostring(data.id)..',"jsonrpc";"2.0","result":{"audioStreamingIndicator":"PAUSE","method":"UI.SetAudioStreamingIndicator", "code":0}}')
   end)
 
-  EXPECT_RESPONSE(corr_id, { success = false, resultCode = "GENERIC_ERROR", info = "Invalid message received from vehicle" })
+  EXPECT_RESPONSE(corr_id, { success = false, resultCode = "GENERIC_ERROR", info = "UI component does not respond" })
 end
 
 --[[ Postconditions ]]


### PR DESCRIPTION
….lua

Update is based on update Note in requirement: "[GENERIC_ERROR]: SDL behavior in case HMI sends invalid response AND SDL must transfer this response to mobile app"