### PR TITLE
Fix ptu is null scripts

### DIFF
--- a/test_scripts/Polices/appID_Management/162_ATF_P_TC_HMI_Status_Appid_Gets_Null_In_Case_Of_PTU.lua
+++ b/test_scripts/Polices/appID_Management/162_ATF_P_TC_HMI_Status_Appid_Gets_Null_In_Case_Of_PTU.lua
@@ -78,7 +78,7 @@ commonFunctions:newTestCasesGroup("Test")
 function Test:TestStep_UpdatePolicy()
   testCasesForPolicyAppIdManagament:updatePolicyTable(self, "files/jsons/Policies/appID_Management/ptu_013_2.json")
   EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", { appID =  HMIAppID, appRevoked =  true})
-  EXPECT_HMICALL("BasicCommunication.ActivateApp", { hmiLevel = "NONE" })
+  EXPECT_HMICALL("BasicCommunication.ActivateApp", { level = "NONE" })
 end
 
 function Test.Postcondition_Stop()

--- a/test_scripts/Polices/appID_Management/162_ATF_P_TC_HMI_Status_Appid_Gets_Null_In_Case_Of_PTU.lua
+++ b/test_scripts/Polices/appID_Management/162_ATF_P_TC_HMI_Status_Appid_Gets_Null_In_Case_Of_PTU.lua
@@ -77,7 +77,8 @@ end
 commonFunctions:newTestCasesGroup("Test")
 function Test:TestStep_UpdatePolicy()
   testCasesForPolicyAppIdManagament:updatePolicyTable(self, "files/jsons/Policies/appID_Management/ptu_013_2.json")
-  self.mobileSession2:ExpectNotification("OnHMIStatus", { hmiLevel ="NONE", systemContext = "MAIN", audioStreamingState = "NOT_AUDIBLE" })
+  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", { appID =  data.params.application.appID, appRevoked =  true})
+  EXPECT_HMICALL("BasicCommunication.ActivateApp")
 end
 
 function Test.Postcondition_Stop()

--- a/test_scripts/Polices/appID_Management/162_ATF_P_TC_HMI_Status_Appid_Gets_Null_In_Case_Of_PTU.lua
+++ b/test_scripts/Polices/appID_Management/162_ATF_P_TC_HMI_Status_Appid_Gets_Null_In_Case_Of_PTU.lua
@@ -77,8 +77,8 @@ end
 commonFunctions:newTestCasesGroup("Test")
 function Test:TestStep_UpdatePolicy()
   testCasesForPolicyAppIdManagament:updatePolicyTable(self, "files/jsons/Policies/appID_Management/ptu_013_2.json")
-  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", { appID =  data.params.application.appID, appRevoked =  true})
-  EXPECT_HMICALL("BasicCommunication.ActivateApp")
+  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", { appID =  HMIAppID, appRevoked =  true})
+  EXPECT_HMICALL("BasicCommunication.ActivateApp", { hmiLevel = "NONE" })
 end
 
 function Test.Postcondition_Stop()

--- a/test_scripts/Polices/appID_Management/163_ATF_P_TC_HMI_Status_Value_Of_AppId_In_PT_Is_Null.lua
+++ b/test_scripts/Polices/appID_Management/163_ATF_P_TC_HMI_Status_Value_Of_AppId_In_PT_Is_Null.lua
@@ -75,7 +75,8 @@ end
 
 function Test:Precondition_UpdatePolicy()
   testCasesForPolicyAppIdManagament:updatePolicyTable(self, "files/jsons/Policies/appID_Management/ptu_013_2.json")
-  self.mobileSession2:ExpectNotification("OnHMIStatus", { hmiLevel ="NONE", systemContext = "MAIN", audioStreamingState = "NOT_AUDIBLE" })
+  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", { appID =  data.params.application.appID, appRevoked =  true})
+  EXPECT_HMICALL("BasicCommunication.ActivateApp")
 end
 
 --[[ Test ]]

--- a/test_scripts/Polices/appID_Management/163_ATF_P_TC_HMI_Status_Value_Of_AppId_In_PT_Is_Null.lua
+++ b/test_scripts/Polices/appID_Management/163_ATF_P_TC_HMI_Status_Value_Of_AppId_In_PT_Is_Null.lua
@@ -76,7 +76,7 @@ end
 function Test:Precondition_UpdatePolicy()
   testCasesForPolicyAppIdManagament:updatePolicyTable(self, "files/jsons/Policies/appID_Management/ptu_013_2.json")
   EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", { appID =  HMIAppID, appRevoked =  true})
-  EXPECT_HMICALL("BasicCommunication.ActivateApp", { hmiLevel = "NONE" })
+  EXPECT_HMICALL("BasicCommunication.ActivateApp", { level = "NONE" })
 end
 
 --[[ Test ]]

--- a/test_scripts/Polices/appID_Management/163_ATF_P_TC_HMI_Status_Value_Of_AppId_In_PT_Is_Null.lua
+++ b/test_scripts/Polices/appID_Management/163_ATF_P_TC_HMI_Status_Value_Of_AppId_In_PT_Is_Null.lua
@@ -75,8 +75,8 @@ end
 
 function Test:Precondition_UpdatePolicy()
   testCasesForPolicyAppIdManagament:updatePolicyTable(self, "files/jsons/Policies/appID_Management/ptu_013_2.json")
-  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", { appID =  data.params.application.appID, appRevoked =  true})
-  EXPECT_HMICALL("BasicCommunication.ActivateApp")
+  EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", { appID =  HMIAppID, appRevoked =  true})
+  EXPECT_HMICALL("BasicCommunication.ActivateApp", { hmiLevel = "NONE" })
 end
 
 --[[ Test ]]


### PR DESCRIPTION
This pull request fixes two scripts, that were not correspondent to current, updated requirements (please ask me if you need applink of correspondent jira task).

With this pr, scripts became updated and represent current requirements state.

@dboltovskyi 
@Itileda 