### PR TITLE
VEHICLE_DATA_NOT_AVAILABLE is commented due to suspendd clarification.

### DIFF
--- a/test_scripts/API/IsReady/UI_IsReady/SetAudioStreamingIndicator/002_ATF_N_TC_SetAudioStreamingIndicator_success_false_IsReady_HMI_doesnot_reply.lua
+++ b/test_scripts/API/IsReady/UI_IsReady/SetAudioStreamingIndicator/002_ATF_N_TC_SetAudioStreamingIndicator_success_false_IsReady_HMI_doesnot_reply.lua
@@ -51,7 +51,8 @@ local hmi_result_code = {
 	{ result_code = "ABORTED"},
 	{ result_code = "IGNORED"},
 	{ result_code = "IN_USE"},
-	{ result_code = "VEHICLE_DATA_NOT_AVAILABLE"},
+	--TODO(istoimenova): update when "Must SDL resend HMI resultCode hmi_apis::Common_Result::DATA_NOT_AVAILABLE to mobile app" is resolved
+	--{ result_code = "VEHICLE_DATA_NOT_AVAILABLE"},
 	{ result_code = "TIMED_OUT"},
 	{ result_code = "INVALID_DATA"},
 	{ result_code = "CHAR_LIMIT_EXCEEDED"},

--- a/test_scripts/API/PerformAudioPassThru/023_ATF_P_PerformAudioPassThru_TTS_SUCCESS_UI_success_false.lua
+++ b/test_scripts/API/PerformAudioPassThru/023_ATF_P_PerformAudioPassThru_TTS_SUCCESS_UI_success_false.lua
@@ -50,7 +50,8 @@ local hmi_result_code = {
   { result_code = "ABORTED", info = "" },
   { result_code = "IGNORED", info = "" },
   { result_code = "IN_USE", info = "" },
-  { result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
+  --TODO(istoimenova): update when "Must SDL resend HMI resultCode hmi_apis::Common_Result::DATA_NOT_AVAILABLE to mobile app" is resolved
+  --{ result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
   { result_code = "TIMED_OUT", info = "" },
   { result_code = "INVALID_DATA", info = "" },
   { result_code = "CHAR_LIMIT_EXCEEDED", info = "" },

--- a/test_scripts/API/PerformAudioPassThru/025_ATF_P_PerformAudioPassThru_UI_SUCCESS_TTS_success_false_true.lua
+++ b/test_scripts/API/PerformAudioPassThru/025_ATF_P_PerformAudioPassThru_UI_SUCCESS_TTS_success_false_true.lua
@@ -51,7 +51,8 @@ local hmi_result_code = {
   { result_code = "ABORTED", success = false, info = "" },
   { result_code = "IGNORED", success = false, info = "" },
   { result_code = "IN_USE", success = false, info = "" },
-  { result_code = "VEHICLE_DATA_NOT_AVAILABLE", success = false, info = "" },
+  --TODO(istoimenova): update when "Must SDL resend HMI resultCode hmi_apis::Common_Result::DATA_NOT_AVAILABLE to mobile app" is resolved
+  --{ result_code = "VEHICLE_DATA_NOT_AVAILABLE", success = false, info = "" },
   { result_code = "TIMED_OUT", success = false, info = "" },
   { result_code = "INVALID_DATA", success = false, info = "" },
   { result_code = "CHAR_LIMIT_EXCEEDED", success = false, info = "" },

--- a/test_scripts/API/PerformAudioPassThru/026_ATF_P_PerformAudioPassThru_UI_success_false_TTS_success_false.lua
+++ b/test_scripts/API/PerformAudioPassThru/026_ATF_P_PerformAudioPassThru_UI_success_false_TTS_success_false.lua
@@ -49,7 +49,8 @@ local hmi_result_code_ui = {
   { result_code = "ABORTED", info = "" },
   { result_code = "IGNORED", info = "" },
   { result_code = "IN_USE", info = "" },
-  { result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
+  --TODO(istoimenova): update when "Must SDL resend HMI resultCode hmi_apis::Common_Result::DATA_NOT_AVAILABLE to mobile app" is resolved
+  --{ result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
   { result_code = "TIMED_OUT", info = "" },
   { result_code = "INVALID_DATA", info = "" },
   { result_code = "CHAR_LIMIT_EXCEEDED", info = "" },
@@ -73,7 +74,8 @@ local hmi_result_code_tts = {
   { result_code = "CHAR_LIMIT_EXCEEDED", info = "" },
   { result_code = "INVALID_DATA", info = "" },
   { result_code = "TIMED_OUT", info = "" },
-  { result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
+  --TODO(istoimenova): update when "Must SDL resend HMI resultCode hmi_apis::Common_Result::DATA_NOT_AVAILABLE to mobile app" is resolved
+  --{ result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
   { result_code = "IN_USE", info = "" },
   { result_code = "IGNORED", info = "" },
   { result_code = "ABORTED", info = "" },

--- a/test_scripts/API/SetAudioStreamingIndicator/033_ATF_N_TC_SetAudioStreamingIndicator_media_app_HMI_replies_resultcode_success_false.lua
+++ b/test_scripts/API/SetAudioStreamingIndicator/033_ATF_N_TC_SetAudioStreamingIndicator_media_app_HMI_replies_resultcode_success_false.lua
@@ -49,7 +49,8 @@ local hmi_result_code = {
 	{ result_code = "ABORTED", info = "" },
 	{ result_code = "IGNORED", info = "" },
 	{ result_code = "IN_USE", info = "" },
-	{ result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
+	--TODO(istoimenova): update when "Must SDL resend HMI resultCode hmi_apis::Common_Result::DATA_NOT_AVAILABLE to mobile app" is resolved
+	--{ result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
 	{ result_code = "TIMED_OUT", info = "" },
 	{ result_code = "INVALID_DATA", info = "" },
 	{ result_code = "CHAR_LIMIT_EXCEEDED", info = "" },

--- a/test_scripts/API/SetAudioStreamingIndicator/067_ATF_N_TC_SetAudioStreamingIndicator_media_app_sends_2_requests_HMI_replies_resultcode_success_false.lua
+++ b/test_scripts/API/SetAudioStreamingIndicator/067_ATF_N_TC_SetAudioStreamingIndicator_media_app_sends_2_requests_HMI_replies_resultcode_success_false.lua
@@ -51,7 +51,8 @@ local hmi_result_code = {
 	{ result_code = "ABORTED", info = "" },
 	{ result_code = "IGNORED", info = "" },
 	{ result_code = "IN_USE", info = "" },
-	{ result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
+	--TODO(istoimenova): update when "Must SDL resend HMI resultCode hmi_apis::Common_Result::DATA_NOT_AVAILABLE to mobile app" is resolved
+	--{ result_code = "VEHICLE_DATA_NOT_AVAILABLE", info = "" },
 	{ result_code = "TIMED_OUT", info = "" },
 	{ result_code = "INVALID_DATA", info = "" },
 	{ result_code = "CHAR_LIMIT_EXCEEDED", info = "" },


### PR DESCRIPTION
Clarification: "Must SDL resend HMI resultCode hmi_apis::Common_Result::DATA_NOT_AVAILABLE to mobile app"