### PR TITLE
Revert "Fix scripts with not finished PTU"

### DIFF
--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/010_ATF_P_TC_media_app_PTU_fail_ForceProtectedService_ON_RPC_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/010_ATF_P_TC_media_app_PTU_fail_ForceProtectedService_ON_RPC_encrypted_true.lua
@@ -121,7 +121,7 @@ function Test:TestStep_PolicyTableUpdate_fails()
 
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/011_ATF_P_TC_comm_app_PTU_fail_ForceProtectedService_ON_RPC_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/011_ATF_P_TC_comm_app_PTU_fail_ForceProtectedService_ON_RPC_encrypted_true.lua
@@ -120,7 +120,7 @@ function Test:TestStep_PolicyTableUpdate_fails()
 
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/012_ATF_P_TC_default_app_PTU_fail_ForceProtectedService_ON_RPC_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/012_ATF_P_TC_default_app_PTU_fail_ForceProtectedService_ON_RPC_encrypted_true.lua
@@ -121,7 +121,7 @@ function Test:TestStep_PolicyTableUpdate_fails()
 
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/027_ATF_P_TC_navi_app_PTU_fail_ForceProtectedService_OFF_Audio_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/027_ATF_P_TC_navi_app_PTU_fail_ForceProtectedService_OFF_Audio_encrypted_true.lua
@@ -85,7 +85,7 @@ commonFunctions:newTestCasesGroup("Test")
 function Test:TestStep_PolicyTableUpdate_fails()
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/028_ATF_P_TC_navi_app_PTU_fail_ForceProtectedService_OFF_Video_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/028_ATF_P_TC_navi_app_PTU_fail_ForceProtectedService_OFF_Video_encrypted_true.lua
@@ -85,7 +85,7 @@ commonFunctions:newTestCasesGroup("Test")
 function Test:TestStep_PolicyTableUpdate_fails()
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/029_ATF_P_TC_navi_app_PTU_fail_ForceProtectedService_OFF_Hybrid_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/029_ATF_P_TC_navi_app_PTU_fail_ForceProtectedService_OFF_Hybrid_encrypted_true.lua
@@ -85,7 +85,7 @@ commonFunctions:newTestCasesGroup("Test")
 function Test:TestStep_PolicyTableUpdate_fails()
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/030_ATF_P_TC_navi_app_PTU_fail_ForceProtectedService_OFF_RPC_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/030_ATF_P_TC_navi_app_PTU_fail_ForceProtectedService_OFF_RPC_encrypted_true.lua
@@ -85,7 +85,7 @@ commonFunctions:newTestCasesGroup("Test")
 function Test:TestStep_PolicyTableUpdate_fails()
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/035_ATF_P_TC_media_app_PTU_fail_ForceProtectedService_OFF_RPC_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/035_ATF_P_TC_media_app_PTU_fail_ForceProtectedService_OFF_RPC_encrypted_true.lua
@@ -101,7 +101,7 @@ function Test:TestStep_PolicyTableUpdate_fails()
 
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/036_ATF_P_TC_comm_app_PTU_fail_ForceProtectedService_OFF_RPC_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/036_ATF_P_TC_comm_app_PTU_fail_ForceProtectedService_OFF_RPC_encrypted_true.lua
@@ -100,7 +100,7 @@ function Test:TestStep_PolicyTableUpdate_fails()
 
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )

--- a/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/037_ATF_P_TC_default_app_PTU_fail_ForceProtectedService_OFF_RPC_encrypted_true.lua
+++ b/test_scripts/Polices/Policies_Security/Trigger_PTU_NO_Certificate/037_ATF_P_TC_default_app_PTU_fail_ForceProtectedService_OFF_RPC_encrypted_true.lua
@@ -101,7 +101,7 @@ function Test:TestStep_PolicyTableUpdate_fails()
 
   local SystemFilesPath = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"}, {status = "UPDATING"}):Times(2)
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status="UPDATE_NEEDED"})
 
   local RequestId_GetUrls = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(RequestId_GetUrls,{result = {code = 0, method = "SDL.GetURLS"} } )


### PR DESCRIPTION
Reverts smartdevicelink/sdl_atf_test_scripts#1396
Based on clarification "Can you clarify should SDL send UPDATING after ptu fails?" changes are removed.