### PR TITLE
Fix for ResetGlobalProperties regarding helpPrompt

### DIFF
--- a/test_scripts/smoke_api.lua
+++ b/test_scripts/smoke_api.lua
@@ -679,17 +679,7 @@ function Test:ResetGlobalProperties_PositiveCase()
 		--hmi side: expect TTS.SetGlobalProperties request
 		EXPECT_HMICALL("TTS.SetGlobalProperties",
 		{
-			helpPrompt =
-			{
-				{
-					type = "TEXT",
-					text = textPromtValue[1]
-				},
-				{
-					type = "TEXT",
-					text = textPromtValue[2]
-				}
-			},
+			helpPrompt = { },
 			timeoutPrompt =
 			{
 				{


### PR DESCRIPTION
According to req-t "[ResetGlobalProperties] SUCCESS on UI.SetGlobalProperties and TTS.SetGlobalPrtoperties":
>In case mobile app sends valid ResetGlobalProperties with "HELPPROMPT" and/or "TIMEOUTPROMPT" and at least one other valid parameter in "properties" array, SDL must:
>1) set-up the value of 'HelpPrompt' to an empty array and/or retrieve the value of "TimeOutPrompt" parameter from .ini file correspondingly
>2) transfer the items requested ("HELPPROMPT" or/and "TIMEOUTPROMPT") TTS.SetGlobalProperties(helpPrompt:"<empty array>", and/or timeoutPrompt:<'TimeOutPrompt' from ini.file>) to HMI.
>3) transfer UI.SetGlobalProperties with appropriate values to HMI (see more APPLINK-20718, APPLINK-20825).
>4) respond (resultCode:SUCCESS, success:true) to mobile application on getting the both SUCCESS:UI.SetGlobalProperties and SUCCESS:TTS.SetGlobalProperties from HMI

Value of "helpPrompt" has to be empty
Current fix implement this