### PR TITLE
Implementation of test runner with sdl build options

### DIFF
--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -31,6 +31,7 @@ module.mobileConnection = mobile.MobileConnection(fileConnection)
 event_dispatcher:AddConnection(module.hmiConnection)
 event_dispatcher:AddConnection(module.mobileConnection)
 module.notification_counter = 1
+module.sdlBuildOptions = SDL.buildOptions
 
 function module.hmiConnection:EXPECT_HMIRESPONSE(id, args)
   local event = events.Event()

--- a/user_modules/hmi_values.lua
+++ b/user_modules/hmi_values.lua
@@ -1,3 +1,4 @@
+local SDL = require('SDL')
 local module = { }
 
 --[[ Functions for Values' Creation ]]
@@ -58,8 +59,7 @@ function module.getDefaultHMITable()
     TTS = { },
     VehicleInfo = { },
     Buttons = { },
-    Navigation = { },
-    RC = { }
+    Navigation = { }
   }
   -- "params" subtables contain values to be passed for creating expectations in
   -- initHMI_onReady() function of "connecttest"/"dummy_connecttest" file.
@@ -308,63 +308,73 @@ function module.getDefaultHMITable()
     pinned = false
   }
 
-  hmi_table.RC.GetCapabilities = {
-    params = {
-      remoteControlCapability = {
-        climateControlCapabilities = {
-            {
-              moduleName = "Climate",
-              currentTemperatureAvailable = true,
-              fanSpeedAvailable = true,
-              desiredTemperatureAvailable = true,
-              acEnableAvailable = true,
-              acMaxEnableAvailable = true,
-              circulateAirEnableAvailable = true,
-              autoModeEnableAvailable = true,
-              dualModeEnableAvailable = true,
-              defrostZoneAvailable = true,
-              defrostZone = {
-                "FRONT", "REAR", "ALL", "NONE"
-              },
-              ventilationModeAvailable = true,
-              ventilationMode = {
-                "UPPER", "LOWER", "BOTH", "NONE"
+  if SDL.buildOptions.remoteControl == "ON" then
+    hmi_table.RC = { }
+    hmi_table.RC.GetCapabilities = {
+      params = {
+        remoteControlCapability = {
+          climateControlCapabilities = {
+              {
+                moduleName = "Climate",
+                currentTemperatureAvailable = true,
+                fanSpeedAvailable = true,
+                desiredTemperatureAvailable = true,
+                acEnableAvailable = true,
+                acMaxEnableAvailable = true,
+                circulateAirEnableAvailable = true,
+                autoModeEnableAvailable = true,
+                dualModeEnableAvailable = true,
+                defrostZoneAvailable = true,
+                defrostZone = {
+                  "FRONT", "REAR", "ALL", "NONE"
+                },
+                ventilationModeAvailable = true,
+                ventilationMode = {
+                  "UPPER", "LOWER", "BOTH", "NONE"
+                }
               }
+            },
+          radioControlCapabilities = {
+              {
+                moduleName = "Radio",
+                radioEnableAvailable = true,
+                radioBandAvailable = true,
+                radioFrequencyAvailable = true,
+                hdChannelAvailable = true,
+                rdsDataAvailable = true,
+                availableHDsAvailable = true,
+                stateAvailable = true,
+                signalStrengthAvailable = true,
+                signalChangeThresholdAvailable = true
+              }
+            },
+          buttonCapabilities = (function()
+            local buttons = {
+              -- climate
+              "AC_MAX", "AC", "RECIRCULATE", "FAN_UP", "FAN_DOWN", "TEMP_UP", "TEMP_DOWN", "DEFROST_MAX", "DEFROST",
+              "DEFROST_REAR", "UPPER_VENT", "LOWER_VENT",
+              -- radio
+              "VOLUME_UP", "VOLUME_DOWN", "EJECT", "SOURCE", "SHUFFLE", "REPEAT"
             }
-          },
-        radioControlCapabilities = {
-            {
-              moduleName = "Radio",
-              radioEnableAvailable = true,
-              radioBandAvailable = true,
-              radioFrequencyAvailable = true,
-              hdChannelAvailable = true,
-              rdsDataAvailable = true,
-              availableHDsAvailable = true,
-              stateAvailable = true,
-              signalStrengthAvailable = true,
-              signalChangeThresholdAvailable = true
-            }
-          },
-        buttonCapabilities = (function()
-          local buttons = {
-            -- climate
-            "AC_MAX", "AC", "RECIRCULATE", "FAN_UP", "FAN_DOWN", "TEMP_UP", "TEMP_DOWN", "DEFROST_MAX", "DEFROST",
-            "DEFROST_REAR", "UPPER_VENT", "LOWER_VENT",
-            -- radio
-            "VOLUME_UP", "VOLUME_DOWN", "EJECT", "SOURCE", "SHUFFLE", "REPEAT"
-          }
-          local out = { }
-          for _, button in pairs(buttons) do
-            table.insert(out, module.createButtonCapability(button, true, true, true))
-          end
-          return out
-        end)()
-      }
-    },
-    mandatory = true,
-    pinned = false
-  }
+            local out = { }
+            for _, button in pairs(buttons) do
+              table.insert(out, module.createButtonCapability(button, true, true, true))
+            end
+            return out
+          end)()
+        }
+      },
+      mandatory = true,
+      pinned = false
+    }
+    hmi_table.RC.IsReady = {
+      params = {
+        available = true
+      },
+      mandatory = true,
+      pinned = false
+    }
+  end
 
   hmi_table.UI.IsReady = {
     params = {
@@ -399,14 +409,6 @@ function module.getDefaultHMITable()
   }
 
   hmi_table.Navigation.IsReady = {
-    params = {
-      available = true
-    },
-    mandatory = true,
-    pinned = false
-  }
-
-  hmi_table.RC.IsReady = {
     params = {
       available = true
     },

--- a/user_modules/shared_testcases/commonFunctions.lua
+++ b/user_modules/shared_testcases/commonFunctions.lua
@@ -130,11 +130,6 @@ function commonFunctions:createMultipleExpectationsWaiter(test, name)
   return exp_waiter
 end
 
-function commonFunctions:userPrint( color, message, delimeter)
-  delimeter = delimeter or "\n"
-  io.write("\27[" .. tostring(color) .. "m" .. tostring(message) .. "\27[0m", delimeter)
-end
-
 --1. Functions for String
 ---------------------------------------------------------------------------------------------
 function commonFunctions:createString(length)
@@ -170,6 +165,18 @@ function commonFunctions:createArrayInteger(size, value)
   end
   return temp
 
+end
+
+function commonFunctions:buildColoredString(color, message)
+  if config.color then
+    return "\27[" .. tostring(color) .. "m" .. tostring(message) .. "\27[0m"
+  end
+  return message
+end
+
+function commonFunctions:userPrint( color, message, delimeter)
+  delimeter = delimeter or "\n"
+  io.write(commonFunctions:buildColoredString(color, message), delimeter)
 end
 ---------------------------------------------------------------------------------------------
 

--- a/user_modules/test_settings.lua
+++ b/user_modules/test_settings.lua
@@ -1,0 +1,10 @@
+local testSettings = {
+	description = "ATF test script",
+	severity = "Major",
+	restrictions = {
+		sdlBuildOptions = {} -- no restrictions on SDL configuration
+	},
+	defaultTimeout = 10000
+}
+
+return testSettings


### PR DESCRIPTION
**Changes:**
 - Function readParameterFromCMakeCacheFile was added to commonFunction module
 - Test script runner was updated with SDL and script compatibility check
 - Created module with table that contains all information and restrictions of test
 - Create module which handle ATF config and populate it with data about SDL build options
 - Updated HMI capabilities module with logic to handle cases when RC functionality is on/off
 - For example one test script was reworked to show described above improvements.

**Examples:**
Run test that requires next SDL build options:
`REMOTE_CONTROL = ON` and `EXTENDED_POLICY = PROPRIETARY`
 with SDL built with options
`REMOTE_CONTROL = ON` and `EXTENDED_POLICY = PROPRIETARY`
```
==============================
Start '/home/aleksandrderiabin/Work/repositories/sdl_atf_test_scripts/test_scripts/RC/OnRemoteControlSettings/001_SUCCESS_in_case_AUTO_ALLOW_seq_1.lua'
==============================
=====================================================================================================
Description:
-- Description: TRS: OnRemoteControlSettings, #1
    -- In case:
    -- 1) SDL received OnRemoteControlSettings notification from HMI with allowed:true
    -- 2) and "accessMode" = "AUTO_ALLOW" or without "accessMode" parameter at all
    -- 3) and RC_module on HMI is alreay in control by RC-application
    -- SDL must:
    -- 1) provide access to RC_module for the second RC_application in HMILevel FULL after it sends control RPC
    -- (either SetInteriorVehicleData or ButtonPress) for the same RC_module without asking a driver
    -- 2) process the request from the second RC_application
  
Test severity: Critical
=====================================================================================================
--------------------------------------------Preconditions--------------------------------------------
 [33m commonSteps:DeletePolicyTable : policy.sqlite is not found [0m 
[15:59:34,442] Clean_environment                                                                     [SUCCESS] (4 ms)
SDL pid 19991
tcp        0      0 127.0.0.1:8087          0.0.0.0:*               LISTEN     
HMI initialized
HMI is ready
Mobile connected
[15:59:35,458] Start_SDL__HMI__connect_Mobile__start_Session                                         [SUCCESS] (1630 ms)
App 1 was used for PTU
[15:59:38,118] RAI1__PTU                                                                             [SUCCESS] (2535 ms)
[15:59:40,660] RAI2                                                                                  [SUCCESS] (449 ms)
------------------------------------------------Test-------------------------------------------------
-------------------------------------------Module: CLIMATE-------------------------------------------
------------------------------------------Access mode: nil-------------------------------------------
[15:59:41,168] Activate_App1                                                                         [SUCCESS] (477 ms)
[15:59:41,715] App1_SetInteriorVehicleData                                                           [SUCCESS] (129 ms)
[15:59:41,873] Set_RA_mode                                                                           [SUCCESS] (528 ms)
[15:59:42,499] Activate_App2                                                                         [SUCCESS] (528 ms)
[15:59:43,030] App2_SetInteriorVehicleData                                                           [SUCCESS] (21 ms)
[15:59:43,052] App2_ButtonPress                                                                      [SUCCESS] (13 ms)
---------------------------------------Access mode: AUTO_ALLOW---------------------------------------
[15:59:43,067] Activate_App1                                                                         [SUCCESS] (490 ms)
[15:59:43,560] App1_SetInteriorVehicleData                                                           [SUCCESS] (22 ms)
[15:59:43,583] Set_RA_mode                                                                           [SUCCESS] (484 ms)
[15:59:44,071] Activate_App2                                                                         [SUCCESS] (481 ms)
[15:59:44,561] App2_SetInteriorVehicleData                                                           [SUCCESS] (28 ms)
[15:59:44,593] App2_ButtonPress                                                                      [SUCCESS] (13 ms)
--------------------------------------------Module: RADIO--------------------------------------------
------------------------------------------Access mode: nil-------------------------------------------
[15:59:44,609] Activate_App1                                                                         [SUCCESS] (478 ms)
[15:59:45,091] App1_SetInteriorVehicleData                                                           [SUCCESS] (27 ms)
[15:59:45,119] Set_RA_mode                                                                           [SUCCESS] (478 ms)
[15:59:45,601] Activate_App2                                                                         [SUCCESS] (477 ms)
[15:59:46,082] App2_SetInteriorVehicleData                                                           [SUCCESS] (22 ms)
[15:59:46,107] App2_ButtonPress                                                                      [SUCCESS] (15 ms)
---------------------------------------Access mode: AUTO_ALLOW---------------------------------------
[15:59:46,124] Activate_App1                                                                         [SUCCESS] (479 ms)
[15:59:46,606] App1_SetInteriorVehicleData                                                           [SUCCESS] (23 ms)
[15:59:46,633] Set_RA_mode                                                                           [SUCCESS] (478 ms)
[15:59:47,115] Activate_App2                                                                         [SUCCESS] (479 ms)
[15:59:47,598] App2_SetInteriorVehicleData                                                           [SUCCESS] (24 ms)
[15:59:47,647] App2_ButtonPress                                                                      [SUCCESS] (15 ms)
-------------------------------------------Postconditions--------------------------------------------
[15:59:47,665] Stop_SDL                                                                              [SUCCESS] (1 ms)
Total executing time is 14s 297ms (summary 14297ms)
==============================
Finish '/home/aleksandrderiabin/Work/repositories/sdl_atf_test_scripts/test_scripts/RC/OnRemoteControlSettings/001_SUCCESS_in_case_AUTO_ALLOW_seq_1.lua'
==============================
```

Run test that requires next SDL build options:
`REMOTE_CONTROL = ON` and `EXTENDED_POLICY = PROPRIETARY`
 with SDL built with options
`REMOTE_CONTROL = OFF` and `EXTENDED_POLICY = PROPRIETARY`
```
==============================
Start '/home/aleksandrderiabin/Work/repositories/sdl_atf_test_scripts/test_scripts/RC/OnRemoteControlSettings/001_SUCCESS_in_case_AUTO_ALLOW_seq_1.lua'
==============================
=====================================================================================================
Description:
-- Description: TRS: OnRemoteControlSettings, #1
    -- In case:
    -- 1) SDL received OnRemoteControlSettings notification from HMI with allowed:true
    -- 2) and "accessMode" = "AUTO_ALLOW" or without "accessMode" parameter at all
    -- 3) and RC_module on HMI is alreay in control by RC-application
    -- SDL must:
    -- 1) provide access to RC_module for the second RC_application in HMILevel FULL after it sends control RPC
    -- (either SetInteriorVehicleData or ButtonPress) for the same RC_module without asking a driver
    -- 2) process the request from the second RC_application
  
Test severity: Critical
=====================================================================================================
--------------------------------------------TEST SKIPPED---------------------------------------------
Test is incompatible with current build configuration of SDL:
    {
        remoteControl = "OFF",
        extendedPolicy = "PROPRIETARY"
    }

Test is compatible with SDL built with next build options:
    {
        {
            remoteControl = 
            {
                "ON"
            },
            extendedPolicy = 
            {
                "PROPRIETARY"
            }
        }
    }
=====================================================================================================
[Finished in 0.1s with exit code 4]
```
