### PR TITLE
Remove condition for triggering ptu regaring navi app.

### DIFF
--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/001_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_on_data_consent_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/001_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_on_data_consent_disallowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" - allowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/002_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_on_user_consent_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/002_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_on_user_consent_disallowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" - allowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/003_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_on_user_consent_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/003_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_on_user_consent_allowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" - allowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/004_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_off_data_consent_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/004_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_off_data_consent_disallowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" - userDisallowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/005_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_off_user_consent_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/005_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_off_user_consent_allowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" - userDisallowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/006_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_off_user_consent_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/006_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_off_user_consent_disallowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" - userDisallowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/007_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_omitted_data_consent_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/007_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_omitted_data_consent_disallowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" in case of omitted "disallowed_by_external_consent_entities" param in functional groupings
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/008_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_omitted_user_consent_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/008_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_omitted_user_consent_allowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" in case of omitted "disallowed_by_external_consent_entities" param in functional groupings
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/009_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_omitted_user_consent_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/009_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_omitted_user_consent_disallowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" in case of omitted "disallowed_by_external_consent_entities" param in functional groupings
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/010_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_omitted_user_consent_omitted.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/010_ATF_Policies_External_Consent_OFF_disallowed_by_external_consent_entities_omitted_user_consent_omitted.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" in case of omitted "disallowed_by_external_consent_entities" param in functional groupings
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/011_ATF_Policies_External_Consent_OFF_through_ignition_cycles.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/011_ATF_Policies_External_Consent_OFF_through_ignition_cycles.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" status between ignition cycles
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/012_ATF_Policies_External_Consent_OFF_through_ignition_cycles_user_disallowed_RPCs.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/012_ATF_Policies_External_Consent_OFF_through_ignition_cycles_user_disallowed_RPCs.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" - userDisallowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/013_ATF_Policies_External_Consent_OFF_through_ignition_cycles_disallowed_by_external_consent_entities_omitted.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/013_ATF_Policies_External_Consent_OFF_through_ignition_cycles_disallowed_by_external_consent_entities_omitted.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" in case of omitted "disallowed_by_external_consent_entities" param in functional groupings
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 config.defaultProtocolVersion = 2
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
@@ -43,7 +44,7 @@ local function CheckGroup001IsNotConsentedAndGroup002IsNotConsented()
     local cid = self.mobileSession:SendRPC("SubscribeVehicleData",{rpm = true})
 
     EXPECT_RESPONSE(cid, {success = true , resultCode = "DISALLOWED"})
-    EXPECT_NOTIFICATION("OnHashChange")
+    EXPECT_NOTIFICATION("OnHashChange"):Times(0)
   end
 
 end -- function CheckGroup001IsNotConsentedAndGroup002IsNotConsented()
@@ -64,7 +65,7 @@ local function CheckGroup001IsConsentedAndGroup002IsConsented()
       end)
     --mobile side: SubscribeWayPoints response
     EXPECT_RESPONSE(cid, {success = true , resultCode = "SUCCESS"})
-    EXPECT_NOTIFICATION("OnHashChange"):Times(0)
+    EXPECT_NOTIFICATION("OnHashChange")
 
     common_functions:DelayedExp(10000)
   end

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/014_ATF_Policies_External_Consent_OFF_disallowed_change_to_ON_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/014_ATF_Policies_External_Consent_OFF_disallowed_change_to_ON_allowed.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" OnPermissionsChange after externalConsentStatus changes to "ON"
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/015_ATF_Policies_External_Consent_OFF_external_consent_disallowed_user_consent_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/015_ATF_Policies_External_Consent_OFF_external_consent_disallowed_user_consent_allowed.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" updates in "consent_groups" and "external_consent_status_groups" when SDL gets user consent for specific app
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/016_ATF_Policies_External_Consent_OFF_external_consent_disallowed_user_consent_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/016_ATF_Policies_External_Consent_OFF_external_consent_disallowed_user_consent_disallowed.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" updates in "consent_groups" and "external_consent_status_groups" when SDL gets user consent for specific app
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/017_ATF_Policies_External_Consent_OFF_external_consent_disallowed_user_consent_omitted.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/017_ATF_Policies_External_Consent_OFF_external_consent_disallowed_user_consent_omitted.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" updates in "consent_groups" and "external_consent_status_groups" when SDL gets user consent for specific app
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/018_ATF_Policies_External_Consent_OFF_external_consent_allowed_user_consent_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/018_ATF_Policies_External_Consent_OFF_external_consent_allowed_user_consent_allowed.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" updates in "consent_groups" and "external_consent_status_groups" when user disables <functional_grouping> for specific app
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/019_ATF_Policies_External_Consent_OFF_external_consent_allowed_user_consent_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/019_ATF_Policies_External_Consent_OFF_external_consent_allowed_user_consent_disallowed.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" updates in "consent_groups" and "external_consent_status_groups" when user disables <functional_grouping> for specific app
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/020_ATF_Policies_External_Consent_OFF_external_consent_allowed_user_consent_omitted.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/020_ATF_Policies_External_Consent_OFF_external_consent_allowed_user_consent_omitted.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" updates in "consent_groups" and "external_consent_status_groups" when user disables <functional_grouping> for specific app
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/021_ATF_Policies_External_Consent_OFF_allowed_change_to_ON_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/021_ATF_Policies_External_Consent_OFF_allowed_change_to_ON_disallowed.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "OFF" OnPermissionsChange for allowed groupings after externalConsentStatus changes to "ON"
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/022_ATF_Policies_External_Consent_OFF_regist_new_app_disallowed_by_external_consent_entities_off.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/022_ATF_Policies_External_Consent_OFF_regist_new_app_disallowed_by_external_consent_entities_off.lua
@@ -2,13 +2,11 @@
 --[Policies] External UCS: settings for all connected apps
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')
 local common_functions = require ('user_modules/common_functions')
-
----------------------------------------Common Variables-----------------------------------------------
-local policy_file = config.pathToSDL .. "storage/policy.sqlite"
 
 ---------------------------------------Preconditions--------------------------------------------------
 common_functions_external_consent:PreconditonSteps("mobileConnection","mobileSession")
@@ -35,7 +33,7 @@ end
 -- 3. add corresponding records to PolicyTable -> "<deviceID>" section
 --------------------------------------------------------------------------
 -- Test 12.02:
--- Description: disallowed_by_external_consent_entities_off. 
+-- Description: disallowed_by_external_consent_entities_off.
 -- HMI -> SDL: OnAppPermissionConsent(externalConsentStatus OFF). Register new applications.
 -- Expected Result: external_consent is created automatically.
 --------------------------------------------------------------------------
@@ -117,7 +115,7 @@ Test["TEST_NAME_OFF".."_Precondition_GetListOfPermissions"] = function(self)
         },
         externalConsentStatus = {}
       }
-  })
+    })
 end
 
 --------------------------------------------------------------------------
@@ -136,7 +134,7 @@ Test["TEST_NAME_OFF" .. "_Precondition_HMI_sends_OnAppPermissionConsent"] = func
       local validate_result = common_functions_external_consent:ValidateHMIPermissions(data,
         "SendLocation", {allowed = {}, userDisallowed = {"BACKGROUND","FULL","LIMITED"}})
       return validate_result
-  end)
+    end)
 end
 
 --------------------------------------------------------------------------
@@ -153,7 +151,7 @@ Test["TEST_NAME_OFF" .. "_MainCheck_RPC_of_Application_1_Group001_is_disallowed"
   self.mobileSession:SendRPC("SendLocation", {
       longitudeDegrees = 1.1,
       latitudeDegrees = 1.1
-  })
+    })
   self.mobileSession:ExpectResponse("SendLocation", {success = false , resultCode = "USER_DISALLOWED"})
 end
 

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/023_ATF_Policies_External_Consent_OFF_regist_new_app_disallowed_by_external_consent_entities_on.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/023_ATF_Policies_External_Consent_OFF_regist_new_app_disallowed_by_external_consent_entities_on.lua
@@ -2,13 +2,11 @@
 --[Policies] External UCS: settings for all connected apps
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')
 local common_functions = require ('user_modules/common_functions')
-
----------------------------------------Common Variables-----------------------------------------------
-local policy_file = config.pathToSDL .. "storage/policy.sqlite"
 
 ---------------------------------------Preconditions--------------------------------------------------
 common_functions_external_consent:PreconditonSteps("mobileConnection","mobileSession")
@@ -116,7 +114,7 @@ Test["TEST_NAME_OFF".."_Precondition_GetListOfPermissions"] = function(self)
         },
         externalConsentStatus = {}
       }
-  })
+    })
 end
 
 --------------------------------------------------------------------------
@@ -135,7 +133,7 @@ Test["TEST_NAME_OFF" .. "_Precondition_HMI_sends_OnAppPermissionConsent"] = func
       local validate_result = common_functions_external_consent:ValidateHMIPermissions(data,
         "SendLocation", {allowed = {"BACKGROUND","FULL","LIMITED"}, userDisallowed = {}})
       return validate_result
-  end)
+    end)
 end
 
 --------------------------------------------------------------------------
@@ -152,11 +150,11 @@ Test["TEST_NAME_OFF" .. "_MainCheck_RPC_of_Application_1_Group001_is_allowed"] =
   self.mobileSession:SendRPC("SendLocation", {
       longitudeDegrees = 1.1,
       latitudeDegrees = 1.1
-  })
+    })
   EXPECT_HMICALL("Navigation.SendLocation")
   :Do(function(_,data)
       self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",{})
-  end)
+    end)
   self.mobileSession:ExpectResponse("SendLocation", {success = true , resultCode = "SUCCESS"})
 end
 
@@ -168,11 +166,11 @@ Test["TEST_NAME_OFF" .. "_MainCheck_RPC_of_Application_2_Group001_is_allowed"] =
   self.mobileSession2:SendRPC("SendLocation", {
       longitudeDegrees = 1.1,
       latitudeDegrees = 1.1
-  })
+    })
   EXPECT_HMICALL("Navigation.SendLocation")
   :Do(function(_,data)
       self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",{})
-  end)
+    end)
   self.mobileSession2:ExpectResponse("SendLocation", {success = true , resultCode = "SUCCESS"})
 end
 

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/024_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_01.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/024_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_01.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "OFF" - userDisallowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/025_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_02.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/025_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_02.lua
@@ -4,6 +4,7 @@
 --[Policies] External UCS: "OFF" - userDisallowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/026_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_03.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/026_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_03.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "ON" - user_disallowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/027_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_04.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/027_ATF_Policies_External_Consent_OFF_many_entities_pairs_in_one_group_04.lua
@@ -3,6 +3,7 @@
 --[Policies] External UCS: "ON" - user_disallowed RPCs
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/028_ATF_Policies_External_Consent_OFF_same_notification_user_consent_allowed_externalConsentStatus_disallowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/028_ATF_Policies_External_Consent_OFF_same_notification_user_consent_allowed_externalConsentStatus_disallowed.lua
@@ -2,6 +2,7 @@
 -- [Policies] External UCS: externalConsentStatus vs. consentedFunctions priority
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/029_ATF_Policies_External_Consent_OFF_same_notification_user_consent_disallowed_externalConsentStatus_allowed.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/029_ATF_Policies_External_Consent_OFF_same_notification_user_consent_disallowed_externalConsentStatus_allowed.lua
@@ -2,6 +2,7 @@
 -- [Policies] External UCS: externalConsentStatus vs. consentedFunctions priority
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/030_ATF_Policies_External_Consent_OFF_empty_consent_groups.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/030_ATF_Policies_External_Consent_OFF_empty_consent_groups.lua
@@ -2,6 +2,7 @@
 -- [Policies] External UCS: empty "consent_groups" changes after externalConsentStatus was received
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')

--- a/test_scripts/Polices/External_UCS/External_Consent_OFF/031_ATF_Policies_External_Consent_missing.lua
+++ b/test_scripts/Polices/External_UCS/External_Consent_OFF/031_ATF_Policies_External_Consent_missing.lua
@@ -2,6 +2,7 @@
 --[Policies] External UCS: "externalConsentStatus" was not received from HMI
 
 ------------------------------------General Settings for Configuration--------------------------------
+config.application1.registerAppInterfaceParams.appHMIType = { "MEDIA" }
 require('user_modules/all_common_modules')
 local common_functions_external_consent = require('user_modules/shared_testcases_custom/ATF_Policies_External_Consent_common_functions')
 local common_steps = require('user_modules/common_steps')


### PR DESCRIPTION
Update based on requirement "[PTU] [GENIVI] SDL must start PTU for navi app right after app successfully registration"