### PR TITLE
Fix EXPECT_HMIRESPONSE issue with expected result validation

### DIFF
--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -50,29 +50,17 @@ function module.hmiConnection:EXPECT_HMIRESPONSE(id, args)
       xmlReporter.AddMessage("EXPECT_HMIRESPONSE", {["Id"] = tostring(id),["Type"] = "AVALIABLE_RESULT"},data)
       local func_name = data.method
       local results_args = arguments
-      local results_args2 = arguments
       if(table2str(arguments):match('result')) then
         results_args = arguments.result
-        results_args2 = arguments.result
       elseif(table2str(arguments):match('error')) then
         results_args = arguments.error
-        results_args2 = arguments.error
       end
-
-      if results_args2 and results_args2.code then
-        results_args2 = table.removeKey(results_args2, 'code')
-      end
-      if results_args2 and results_args2.method then
-        results_args2 = table.removeKey(results_args2, 'method')
-      end
-
       if func_name == nil and type(data.result) == 'table' then
         func_name = data.result.method
       elseif func_name == nil and type(data.error) == 'table' then
         print_table(data)
         func_name = data.error.data.method
       end
-
       local _res, _err
       _res = true
       if not (table2str(arguments):match('error')) then
@@ -81,7 +69,6 @@ function module.hmiConnection:EXPECT_HMIRESPONSE(id, args)
       if (not _res) then
         return _res,_err
       end
-
       if func_name and results_args and data.result then
         return compareValues(results_args, data.result, "result")
       elseif func_name and results_args and data.error then

--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -64,8 +64,6 @@ function module.hmiConnection:EXPECT_HMIRESPONSE(id, args)
       end
       if results_args2 and results_args2.method then
         results_args2 = table.removeKey(results_args2, 'method')
-      elseif results_args2 and results_args2.data.method then
-        results_args2 = table.removeKey(results_args2.data, 'method')
       end
 
       if func_name == nil and type(data.result) == 'table' then


### PR DESCRIPTION
Currently if expected data is provided in EXPECT_HMIRESPONSE() function it fails with error.
This fix removes unnecessary code that was the reason of the issue.