### PR TITLE
Added common module for VehicleData and test coverage

### DIFF
--- a/test_scripts/API/VehicleData/GetVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/001_Success_flow.lua
@@ -29,9 +29,9 @@ local function processRPCSuccess(self)
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", { engineOilLife = 52.3 })
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = 50.30})
     end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = 50.30})
 end
 
 --[[ Scenario ]]

--- a/test_scripts/API/VehicleData/GetVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/001_Success_flow.lua
@@ -1,22 +1,25 @@
 ---------------------------------------------------------------------------------------------------
--- Item: Use Case: request is NOT allowed by Policies
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
+-- Item: Use Case 1: Main Flow
 --
 -- Requirement summary:
 -- [GetVehicleData] As a mobile app wants to send a request to get the details of the vehicle data
 --
 -- Description:
 -- In case:
--- 1) mobile application sends valid GetVehicleData to SDL and this request is allowed by Policies
+-- mobile application sends valid GetVehicleData to SDL and this request is allowed by Policies
 -- SDL must:
--- Transfer this request to HMI and after successful response from hmi
--- Respond SUCCESS, success:true to mobile application
+-- 1) Transfer this request to HMI
+-- 2) After successful response from hmi
+--    respond SUCCESS, success:true and parameter value received from HMI to mobile application
+---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
 
 --[[ Local Variables ]]
-
 local rpc = {
   name = "GetVehicleData",
   params = {
@@ -24,14 +27,15 @@ local rpc = {
   }
 }
 
+--[[ Local Functions ]]
 local function processRPCSuccess(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = 50.30})
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", { engineOilLife = 50.30 } )
     end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = 50.30})
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = 50.30 } )
 end
 
 --[[ Scenario ]]
@@ -42,7 +46,6 @@ runner.Step("RAI with PTU", common.registerAppWithPTU)
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc.name, processRPCSuccess)
 
 runner.Title("Postconditions")

--- a/test_scripts/API/VehicleData/GetVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/001_Success_flow.lua
@@ -1,0 +1,49 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is NOT allowed by Policies
+--
+-- Requirement summary:
+-- [GetVehicleData] As a mobile app wants to send a request to get the details of the vehicle data
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid GetVehicleData to SDL and this request is allowed by Policies
+-- SDL must:
+-- Transfer this request to HMI and after successful response from hmi
+-- Respond SUCCESS, success:true to mobile application
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+
+--[[ Local Variables ]]
+
+local rpc = {
+  name = "GetVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", { engineOilLife = 52.3 })
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc.name, processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
@@ -1,4 +1,6 @@
 ---------------------------------------------------------------------------------------------------
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
 -- Item: Use Case: request is allowed but parameter of this request is NOT allowed by Policies
 --
 -- Requirement summary:
@@ -6,17 +8,19 @@
 --
 -- Description:
 -- In case:
--- 1) mobile application sends valid GetVehicleData to SDL and this request is allowed by Policies but RPC parameter is not allowed
+-- 1) mobile application sends valid GetVehicleData to SDL and this request is allowed
+--    by Policies but RPC parameter is not allowed
 -- SDL must:
--- 1) SDL responds DISALLOWED, success:false to mobile application and doesn't transfer this request to HMI
+-- SDL responds DISALLOWED, success:false to mobile application
+-- and doesn't transfer this request to HMI
+---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
-local commonTestCases = require("user_modules/shared_testcases/commonTestCases")
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 
 --[[ Local Variables ]]
-
 local rpc = {
   name = "GetVehicleData",
   params = {
@@ -24,7 +28,7 @@ local rpc = {
   }
 }
 
--- Function which removes engineOilLife parameter from specified func group and rpc
+--[[ Local Functions ]]
 local function ptu_update_func(tbl)
   local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["GetVehicleData"].parameters
   for index, value in pairs(params) do
@@ -46,6 +50,7 @@ local function processRPCFailure(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  commonTestCases:DelayedExp(common.timeout)
   mobileSession:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED" })
 end
 
@@ -57,13 +62,8 @@ runner.Step("RAI with PTU", common.registerAppWithPTU)
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc.name .. " 1st time" , processRPCSuccess)
-
 runner.Step("RAI 2nd app with PTU", common.registerAppWithPTU, {2, ptu_update_func})
-
---runner.Step("Delay..", delayExp)
-
 runner.Step("RPC " .. rpc.name .. " 2nd time", processRPCFailure)
 
 runner.Title("Postconditions")

--- a/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
@@ -32,10 +32,6 @@ local function ptu_update_func(tbl)
   end
 end
 
-local function delayExp()
-  commonTestCases:DelayedExp(2000)
-end
-
 local function processRPCSuccess(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)

--- a/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
@@ -1,0 +1,74 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed but parameter of this request is NOT allowed by Policies
+--
+-- Requirement summary:
+-- [GetVehicleData] As a mobile app wants to send a request to get the details of the vehicle data
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid GetVehicleData to SDL and this request is allowed by Policies but RPC parameter is not allowed
+-- SDL must:
+-- 1) SDL responds DISALLOWED, success:false to mobile application and doesn't transfer this request to HMI
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+local commonTestCases = require("user_modules/shared_testcases/commonTestCases")
+
+--[[ Local Variables ]]
+
+local rpc = {
+  name = "GetVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+-- Function which removes engineOilLife parameter from specified func group and rpc
+local function ptu_update_func(tbl)
+  local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["GetVehicleData"].parameters
+  for index, value in pairs(params) do
+    if ("engineOilLife" == value) then params[index] = nil end
+  end
+end
+
+local function delayExp()
+  commonTestCases:DelayedExp(2000)
+end
+
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", { engineOilLife = 52.3 })
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+end
+
+local function processRPCFailure(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  mobileSession:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc.name .. " 1st time" , processRPCSuccess)
+
+runner.Step("RAI 2nd app with PTU", common.registerAppWithPTU, {2, ptu_update_func})
+
+--runner.Step("Delay..", delayExp)
+
+runner.Step("RPC " .. rpc.name .. " 2nd time", processRPCFailure)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/OnVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/001_Success_flow.lua
@@ -1,26 +1,25 @@
 ---------------------------------------------------------------------------------------------------
--- Item: Use Case: request is allowed by Policies
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
+-- Item: Use Case 1: TO ADD!!!
 --
 -- Requirement summary:
--- [SubscribeVehicleData] As a mobile app wants to send a request to subscribe for specified parameter
+-- [OnVehicleData] As a mobile app is subscribed for VI parameter
+-- and received notification about this parameter change from hmi
 --
 -- Description:
 -- In case:
--- 1) hmi application sends valid SubscribeVehicleData to SDL and this request is allowed by Policies
--- SDL must:
--- Transfer this request to HMI and after successful response from hmi
--- Respond SUCCESS, success:true to mobile application
--- After HMI sends notification about changes in subcribed parameter
+-- 1) If application is subscribed to get vehicle data with 'engineOilLife' parameter
+-- 2) Notification about changes in subscribed parameter is received from hmi
 -- SDL must:
 -- Forward this notification to mobile application
-
+---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
 
 --[[ Local Variables ]]
-
 local rpc1 = {
   name = "SubscribeVehicleData",
   params = {
@@ -35,21 +34,22 @@ local rpc2 = {
   }
 }
 
+--[[ Local Functions ]]
 local function processRPCSubscribeSuccess(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc1.name, rpc1.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc1.name, rpc1.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+        {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
     end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife =
+    {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
 end
-
 
 local function checkNotificationSuccess(self)
   local mobileSession = common.getMobileSession(self, 1)
   self.hmiConnection:SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
-  --mobile side: expected SubscribeVehicleData response
   mobileSession:ExpectNotification("OnVehicleData", rpc2.params)
 end
 
@@ -61,7 +61,6 @@ runner.Step("RAI with PTU", common.registerAppWithPTU)
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc1.name, processRPCSubscribeSuccess)
 runner.Step("RPC " .. rpc2.name, checkNotificationSuccess)
 

--- a/test_scripts/API/VehicleData/OnVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/001_Success_flow.lua
@@ -1,0 +1,69 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed by Policies
+--
+-- Requirement summary:
+-- [SubscribeVehicleData] As a mobile app wants to send a request to subscribe for specified parameter
+--
+-- Description:
+-- In case:
+-- 1) hmi application sends valid SubscribeVehicleData to SDL and this request is allowed by Policies
+-- SDL must:
+-- Transfer this request to HMI and after successful response from hmi
+-- Respond SUCCESS, success:true to mobile application
+-- After HMI sends notification about changes in subcribed parameter
+-- SDL must:
+-- Forward this notification to mobile application
+
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+
+--[[ Local Variables ]]
+
+local rpc1 = {
+  name = "SubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local rpc2 = {
+  name = "OnVehicleData",
+  params = {
+    engineOilLife = 50.3
+  }
+}
+
+local function processRPCSubscribeSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc1.name, rpc1.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc1.name, rpc1.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+
+local function checkNotificationSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  self.hmiConnection:SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
+  --mobile side: expected SubscribeVehicleData response
+  mobileSession:ExpectNotification("OnVehicleData", rpc2.params)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc1.name, processRPCSubscribeSuccess)
+runner.Step("RPC " .. rpc2.name, checkNotificationSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/OnVehicleData/002_NotificationForUnsubsribedParameter_Ignored_flow.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/002_NotificationForUnsubsribedParameter_Ignored_flow.lua
@@ -1,0 +1,95 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed by Policies
+--
+-- Requirement summary:
+-- [SubscribeVehicleData] As a mobile app wants to send a request to subscribe for specified parameter
+--
+-- Description:
+-- In case:
+-- 1) hmi application sends valid SubscribeVehicleData to SDL and this request is allowed by Policies
+-- SDL must:
+-- Transfer this request to HMI and after successful response from hmi
+-- Respond SUCCESS, success:true to mobile application
+-- After HMI sends notification about changes in subcribed parameter
+-- SDL must:
+-- Forward this notification to mobile application
+
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+
+--[[ Local Variables ]]
+
+local rpc1 = {
+  name = "SubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local rpc2 = {
+  name = "OnVehicleData",
+  params = {
+    engineOilLife = 50.3
+  }
+}
+
+local rpc3 = {
+  name = "UnsubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local function processRPCSubscribeSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc1.name, rpc1.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc1.name, rpc1.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+local function processRPCUnsubscribeSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc3.name, rpc3.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc3.name, rpc3.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+
+local function checkNotificationSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  self.hmiConnection:SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
+  --mobile side: expected SubscribeVehicleData response
+  mobileSession:ExpectNotification("OnVehicleData", rpc2.params)
+end
+
+local function checkNotificationIgnored(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  self.hmiConnection:SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
+  --mobile side: expected SubscribeVehicleData response
+  mobileSession:ExpectNotification("OnVehicleData", rpc2.params):Times(0)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc1.name, processRPCSubscribeSuccess)
+runner.Step("RPC " .. rpc2.name .. " forwarded to mobile", checkNotificationSuccess)
+runner.Step("RPC " .. rpc3.name, processRPCUnsubscribeSuccess)
+runner.Step("RPC " .. rpc2.name .. " not forwarded to mobile", checkNotificationIgnored)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/OnVehicleData/002_NotificationForUnsubsribedParameter_Ignored_flow.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/002_NotificationForUnsubsribedParameter_Ignored_flow.lua
@@ -66,14 +66,14 @@ end
 local function checkNotificationSuccess(self)
   local mobileSession = common.getMobileSession(self, 1)
   self.hmiConnection:SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
-  --mobile side: expected SubscribeVehicleData response
+  --mobile side: expected OnVehicleData notification
   mobileSession:ExpectNotification("OnVehicleData", rpc2.params)
 end
 
 local function checkNotificationIgnored(self)
   local mobileSession = common.getMobileSession(self, 1)
   self.hmiConnection:SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
-  --mobile side: expected SubscribeVehicleData response
+  --mobile side: OnVehicleData notification not expected
   mobileSession:ExpectNotification("OnVehicleData", rpc2.params):Times(0)
 end
 

--- a/test_scripts/API/VehicleData/OnVehicleData/003_NotificationParameterDisallowedByPolicies_Ignored_flow.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/003_NotificationParameterDisallowedByPolicies_Ignored_flow.lua
@@ -1,0 +1,79 @@
+---------------------------------------------------------------------------------------------------
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
+-- Item: Use Case 1: TO ADD!!!
+--
+-- Requirement summary:
+-- [OnVehicleData] As a mobile app is subscribed for VI parameter
+-- and received notification about this parameter change from hmi
+--
+-- Description:
+-- In case:
+-- 1) If application is subscribed to get vehicle data with 'engineOilLife' parameter
+-- 2) Parameter is disallowed by Policies in this notification
+-- 3) Notification about changes in subscribed parameter is received from hmi
+-- SDL must:
+-- Ignore this notification and not send to mobile application
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
+
+--[[ Local Variables ]]
+local rpc1 = {
+  name = "SubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local rpc2 = {
+  name = "OnVehicleData",
+  params = {
+    engineOilLife = 50.3
+  }
+}
+
+--[[ Local Functions ]]
+local function ptu_update_func(tbl)
+  local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["OnVehicleData"].parameters
+  for index, value in pairs(params) do
+    if ("engineOilLife" == value) then params[index] = nil end
+  end
+end
+
+local function processRPCSubscribeSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc1.name, rpc1.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc1.name, rpc1.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+        {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife =
+    {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+local function checkNotificationIgnored(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  self.hmiConnection:SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
+  mobileSession:ExpectNotification("OnVehicleData", rpc2.params):Times(0)
+  commonTestCases:DelayedExp(common.timeout)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("RPC " .. rpc1.name, processRPCSubscribeSuccess)
+runner.Step("RAI 2nd app with PTU", common.registerAppWithPTU, {2, ptu_update_func})
+runner.Step("RPC " .. rpc2.name, checkNotificationIgnored)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/SubscribeVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/001_Success_flow.lua
@@ -1,0 +1,51 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed by Policies
+--
+-- Requirement summary:
+-- [SubscribeVehicleData] As a mobile app wants to send a request to subscribe for specified parameter
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid SubscribeVehicleData to SDL and this request is allowed by Policies
+-- SDL must:
+-- Transfer this request to HMI and after successful response from hmi
+-- Respond SUCCESS, success:true to mobile application
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+
+--[[ Local Variables ]]
+
+local rpc = {
+  name = "SubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc.name, processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/SubscribeVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/001_Success_flow.lua
@@ -1,4 +1,6 @@
 ---------------------------------------------------------------------------------------------------
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
 -- Item: Use Case: request is allowed by Policies
 --
 -- Requirement summary:
@@ -10,13 +12,13 @@
 -- SDL must:
 -- Transfer this request to HMI and after successful response from hmi
 -- Respond SUCCESS, success:true to mobile application
+---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
 
 --[[ Local Variables ]]
-
 local rpc = {
   name = "SubscribeVehicleData",
   params = {
@@ -24,17 +26,18 @@ local rpc = {
   }
 }
 
+--[[ Local Functions ]]
 local function processRPCSuccess(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+        {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
     end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
 end
-
-
 
 --[[ Scenario ]]
 runner.Title("Preconditions")
@@ -44,7 +47,6 @@ runner.Step("RAI with PTU", common.registerAppWithPTU)
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc.name, processRPCSuccess)
 
 runner.Title("Postconditions")

--- a/test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
@@ -1,4 +1,6 @@
 ---------------------------------------------------------------------------------------------------
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
 -- Item: Use Case: request is allowed but parameter of this request is NOT allowed by Policies
 --
 -- Requirement summary:
@@ -6,15 +8,18 @@
 --
 -- Description:
 -- In case:
--- 1) mobile application sends valid SubscribeVehicleData to SDL and this request is allowed by Policies but RPC parameter is not allowed
+-- Mobile application sends valid SubscribeVehicleData to SDL and this request is
+-- allowed by Policies but RPC parameter is not allowed
 -- SDL must:
--- 1) SDL responds DISALLOWED, success:false to mobile application and doesn't transfer this request to HMI
+-- Respond DISALLOWED, success:false to mobile application and not transfer this request to HMI
+---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
---[[ Local Variables ]]
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 
+--[[ Local Variables ]]
 local rpc = {
     name = "SubscribeVehicleData",
     params = {
@@ -22,7 +27,7 @@ local rpc = {
     }
 }
 
--- Function which removes engineOilLife parameter from specified func group and rpc
+--[[ Local Functions ]]
 local function ptu_update_func(tbl)
   local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["SubscribeVehicleData"].parameters
   for index, value in pairs(params) do
@@ -34,6 +39,7 @@ local function processRPCFailure(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  commonTestCases:DelayedExp(common.timeout)
   mobileSession:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED",
     info = "'engineOilLife' disallowed by policies.",
     engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "DISALLOWED"} })
@@ -47,7 +53,6 @@ runner.Step("RAI with PTU", common.registerAppWithPTU, {1, ptu_update_func})
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc.name , processRPCFailure)
 
 runner.Title("Postconditions")

--- a/test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
@@ -1,0 +1,54 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed but parameter of this request is NOT allowed by Policies
+--
+-- Requirement summary:
+-- [SubscribeVehicleData] As a mobile app wants to send a request to get the details of the vehicle data
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid SubscribeVehicleData to SDL and this request is allowed by Policies but RPC parameter is not allowed
+-- SDL must:
+-- 1) SDL responds DISALLOWED, success:false to mobile application and doesn't transfer this request to HMI
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+--[[ Local Variables ]]
+
+local rpc = {
+    name = "SubscribeVehicleData",
+    params = {
+    engineOilLife = true
+    }
+}
+
+-- Function which removes engineOilLife parameter from specified func group and rpc
+local function ptu_update_func(tbl)
+  local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["SubscribeVehicleData"].parameters
+  for index, value in pairs(params) do
+    if ("engineOilLife" == value) then params[index] = nil end
+  end
+end
+
+local function processRPCFailure(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  mobileSession:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED",
+    info = "'engineOilLife' disallowed by policies.",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "DISALLOWED"} })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU, {1, ptu_update_func})
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc.name , processRPCFailure)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/SubscribeVehicleData/003_RPC_parameter_already_subscribed_Result_IGNORED_flow.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/003_RPC_parameter_already_subscribed_Result_IGNORED_flow.lua
@@ -1,0 +1,62 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed by policies but app is already subscribed for specified parameter
+--
+-- Requirement summary:
+-- [SubscribeVehicleData] As a mobile app wants to send a request to subscribe for specified parameter
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid SubscribeVehicleData to SDL and this request
+--    is allowed by Policies but app is already subscribed for specified parameter
+-- SDL must:
+-- 1) SDL responds IGNORED, success:true and info: "Already subscribed on some provided VehicleData."
+--    to mobile application and doesn't transfer this request to HMI
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+--[[ Local Variables ]]
+
+local rpc = {
+    name = "SubscribeVehicleData",
+    params = {
+    engineOilLife = true
+    }
+}
+
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+        {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+
+local function processRPCIgnored(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  mobileSession:ExpectResponse(cid, { success = false, resultCode = "IGNORED",
+    info = "Already subscribed on some provided VehicleData.",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "DATA_ALREADY_SUBSCRIBED"} })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc.name .. " 1st time" , processRPCSuccess)
+runner.Step("RPC " .. rpc.name .. " 2nd time" , processRPCIgnored)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/001_Success_flow.lua
@@ -1,0 +1,70 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed by Policies
+--
+-- Requirement summary:
+-- [UnsubscribeVehicleData] As a mobile app wants to send a request to unsubscribe
+--  for already subscribed specified parameter
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request is allowed by Policies
+-- SDL must:
+-- Transfer this request to HMI and after successful response from hmi
+-- Respond SUCCESS, success:true to mobile application
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+
+--[[ Local Variables ]]
+
+local rpc_subscribe = {
+  name = "SubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local rpc_unsubscribe = {
+  name = "UnsubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local function processRPCSubscribeSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc_subscribe.name, rpc_subscribe.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc_subscribe.name, rpc_subscribe.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+local function processRPCUnsubscribeSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc_unsubscribe.name, rpc_unsubscribe.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc_unsubscribe.name, rpc_unsubscribe.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc_subscribe.name, processRPCSubscribeSuccess)
+runner.Step("RPC " .. rpc_unsubscribe.name, processRPCUnsubscribeSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/001_Success_flow.lua
@@ -1,23 +1,25 @@
 ---------------------------------------------------------------------------------------------------
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
 -- Item: Use Case: request is allowed by Policies
 --
 -- Requirement summary:
--- [UnsubscribeVehicleData] As a mobile app wants to send a request to unsubscribe
+-- [UnsubscribeVehicleData] Mobile app wants to send a request to unsubscribe
 --  for already subscribed specified parameter
 --
 -- Description:
 -- In case:
--- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request is allowed by Policies
+-- Mobile application sends valid UnsubscribeVehicleData to SDL
+-- This request is allowed by Policies and mobile app is subscribed for this parameter
 -- SDL must:
 -- Transfer this request to HMI and after successful response from hmi
 -- Respond SUCCESS, success:true to mobile application
-
+---------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
 
 --[[ Local Variables ]]
-
 local rpc_subscribe = {
   name = "SubscribeVehicleData",
   params = {
@@ -32,14 +34,17 @@ local rpc_unsubscribe = {
   }
 }
 
+--[[ Local Functions ]]
 local function processRPCSubscribeSuccess(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc_subscribe.name, rpc_subscribe.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc_subscribe.name, rpc_subscribe.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+        {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
     end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
 end
 
 local function processRPCUnsubscribeSuccess(self)
@@ -47,12 +52,12 @@ local function processRPCUnsubscribeSuccess(self)
   local cid = mobileSession:SendRPC(rpc_unsubscribe.name, rpc_unsubscribe.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc_unsubscribe.name, rpc_unsubscribe.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+        {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
     end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
 end
-
-
 
 --[[ Scenario ]]
 runner.Title("Preconditions")
@@ -62,7 +67,6 @@ runner.Step("RAI with PTU", common.registerAppWithPTU)
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc_subscribe.name, processRPCSubscribeSuccess)
 runner.Step("RPC " .. rpc_unsubscribe.name, processRPCUnsubscribeSuccess)
 

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/002_RPC_parameter_not_yet_subscribed_IGNORED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/002_RPC_parameter_not_yet_subscribed_IGNORED_flow.lua
@@ -1,21 +1,26 @@
 ---------------------------------------------------------------------------------------------------
--- Item: Use Case: request is allowed but parameter of this request is NOT allowed by Policies
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
+-- Item: Use Case: request is allowed by Policies
 --
 -- Requirement summary:
--- [UnsubscribeVehicleData] As a mobile app wants to send a request to get the details of the vehicle data
+-- [UnsubscribeVehicleData] Mobile app wants to send a request to unsubscribe
+-- for not yet subscribed specified parameter
 --
 -- Description:
 -- In case:
--- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request
---    is allowed by Policies for parameter not yet subscribed
+-- Mobile application sends valid UnsubscribeVehicleData to SDL and this request
+-- is allowed by Policies but app is not yet subscribed for this parameter
 -- SDL must:
--- 1) SDL responds IGNORED, success:false to mobile application and doesn't transfer this request to HMI
+-- Respond IGNORED, success:false to mobile application and not transfer this request to HMI
+---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
---[[ Local Variables ]]
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 
+--[[ Local Variables ]]
 local rpc = {
     name = "UnsubscribeVehicleData",
     params = {
@@ -23,10 +28,12 @@ local rpc = {
     }
 }
 
+--[[ Local Functions ]]
 local function processRPCFailure(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  commonTestCases:DelayedExp(common.timeout)
   mobileSession:ExpectResponse(cid, { success = false, resultCode = "IGNORED",
     info = "Some provided VehicleData was not subscribed.",
     engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "DATA_NOT_SUBSCRIBED"} })
@@ -40,7 +47,6 @@ runner.Step("RAI with PTU", common.registerAppWithPTU)
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc.name , processRPCFailure)
 
 runner.Title("Postconditions")

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/002_RPC_parameter_not_yet_subscribed_IGNORED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/002_RPC_parameter_not_yet_subscribed_IGNORED_flow.lua
@@ -1,0 +1,47 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed but parameter of this request is NOT allowed by Policies
+--
+-- Requirement summary:
+-- [UnsubscribeVehicleData] As a mobile app wants to send a request to get the details of the vehicle data
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request
+--    is allowed by Policies for parameter not yet subscribed
+-- SDL must:
+-- 1) SDL responds IGNORED, success:false to mobile application and doesn't transfer this request to HMI
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+--[[ Local Variables ]]
+
+local rpc = {
+    name = "UnsubscribeVehicleData",
+    params = {
+    engineOilLife = true
+    }
+}
+
+local function processRPCFailure(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  mobileSession:ExpectResponse(cid, { success = false, resultCode = "IGNORED",
+    info = "Some provided VehicleData was not subscribed.",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "DATA_NOT_SUBSCRIBED"} })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc.name , processRPCFailure)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/003_RPC_parameter_already_unsubscribed_Result_IGNORED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/003_RPC_parameter_already_unsubscribed_Result_IGNORED_flow.lua
@@ -1,23 +1,27 @@
 ---------------------------------------------------------------------------------------------------
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
 -- Item: Use Case: request is allowed by Policies
 --
 -- Requirement summary:
--- [UnsubscribeVehicleData] As a mobile app wants to send a request to unsubscribe
---  for already subscribed specified parameter
+-- [UnsubscribeVehicleData] Mobile app wants to send a request to unsubscribe
+--  for already unsubscribed specified parameter
 --
 -- Description:
 -- In case:
--- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request is allowed by Policies
+-- 1) Mobile application sends valid UnsubscribeVehicleData to SDL and this request is allowed by Policies
+-- 2) Mobile app is already unsubscribed from this parameter
 -- SDL must:
 -- Transfer this request to HMI and after successful response from hmi
 -- Respond SUCCESS, success:true to mobile application
+---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 
 --[[ Local Variables ]]
-
 local rpc_subscribe = {
   name = "SubscribeVehicleData",
   params = {
@@ -32,14 +36,17 @@ local rpc_unsubscribe = {
   }
 }
 
+--[[ Local Functions ]]
 local function processRPCSubscribeSuccess(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc_subscribe.name, rpc_subscribe.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc_subscribe.name, rpc_subscribe.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+        { engineOilLife = { dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS" } })
     end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+    engineOilLife = { dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS" } })
 end
 
 local function processRPCUnsubscribeSuccess(self)
@@ -47,15 +54,18 @@ local function processRPCUnsubscribeSuccess(self)
   local cid = mobileSession:SendRPC(rpc_unsubscribe.name, rpc_unsubscribe.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc_unsubscribe.name, rpc_unsubscribe.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+        { engineOilLife = { dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS" } })
     end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+    engineOilLife = { dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
 end
 
 local function processRPCUnsubscribeIgnored(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc_unsubscribe.name, rpc_unsubscribe.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc_unsubscribe.name, rpc_unsubscribe.params):Times(0)
+  commonTestCases:DelayedExp(common.timeout)
   mobileSession:ExpectResponse(cid, { success = false, resultCode = "IGNORED",
     engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE",
     resultCode = "DATA_NOT_SUBSCRIBED"} })
@@ -69,7 +79,6 @@ runner.Step("RAI with PTU", common.registerAppWithPTU)
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc_subscribe.name, processRPCSubscribeSuccess)
 runner.Step("RPC " .. rpc_unsubscribe.name, processRPCUnsubscribeSuccess)
 runner.Title("Trying to unsubscribe from already unsubscribed parameter...")

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/003_RPC_parameter_already_unsubscribed_Result_IGNORED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/003_RPC_parameter_already_unsubscribed_Result_IGNORED_flow.lua
@@ -1,0 +1,79 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed by Policies
+--
+-- Requirement summary:
+-- [UnsubscribeVehicleData] As a mobile app wants to send a request to unsubscribe
+--  for already subscribed specified parameter
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request is allowed by Policies
+-- SDL must:
+-- Transfer this request to HMI and after successful response from hmi
+-- Respond SUCCESS, success:true to mobile application
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+
+--[[ Local Variables ]]
+
+local rpc_subscribe = {
+  name = "SubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local rpc_unsubscribe = {
+  name = "UnsubscribeVehicleData",
+  params = {
+    engineOilLife = true
+  }
+}
+
+local function processRPCSubscribeSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc_subscribe.name, rpc_subscribe.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc_subscribe.name, rpc_subscribe.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+local function processRPCUnsubscribeSuccess(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc_unsubscribe.name, rpc_unsubscribe.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc_unsubscribe.name, rpc_unsubscribe.params)
+  :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"}})
+    end)
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "SUCCESS"} })
+end
+
+local function processRPCUnsubscribeIgnored(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc_unsubscribe.name, rpc_unsubscribe.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc_unsubscribe.name, rpc_unsubscribe.params):Times(0)
+  mobileSession:ExpectResponse(cid, { success = false, resultCode = "IGNORED",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE",
+    resultCode = "DATA_NOT_SUBSCRIBED"} })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc_subscribe.name, processRPCSubscribeSuccess)
+runner.Step("RPC " .. rpc_unsubscribe.name, processRPCUnsubscribeSuccess)
+runner.Title("Trying to unsubscribe from already unsubscribed parameter...")
+runner.Step("RPC " .. rpc_unsubscribe.name, processRPCUnsubscribeIgnored)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/003_RPC_parameter_already_unsubscribed_Result_IGNORED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/003_RPC_parameter_already_unsubscribed_Result_IGNORED_flow.lua
@@ -12,8 +12,8 @@
 -- 1) Mobile application sends valid UnsubscribeVehicleData to SDL and this request is allowed by Policies
 -- 2) Mobile app is already unsubscribed from this parameter
 -- SDL must:
--- Transfer this request to HMI and after successful response from hmi
--- Respond SUCCESS, success:true to mobile application
+-- Respond IGNORED, success:false {dataType = "VEHICLEDATA_ENGINEOILLIFE",
+-- resultCode = "DATA_NOT_SUBSCRIBED"} to mobile application
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/004_RPC_parameter_disallowed_by_policies_Result_DISALLOWED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/004_RPC_parameter_disallowed_by_policies_Result_DISALLOWED_flow.lua
@@ -1,0 +1,54 @@
+---------------------------------------------------------------------------------------------------
+-- Item: Use Case: request is allowed but parameter of this request is NOT allowed by Policies
+--
+-- Requirement summary:
+-- [UnsubscribeVehicleData] As a mobile app wants to send a request to get the details of the vehicle data
+--
+-- Description:
+-- In case:
+-- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request is allowed by Policies but RPC parameter is not allowed
+-- SDL must:
+-- 1) SDL responds DISALLOWED, success:false to mobile application and doesn't transfer this request to HMI
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/VehicleData/commonVehicleData')
+--[[ Local Variables ]]
+
+local rpc = {
+    name = "UnsubscribeVehicleData",
+    params = {
+    engineOilLife = true
+    }
+}
+
+-- Function which removes engineOilLife parameter from specified func group and rpc
+local function ptu_update_func(tbl)
+  local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["UnsubscribeVehicleData"].parameters
+  for index, value in pairs(params) do
+    if ("engineOilLife" == value) then params[index] = nil end
+  end
+end
+
+local function processRPCFailure(self)
+  local mobileSession = common.getMobileSession(self, 1)
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  mobileSession:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED",
+    info = "'engineOilLife' disallowed by policies.",
+    engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "DISALLOWED"} })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI with PTU", common.registerAppWithPTU, {1, ptu_update_func})
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+
+runner.Step("RPC " .. rpc.name , processRPCFailure)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/004_RPC_parameter_disallowed_by_policies_Result_DISALLOWED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/004_RPC_parameter_disallowed_by_policies_Result_DISALLOWED_flow.lua
@@ -1,20 +1,25 @@
 ---------------------------------------------------------------------------------------------------
+-- User story: TO ADD !!!
+-- Use case: TO ADD !!!
 -- Item: Use Case: request is allowed but parameter of this request is NOT allowed by Policies
 --
 -- Requirement summary:
--- [UnsubscribeVehicleData] As a mobile app wants to send a request to get the details of the vehicle data
---
+-- [UnsubscribeVehicleData] Mobile app wants to send a request to unsubscribe
+-- from specified parameter but parameter is disallowed by Policies
 -- Description:
 -- In case:
--- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request is allowed by Policies but RPC parameter is not allowed
+-- 1) mobile application sends valid UnsubscribeVehicleData to SDL and this request is
+-- allowed by Policies but RPC parameter is not allowed
 -- SDL must:
 -- 1) SDL responds DISALLOWED, success:false to mobile application and doesn't transfer this request to HMI
+---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
---[[ Local Variables ]]
+local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 
+--[[ Local Variables ]]
 local rpc = {
     name = "UnsubscribeVehicleData",
     params = {
@@ -22,7 +27,7 @@ local rpc = {
     }
 }
 
--- Function which removes engineOilLife parameter from specified func group and rpc
+--[[ Local Functions ]]
 local function ptu_update_func(tbl)
   local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["UnsubscribeVehicleData"].parameters
   for index, value in pairs(params) do
@@ -34,6 +39,7 @@ local function processRPCFailure(self)
   local mobileSession = common.getMobileSession(self, 1)
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)
   EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  commonTestCases:DelayedExp(common.timeout)
   mobileSession:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED",
     info = "'engineOilLife' disallowed by policies.",
     engineOilLife = {dataType = "VEHICLEDATA_ENGINEOILLIFE", resultCode = "DISALLOWED"} })
@@ -47,7 +53,6 @@ runner.Step("RAI with PTU", common.registerAppWithPTU, {1, ptu_update_func})
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")
-
 runner.Step("RPC " .. rpc.name , processRPCFailure)
 
 runner.Title("Postconditions")

--- a/test_scripts/API/VehicleData/commonVehicleData.lua
+++ b/test_scripts/API/VehicleData/commonVehicleData.lua
@@ -85,7 +85,8 @@ local function ptu(self, app_id, ptu_update_func)
   local requestId = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(requestId)
   :Do(function()
-      self.hmiConnection:SendNotification("BasicCommunication.OnSystemRequest", { requestType = "PROPRIETARY", fileName = pts_file_name })
+      self.hmiConnection:SendNotification("BasicCommunication.OnSystemRequest",
+        { requestType = "PROPRIETARY", fileName = pts_file_name })
       getPTUFromPTS(ptu_table)
        local function updatePTU(tbl)
         for rpc in pairs(tbl.policy_table.functional_groupings["Emergency-1"].rpcs) do
@@ -116,11 +117,13 @@ local function ptu(self, app_id, ptu_update_func)
             print("App ".. id .. " was used for PTU")
             RAISE_EVENT(event, event, "PTU event")
             checkIfPTSIsSentAsBinary(d2.binaryData)
-            local corIdSystemRequest = mobileSession:SendRPC("SystemRequest", { requestType = "PROPRIETARY", fileName = policy_file_name }, ptu_file_name)
+            local corIdSystemRequest = mobileSession:SendRPC("SystemRequest",
+              { requestType = "PROPRIETARY", fileName = policy_file_name }, ptu_file_name)
             EXPECT_HMICALL("BasicCommunication.SystemRequest")
             :Do(function(_, d3)
                 self.hmiConnection:SendResponse(d3.id, "BasicCommunication.SystemRequest", "SUCCESS", { })
-                self.hmiConnection:SendNotification("SDL.OnReceivedPolicyUpdate", { policyfile = policy_file_path .. "/" .. policy_file_name })
+                self.hmiConnection:SendNotification("SDL.OnReceivedPolicyUpdate",
+                  { policyfile = policy_file_path .. "/" .. policy_file_name })
               end)
             mobileSession:ExpectResponse(corIdSystemRequest, { success = true, resultCode = "SUCCESS" })
           end)
@@ -137,7 +140,6 @@ function commonVehicleData.preconditions()
 end
 
 --[[Module functions]]
-
 function commonVehicleData.activateApp(pAppId, self)
   self, pAppId = commonVehicleData.getSelfAndParams(pAppId, self)
   if not pAppId then pAppId = 1 end
@@ -145,10 +147,10 @@ function commonVehicleData.activateApp(pAppId, self)
   local mobSession = commonVehicleData.getMobileSession(self, pAppId)
   local requestId = self.hmiConnection:SendRequest("SDL.ActivateApp", { appID = pHMIAppId })
   EXPECT_HMIRESPONSE(requestId)
-  mobSession:ExpectNotification("OnHMIStatus", { hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN" })
+  mobSession:ExpectNotification("OnHMIStatus",
+    { hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN" })
   commonTestCases:DelayedExp(commonVehicleData.minTimeout)
 end
-
 
 function commonVehicleData.getSelfAndParams(...)
   local out = { }
@@ -199,11 +201,14 @@ function commonVehicleData.registerAppWithPTU(id, ptu_update_func, self)
   self["mobileSession" .. id] = mobile_session.MobileSession(self, self.mobileConnection)
   self["mobileSession" .. id]:StartService(7)
   :Do(function()
-      local corId = self["mobileSession" .. id]:SendRPC("RegisterAppInterface", config["application" .. id].registerAppInterfaceParams)
-      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config["application" .. id].registerAppInterfaceParams.appName } })
+      local corId = self["mobileSession" .. id]:SendRPC("RegisterAppInterface",
+        config["application" .. id].registerAppInterfaceParams)
+      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered",
+        { application = { appName = config["application" .. id].registerAppInterfaceParams.appName } })
       :Do(function(_, d1)
           hmiAppIds[config["application" .. id].registerAppInterfaceParams.appID] = d1.params.application.appID
-          EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }, { status = "UP_TO_DATE" })
+          EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate",
+            { status = "UPDATE_NEEDED" }, { status = "UPDATING" }, { status = "UP_TO_DATE" })
           :Times(3)
           EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
           :Do(function(_, d2)
@@ -214,7 +219,8 @@ function commonVehicleData.registerAppWithPTU(id, ptu_update_func, self)
         end)
       self["mobileSession" .. id]:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
       :Do(function()
-          self["mobileSession" .. id]:ExpectNotification("OnHMIStatus", { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+          self["mobileSession" .. id]:ExpectNotification("OnHMIStatus",
+            { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
           :Times(1)
           self["mobileSession" .. id]:ExpectNotification("OnPermissionsChange"):Times(2)
           EXPECT_HMICALL("VehicleInfo.GetVehicleData", { odometer = true})
@@ -228,14 +234,17 @@ function commonVehicleData.raiN(id, self)
   self["mobileSession" .. id] = mobile_session.MobileSession(self, self.mobileConnection)
   self["mobileSession" .. id]:StartService(7)
   :Do(function()
-      local corId = self["mobileSession" .. id]:SendRPC("RegisterAppInterface", config["application" .. id].registerAppInterfaceParams)
-      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config["application" .. id].registerAppInterfaceParams.appName } })
+      local corId = self["mobileSession" .. id]:SendRPC("RegisterAppInterface",
+        config["application" .. id].registerAppInterfaceParams)
+      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered",
+        { application = { appName = config["application" .. id].registerAppInterfaceParams.appName } })
       :Do(function(_, d1)
           hmiAppIds[config["application" .. id].registerAppInterfaceParams.appID] = d1.params.application.appID
         end)
       self["mobileSession" .. id]:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
       :Do(function()
-          self["mobileSession" .. id]:ExpectNotification("OnHMIStatus", { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+          self["mobileSession" .. id]:ExpectNotification("OnHMIStatus",
+            { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
           :Times(1)
           self["mobileSession" .. id]:ExpectNotification("OnPermissionsChange")
         end)
@@ -266,24 +275,6 @@ function commonVehicleData.start(pHMIParams, self)
             end)
         end)
     end)
-end
-
-function commonVehicleData.unregisterApp(pAppId, self)
-  local mobSession = commonVehicleData.getMobileSession(self, pAppId)
-  local hmiAppId = commonVehicleData.getHMIAppId(pAppId)
-  local cid = mobSession:SendRPC("UnregisterAppInterface",{})
-  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { appID = hmiAppId, unexpectedDisconnect = false })
-  mobSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS"})
-end
-
-function commonVehicleData.backupHMICapabilities()
-  local hmiCapabilitiesFile = commonFunctions:read_parameter_from_smart_device_link_ini("HMICapabilities")
-  commonPreconditions:BackupFile(hmiCapabilitiesFile)
-end
-
-function commonVehicleData.restoreHMICapabilities()
-  local hmiCapabilitiesFile = commonFunctions:read_parameter_from_smart_device_link_ini("HMICapabilities")
-  commonPreconditions:RestoreFile(hmiCapabilitiesFile)
 end
 
 return commonVehicleData

--- a/test_scripts/API/VehicleData/commonVehicleData.lua
+++ b/test_scripts/API/VehicleData/commonVehicleData.lua
@@ -12,7 +12,6 @@ local json = require("modules/json")
 local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
 local commonSteps = require("user_modules/shared_testcases/commonSteps")
 local commonTestCases = require("user_modules/shared_testcases/commonTestCases")
-local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
 
 --[[ Local Variables ]]
 local ptu_table = {}

--- a/test_scripts/API/VehicleData/commonVehicleData.lua
+++ b/test_scripts/API/VehicleData/commonVehicleData.lua
@@ -1,0 +1,289 @@
+---------------------------------------------------------------------------------------------------
+-- VehicleData common module
+---------------------------------------------------------------------------------------------------
+--[[ General configuration parameters ]]
+config.deviceMAC = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0"
+config.defaultProtocolVersion = 2
+
+--[[ Required Shared libraries ]]
+local mobile_session = require("mobile_session")
+local json = require("modules/json")
+
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+local commonSteps = require("user_modules/shared_testcases/commonSteps")
+local commonTestCases = require("user_modules/shared_testcases/commonTestCases")
+local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
+
+--[[ Local Variables ]]
+local ptu_table = {}
+local hmiAppIds = {}
+
+local commonVehicleData = {}
+
+commonVehicleData.timeout = 2000
+commonVehicleData.minTimeout = 500
+commonVehicleData.DEFAULT = "Default"
+
+local function checkIfPTSIsSentAsBinary(bin_data)
+  if not (bin_data ~= nil and string.len(bin_data) > 0) then
+    commonFunctions:userPrint(31, "PTS was not sent to Mobile in payload of OnSystemRequest")
+  end
+end
+
+function commonVehicleData.getGetVehicleDataConfig()
+  return {
+    keep_context = false,
+    steal_focus = false,
+    priority = "NONE",
+    default_hmi = "NONE",
+    groups = { "Base-4", "Emergency-1" }
+  }
+end
+
+local function getPTUFromPTS(tbl)
+  tbl.policy_table.consumer_friendly_messages.messages = nil
+  tbl.policy_table.device_data = nil
+  tbl.policy_table.module_meta = nil
+  tbl.policy_table.usage_and_error_counts = nil
+  tbl.policy_table.functional_groupings["DataConsent-2"].rpcs = json.null
+  tbl.policy_table.module_config.preloaded_pt = nil
+  tbl.policy_table.module_config.preloaded_date = nil
+end
+
+local function jsonFileToTable(file_name)
+  local f = io.open(file_name, "r")
+  local content = f:read("*all")
+  f:close()
+  return json.decode(content)
+end
+
+
+local function addParamToRPC(tbl, functional_grouping, rpc, param)
+  local is_found = false
+  local params = tbl.policy_table.functional_groupings[functional_grouping].rpcs[rpc].parameters
+  for _, value in pairs(params) do
+    if (value == param) then is_found = true end
+  end
+  if not is_found then
+    table.insert(tbl.policy_table.functional_groupings[functional_grouping].rpcs[rpc].parameters, param)
+  end
+end
+
+local function ptu(self, app_id, ptu_update_func)
+  local function getAppsCount()
+    local count = 0
+    for _ in pairs(hmiAppIds) do
+      count = count + 1
+    end
+    return count
+  end
+
+  local policy_file_name = "PolicyTableUpdate"
+  local policy_file_path = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
+  local pts_file_name = commonFunctions:read_parameter_from_smart_device_link_ini("PathToSnapshot")
+  local ptu_file_name = os.tmpname()
+  local requestId = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
+  EXPECT_HMIRESPONSE(requestId)
+  :Do(function()
+      self.hmiConnection:SendNotification("BasicCommunication.OnSystemRequest", { requestType = "PROPRIETARY", fileName = pts_file_name })
+      getPTUFromPTS(ptu_table)
+       local function updatePTU(tbl)
+        for rpc in pairs(tbl.policy_table.functional_groupings["Emergency-1"].rpcs) do
+          addParamToRPC(tbl, "Emergency-1", rpc, "engineOilLife")
+        end
+        tbl.policy_table.app_policies[commonVehicleData.getMobileAppId(app_id)] = commonVehicleData.getGetVehicleDataConfig()
+      end
+      updatePTU(ptu_table)
+      if ptu_update_func then
+        ptu_update_func(ptu_table)
+      end
+      local function tableToJsonFile(tbl, file_name)
+        local f = io.open(file_name, "w")
+        f:write(json.encode(tbl))
+        f:close()
+      end
+      tableToJsonFile(ptu_table, ptu_file_name)
+
+      local event = events.Event()
+      event.matches = function(self, e) return self == e end
+      EXPECT_EVENT(event, "PTU event")
+      :Timeout(11000)
+
+      for id = 1, getAppsCount() do
+        local mobileSession = commonVehicleData.getMobileSession(self, id)
+        mobileSession:ExpectNotification("OnSystemRequest", { requestType = "PROPRIETARY" })
+        :Do(function(_, d2)
+            print("App ".. id .. " was used for PTU")
+            RAISE_EVENT(event, event, "PTU event")
+            checkIfPTSIsSentAsBinary(d2.binaryData)
+            local corIdSystemRequest = mobileSession:SendRPC("SystemRequest", { requestType = "PROPRIETARY", fileName = policy_file_name }, ptu_file_name)
+            EXPECT_HMICALL("BasicCommunication.SystemRequest")
+            :Do(function(_, d3)
+                self.hmiConnection:SendResponse(d3.id, "BasicCommunication.SystemRequest", "SUCCESS", { })
+                self.hmiConnection:SendNotification("SDL.OnReceivedPolicyUpdate", { policyfile = policy_file_path .. "/" .. policy_file_name })
+              end)
+            mobileSession:ExpectResponse(corIdSystemRequest, { success = true, resultCode = "SUCCESS" })
+          end)
+        :Times(AtMost(1))
+      end
+    end)
+  os.remove(ptu_file_name)
+end
+
+function commonVehicleData.preconditions()
+  commonFunctions:SDLForceStop()
+  commonSteps:DeletePolicyTable()
+  commonSteps:DeleteLogsFiles()
+end
+
+--[[Module functions]]
+
+function commonVehicleData.activateApp(pAppId, self)
+  self, pAppId = commonVehicleData.getSelfAndParams(pAppId, self)
+  if not pAppId then pAppId = 1 end
+  local pHMIAppId = hmiAppIds[config["application" .. pAppId].registerAppInterfaceParams.appID]
+  local mobSession = commonVehicleData.getMobileSession(self, pAppId)
+  local requestId = self.hmiConnection:SendRequest("SDL.ActivateApp", { appID = pHMIAppId })
+  EXPECT_HMIRESPONSE(requestId)
+  mobSession:ExpectNotification("OnHMIStatus", { hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN" })
+  commonTestCases:DelayedExp(commonVehicleData.minTimeout)
+end
+
+
+function commonVehicleData.getSelfAndParams(...)
+  local out = { }
+  local selfIdx = nil
+  for i,v in pairs({...}) do
+    if type(v) == "table" and v.isTest then
+      table.insert(out, v)
+      selfIdx = i
+      break
+    end
+  end
+  local idx = 2
+  for i = 1, table.maxn({...}) do
+    if i ~= selfIdx then
+      out[idx] = ({...})[i]
+      idx = idx + 1
+    end
+  end
+  return table.unpack(out, 1, table.maxn(out))
+end
+
+function commonVehicleData.getHMIAppId(pAppId)
+  if not pAppId then pAppId = 1 end
+  return hmiAppIds[config["application" .. pAppId].registerAppInterfaceParams.appID]
+end
+
+function commonVehicleData.getMobileSession(self, pAppId)
+  if not pAppId then pAppId = 1 end
+  return self["mobileSession" .. pAppId]
+end
+
+function commonVehicleData.getMobileAppId(pAppId)
+  if not pAppId then pAppId = 1 end
+  return config["application" .. pAppId].registerAppInterfaceParams.appID
+end
+
+function commonVehicleData.getPathToSDL()
+  return config.pathToSDL
+end
+
+function commonVehicleData.postconditions()
+  StopSDL()
+end
+
+function commonVehicleData.registerAppWithPTU(id, ptu_update_func, self)
+  self, id, ptu_update_func = commonVehicleData.getSelfAndParams(id, ptu_update_func, self)
+  if not id then id = 1 end
+  self["mobileSession" .. id] = mobile_session.MobileSession(self, self.mobileConnection)
+  self["mobileSession" .. id]:StartService(7)
+  :Do(function()
+      local corId = self["mobileSession" .. id]:SendRPC("RegisterAppInterface", config["application" .. id].registerAppInterfaceParams)
+      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config["application" .. id].registerAppInterfaceParams.appName } })
+      :Do(function(_, d1)
+          hmiAppIds[config["application" .. id].registerAppInterfaceParams.appID] = d1.params.application.appID
+          EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }, { status = "UP_TO_DATE" })
+          :Times(3)
+          EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
+          :Do(function(_, d2)
+              self.hmiConnection:SendResponse(d2.id, d2.method, "SUCCESS", { })
+              ptu_table = jsonFileToTable(d2.params.file)
+              ptu(self, id, ptu_update_func)
+            end)
+        end)
+      self["mobileSession" .. id]:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
+      :Do(function()
+          self["mobileSession" .. id]:ExpectNotification("OnHMIStatus", { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+          :Times(1)
+          self["mobileSession" .. id]:ExpectNotification("OnPermissionsChange"):Times(2)
+          EXPECT_HMICALL("VehicleInfo.GetVehicleData", { odometer = true})
+        end)
+    end)
+end
+
+function commonVehicleData.raiN(id, self)
+  self, id = commonVehicleData.getSelfAndParams(id, self)
+  if not id then id = 1 end
+  self["mobileSession" .. id] = mobile_session.MobileSession(self, self.mobileConnection)
+  self["mobileSession" .. id]:StartService(7)
+  :Do(function()
+      local corId = self["mobileSession" .. id]:SendRPC("RegisterAppInterface", config["application" .. id].registerAppInterfaceParams)
+      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config["application" .. id].registerAppInterfaceParams.appName } })
+      :Do(function(_, d1)
+          hmiAppIds[config["application" .. id].registerAppInterfaceParams.appID] = d1.params.application.appID
+        end)
+      self["mobileSession" .. id]:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
+      :Do(function()
+          self["mobileSession" .. id]:ExpectNotification("OnHMIStatus", { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+          :Times(1)
+          self["mobileSession" .. id]:ExpectNotification("OnPermissionsChange")
+        end)
+    end)
+end
+
+local function allowSDL(self)
+  self.hmiConnection:SendNotification("SDL.OnAllowSDLFunctionality",
+    { allowed = true, source = "GUI", device = { id = config.deviceMAC, name = "127.0.0.1" } })
+end
+
+function commonVehicleData.start(pHMIParams, self)
+  self, pHMIParams = commonVehicleData.getSelfAndParams(pHMIParams, self)
+  self:runSDL()
+  commonFunctions:waitForSDLStart(self)
+  :Do(function()
+      self:initHMI(self)
+      :Do(function()
+          commonFunctions:userPrint(35, "HMI initialized")
+          self:initHMI_onReady(pHMIParams)
+          :Do(function()
+              commonFunctions:userPrint(35, "HMI is ready")
+              self:connectMobile()
+              :Do(function()
+                  commonFunctions:userPrint(35, "Mobile connected")
+                  allowSDL(self)
+                end)
+            end)
+        end)
+    end)
+end
+
+function commonVehicleData.unregisterApp(pAppId, self)
+  local mobSession = commonVehicleData.getMobileSession(self, pAppId)
+  local hmiAppId = commonVehicleData.getHMIAppId(pAppId)
+  local cid = mobSession:SendRPC("UnregisterAppInterface",{})
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { appID = hmiAppId, unexpectedDisconnect = false })
+  mobSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS"})
+end
+
+function commonVehicleData.backupHMICapabilities()
+  local hmiCapabilitiesFile = commonFunctions:read_parameter_from_smart_device_link_ini("HMICapabilities")
+  commonPreconditions:BackupFile(hmiCapabilitiesFile)
+end
+
+function commonVehicleData.restoreHMICapabilities()
+  local hmiCapabilitiesFile = commonFunctions:read_parameter_from_smart_device_link_ini("HMICapabilities")
+  commonPreconditions:RestoreFile(hmiCapabilitiesFile)
+end
+
+return commonVehicleData


### PR DESCRIPTION
Created test coverage for RPCs containing `engineOilLife` parameter

``` "GitHub issue link" ~ "https://github.com/SmartDeviceLink/sdl_core/issues/1733" ```