### PR TITLE
Remove expectation of UPDATE_NEEDED

### DIFF
--- a/test_scripts/Polices/Related_HMI_API/206_ATF_OnAppPermissionConsent_with_appID.lua
+++ b/test_scripts/Polices/Related_HMI_API/206_ATF_OnAppPermissionConsent_with_appID.lua
@@ -93,8 +93,6 @@ function Test:TestStep_check_LocalPT_for_updates()
   local is_test_fail = false
   self.hmiConnection:SendNotification("SDL.OnPolicyUpdate", {} )
 
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"})
-
   EXPECT_HMICALL("BasicCommunication.PolicyUpdate",{})
   :Do(function(_,data)
       testCasesForPolicyTableSnapshot:extract_pts({self.applications[config.application1.registerAppInterfaceParams.appName]})

--- a/test_scripts/Polices/Related_HMI_API/211_ATF_GetListOfPermissions_without_appID.lua
+++ b/test_scripts/Polices/Related_HMI_API/211_ATF_GetListOfPermissions_without_appID.lua
@@ -79,7 +79,10 @@ end
 
 -- Triger PTU to update sdl snapshot
 function Test:TestStep_trigger_user_request_update_from_HMI()
-  testCasesForPolicyTable:trigger_user_request_update_from_HMI(self)
+  self.hmiConnection:SendNotification("SDL.OnPolicyUpdate", {} )
+
+  EXPECT_HMICALL("BasicCommunication.PolicyUpdate",{})
+  :Do(function(_,data) self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {}) end)
 end
 
 function Test:TestStep_verify_PermissionConsent()

--- a/test_scripts/Polices/Related_HMI_API/212_ATF_GetListOfPermissions_with_appID.lua
+++ b/test_scripts/Polices/Related_HMI_API/212_ATF_GetListOfPermissions_with_appID.lua
@@ -79,7 +79,10 @@ end
 
 -- Triger PTU to update sdl snapshot
 function Test:TestStep_trigger_user_request_update_from_HMI()
-  testCasesForPolicyTable:trigger_user_request_update_from_HMI(self)
+  self.hmiConnection:SendNotification("SDL.OnPolicyUpdate", {} )
+
+  EXPECT_HMICALL("BasicCommunication.PolicyUpdate",{})
+  :Do(function(_,data) self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {}) end)
 end
 
 function Test:TestStep_verify_PermissionConsent()


### PR DESCRIPTION
UPDATE_NEEDED because of new trigger will be sent after finish first PTU.
As this is not expected in script, successful PTU is not added.