### PR TITLE
Fixed issue with Times 0

### DIFF
--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -380,7 +380,7 @@ function module:initHMI_onReady(hmi_table)
     end
 
     local exp = EXPECT_HMIEVENT(event, name)
-    :Times(hmi_table_element.occurrence or hmi_table_element.mandatory and 1 or AnyNumber())
+    :Times(hmi_table_element.occurrence or (hmi_table_element.mandatory and 1) or AnyNumber())
     :Do(function(_, data)
       if hmi_table_element.occurrence ~= 0 and hmi_table_element.params then
         xmlReporter.AddMessage("hmi_connection","SendResponse",

--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -381,7 +381,7 @@ function module:initHMI_onReady(hmi_table)
     local exp = EXPECT_HMIEVENT(event, name)
     :Times(hmi_table_element.occurrence or hmi_table_element.mandatory and 1 or AnyNumber())
     :Do(function(_, data)
-      if hmi_table_element.occurrence ~= 0 then
+      if hmi_table_element.occurrence ~= 0 and hmi_table_element.params then
         xmlReporter.AddMessage("hmi_connection","SendResponse",
         {
           ["methodName"] = tostring(name),

--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -378,6 +378,7 @@ function module:initHMI_onReady(hmi_table)
     event.matches = function(self, data)
       return data.method == name
     end
+
     local exp = EXPECT_HMIEVENT(event, name)
     :Times(hmi_table_element.occurrence or hmi_table_element.mandatory and 1 or AnyNumber())
     :Do(function(_, data)
@@ -392,18 +393,23 @@ function module:initHMI_onReady(hmi_table)
       end
     end)
 
-    if hmi_table_element.wait and delayValue < hmi_table_element.wait then
-      delayValue = hmi_table_element.wait
-      commonTestCases:DelayedExp(delayValue)
-    end
-
     if hmi_table_element.occurrence ~= 0 then
+      if hmi_table_element.wait then
+        exp = exp:Timeout(hmi_table_element.wait)
+      end
+
       if hmi_table_element.mandatory then
       exp_waiter:AddExpectation(exp)
       end
 
       if hmi_table_element.pinned then
         exp:Pin()
+      end
+    else
+      local waitTime = hmi_table_element.wait or 0
+      if delayValue < waitTime then
+        delayValue = waitTime
+        commonTestCases:DelayedExp(delayValue)
       end
     end
     return exp

--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -371,7 +371,7 @@ end
 --! @example: self:initHMI_onReady(local_hmi_table) ]]
 function module:initHMI_onReady(hmi_table)
   local exp_waiter = commonFunctions:createMultipleExpectationsWaiter(module, "HMI on ready")
-
+  local delayValue = 0
   local function ExpectRequest(name, hmi_table_element)
     local event = events.Event()
     event.level = 2
@@ -391,9 +391,13 @@ function module:initHMI_onReady(hmi_table)
         self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", hmi_table_element.params)
       end
     end)
-    if hmi_table_element.occurrence == 0 then
-      commonTestCases:DelayedExp(3000)
-    else
+
+    if hmi_table_element.wait and delayValue < hmi_table_element.wait then
+      delayValue = hmi_table_element.wait
+      commonTestCases:DelayedExp(delayValue)
+    end
+
+    if hmi_table_element.occurrence ~= 0 then
       if hmi_table_element.mandatory then
       exp_waiter:AddExpectation(exp)
       end


### PR DESCRIPTION
 - Added `hmi_table_element.occurrence` to hmi_capabilities
 - Added logic for `hmi_table_element.occurrence == 0`
Example of input table:
```
hmi_table.UI.IsReady = {
    params = {
      available = true
    },
    mandatory = true,
    pinned = false,
    occurrence = 0
  }
```
 - Remove strict derivation of function logic on base of  `hmi_table_element.occurrence`
 - Add logic for case SDL sends request and HMI does not responds (parameter "params = nil")
Example of input table:
```
hmi_table.UI.IsReady = {
    params = nil,
    mandatory = true,
    pinned = false
  }
```
 - Add wait parameter for delay expectation configuring 
(with next logic: create delayed expectation only in case it was not created for set or bigger time)
Example of input table:
```
hmi_table.UI.IsReady = {
    params = {
      available = true
    },
    mandatory = true,
    pinned = false,
    occurrence = 0,
    wait = 12000
  }
```