### PR TITLE
Cast number to string

### DIFF
--- a/test_scripts/Polices/build_options/015_ATF_P_TC_Sending_PTS_to_Mobile_Application_HTTP.lua
+++ b/test_scripts/Polices/build_options/015_ATF_P_TC_Sending_PTS_to_Mobile_Application_HTTP.lua
@@ -82,7 +82,7 @@ function Test:TestStep_Sending_PTS_to_mobile_application()
             if (d.payload.url ~= endpoints_url) then
               return false, "Expected URL: " .. endpoints_url .. ", actual: " .. tostring(d.payload.url)
             end
-            if (d.payload.timeout ~= timeout) then
+            if (tostring(d.payload.timeout) ~= timeout) then
               return false, "Expected Timeout: " .. timeout .. ", actual: " .. tostring(d.payload.timeout)
             end
           else


### PR DESCRIPTION
"d.payload.timeout" is a number, but "timeout" is a string,
 so because of that: (d.payload.timeout ~= timeout) was always return true.
After  type casting **tostring(**d.payload.timeout**)**  ValidIf(..) works correctly