### PR TITLE
Remove activation of first application.

### DIFF
--- a/test_scripts/Polices/Policy_Table_Update/027_ATF_P_TC_HMILvl_on_PTU_affected_in_FULL_or_LIMITED.lua
+++ b/test_scripts/Polices/Policy_Table_Update/027_ATF_P_TC_HMILvl_on_PTU_affected_in_FULL_or_LIMITED.lua
@@ -8,15 +8,14 @@
 -- a) SDL and HMI are running
 -- b) device is connected to SDL and is consented by the User
 -- 2. Performed steps
--- 1) register the app_1 and activate in FULL HMILevel
--- 2) Update PTU.
--- 3) register the app_2 and activate in LIMITED HMILevel
+-- 1) register the app_1
+-- 2) register the app_2 and activate in FULL HMILevel
 -- 4) Update PTU.
 
 -- Expected result:
--- 1) appID_1 remains in FULL. After PTU OnHMIStatus does not calls
--- 2) appID_2 remains in LIMITED. After PTU OnHMIStatus does not calls
--- 3) After each PTU OnPermissionsChange is called
+-- 1) appID_1 remains in NONE. After PTU OnHMIStatus does not calls
+-- 2) appID_2 remains in FULL. After PTU OnHMIStatus does not calls
+-- 3) After PTU OnPermissionsChange is called
 
 ---------------------------------------------------------------------------------------------
 --[[ General configuration parameters ]]

--- a/test_scripts/Polices/Policy_Table_Update/027_ATF_P_TC_HMILvl_on_PTU_affected_in_FULL_or_LIMITED.lua
+++ b/test_scripts/Polices/Policy_Table_Update/027_ATF_P_TC_HMILvl_on_PTU_affected_in_FULL_or_LIMITED.lua
@@ -28,7 +28,7 @@ local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
 local testCasesForPolicyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
 local json = require('json')
 --[[ Local Variables ]]
-local HMIAppID, HMIAppID2
+local HMIAppID2
 
 local applications =
 {
@@ -161,9 +161,7 @@ function Test:RegisterFirstApp()
       local correlationId = self.mobileSession:SendRPC("RegisterAppInterface", applications[1].registerAppInterfaceParams)
 
       EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered")
-      :Do(function(_,data)
-          HMIAppID = data.params.application.appID
-        end)
+
       self.mobileSession:ExpectResponse(correlationId, { success = true })
       -- EXPECT_RESPONSE(correlationId, { success = true })
       self.mobileSession:ExpectNotification("OnPermissionsChange")
@@ -182,19 +180,15 @@ function Test:RegisterSecondApp()
       self.mobileSession2:ExpectResponse(correlationId2, { success = true })
       self.mobileSession2:ExpectNotification("OnPermissionsChange")
     end)
-end
-
-function Test:ActivateFirstApp()
-  commonSteps:ActivateAppInSpecificLevel(self, HMIAppID)
+  self.mobileSession2:ExpectNotification("OnHMIStatus",{ systemContext = "MAIN", hmiLevel = "NONE"})
 end
 
 function Test:ActivateSecondApp()
   commonSteps:ActivateAppInSpecificLevel(self, HMIAppID2)
+  self.mobileSession2:ExpectNotification("OnHMIStatus",{ systemContext = "MAIN", hmiLevel = "FULL"})
 end
 
 function Test:UpdatePolicyAfterAddApps_ExpectOnHMIStatusNotCall()
-  EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
-
   testCasesForPolicyTable:updatePolicyInDifferentSessions(Test, ptu_first_app_registered,
     applications[2].registerAppInterfaceParams.appName,
     self.mobileSession2)


### PR DESCRIPTION
SDL will use one of applications in HMI level different that NONE.
To be sure that SDL will use application 2, first application is left in HMI level NONE.