### PR TITLE
Regression SendLocation scripts

### DIFF
--- a/test_scripts/API/Navigation/SendLocation/021_SendLocation_out_of_bound_values.lua
+++ b/test_scripts/API/Navigation/SendLocation/021_SendLocation_out_of_bound_values.lua
@@ -11,7 +11,7 @@
 -- phoneNumber, locationImage, timeStamp, address, deliveryMode parameters.
 --
 -- Steps:
--- mobile app requests SendLocation with with out of bounds values
+-- mobile app requests SendLocation with out of bounds values
 --
 -- Expected:
 -- SDL responds INVALID_DATA, success:false
@@ -80,7 +80,7 @@ local function sendLocation(parameter, paramValue, self)
     :Times(0)
 
     self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA" })
-    commonSendLocation.delayedExp(1000)
+    commonSendLocation.delayedExp()
 end
 
 local function sendLocationAddressLines(paramValue, self)
@@ -93,7 +93,7 @@ local function sendLocationAddressLines(paramValue, self)
     :Times(0)
 
     self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA" })
-    commonSendLocation.delayedExp(1000)
+    commonSendLocation.delayedExp()
 end
 
 local function sendLocationTimeStamp(innerParam, paramValue, self)
@@ -107,7 +107,7 @@ local function sendLocationTimeStamp(innerParam, paramValue, self)
     :Times(0)
 
     self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA" })
-    commonSendLocation.delayedExp(1000)
+    commonSendLocation.delayedExp()
 end
 
 local function sendLocationAddress(innerParam, paramValue, self)
@@ -121,7 +121,7 @@ local function sendLocationAddress(innerParam, paramValue, self)
     :Times(0)
 
     self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA" })
-    commonSendLocation.delayedExp(1000)
+    commonSendLocation.delayedExp()
 end
 
 --[[ Scenario ]]
@@ -189,4 +189,3 @@ runner.Step("SendLocation_deliveryMode_out_bound", sendLocation,
 
 runner.Title("Postconditions")
 runner.Step("Stop SDL", commonSendLocation.postconditions)
-

--- a/test_scripts/API/Navigation/SendLocation/021_SendLocation_out_of_bound_values.lua
+++ b/test_scripts/API/Navigation/SendLocation/021_SendLocation_out_of_bound_values.lua
@@ -1,0 +1,192 @@
+---------------------------------------------------------------------------------------------
+-- Requirements: https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/TRS/embedded_navi/SendLocation_TRS.md
+--
+-- Requirement summary:
+-- 1. Request is invalid: Wrong json, parameters of wrong type, string parameters with empty values or whitespace as the
+-- only symbol, out of bounds, wrong characters, missing mandatory parameters
+-- 2. SDL responds INVALID_DATA, success:false
+--
+-- Description:
+-- App sends SendLocation request with out of bounds values of locationName, locationDescription, addressLines,
+-- phoneNumber, locationImage, timeStamp, address, deliveryMode parameters.
+--
+-- Steps:
+-- mobile app requests SendLocation with with out of bounds values
+--
+-- Expected:
+-- SDL responds INVALID_DATA, success:false
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSendLocation = require('test_scripts/API/Navigation/commonSendLocation')
+local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
+
+--[[ Local Variables ]]
+local string501char = string.rep ("a", 501)
+local string201char = string.rep ("a", 201)
+local requestParams = {
+        longitudeDegrees = 1.1,
+        latitudeDegrees = 1.1
+}
+
+local outBoundValuesForStrings = { outLower = "", outUpper = string501char }
+
+local StringParam = {
+    "locationName",
+    "locationDescription",
+    "addressLines",
+    "phoneNumber"
+}
+
+local addressParams = {
+    "countryName",
+    "countryCode",
+    "postalCode",
+    "administrativeArea",
+    "subAdministrativeArea",
+    "locality",
+    "subLocality",
+    "thoroughfare",
+    "subThoroughfare"
+}
+
+local DateTimeParams = {
+    millisecond = { name = "millisecond", outLower = -1, outUpper = 1000 },
+    second = { name = "second", outLower = -1, outUpper = 61 },
+    minute = { name = "minute", outLower = -1, outUpper = 60 },
+    hour = { name = "hour", outLower = -1, outUpper = 24 },
+    day = { name = "day", outLower = 0, outUpper = 32 },
+    month  = { name = "month", outLower = 0, outUpper = 13 },
+    year = { name = "year", outUpper = 4096 },
+    tz_hour = { name = "tz_hour", outLower = -13, outUpper = 15 },
+    tz_minute = { name = "tz_minute", outLower = -1, outUpper = 60 }
+}
+
+local emptyArray = {}
+local addressLinesArrayOutUpperBound = {}
+for i=1, 5 do
+    addressLinesArrayOutUpperBound[i] = "a"
+end
+
+--[[ Local Functions ]]
+local function sendLocation(parameter, paramValue, self)
+    local params = commonFunctions:cloneTable(requestParams)
+    params[parameter] = paramValue
+
+    local cid = self.mobileSession1:SendRPC("SendLocation", params)
+
+    EXPECT_HMICALL("Navigation.SendLocation")
+    :Times(0)
+
+    self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA" })
+    commonSendLocation.delayedExp(1000)
+end
+
+local function sendLocationAddressLines(paramValue, self)
+    local params = commonFunctions:cloneTable(requestParams)
+    params.addressLines = paramValue
+
+    local cid = self.mobileSession1:SendRPC("SendLocation", params)
+
+    EXPECT_HMICALL("Navigation.SendLocation")
+    :Times(0)
+
+    self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA" })
+    commonSendLocation.delayedExp(1000)
+end
+
+local function sendLocationTimeStamp(innerParam, paramValue, self)
+    local params = commonFunctions:cloneTable(requestParams)
+    params["timeStamp"] = {}
+    params.timeStamp[innerParam] = paramValue
+
+    local cid = self.mobileSession1:SendRPC("SendLocation", params)
+
+    EXPECT_HMICALL("Navigation.SendLocation")
+    :Times(0)
+
+    self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA" })
+    commonSendLocation.delayedExp(1000)
+end
+
+local function sendLocationAddress(innerParam, paramValue, self)
+    local params = commonFunctions:cloneTable(requestParams)
+    params["address"] = {}
+    params.address[innerParam] = paramValue
+
+    local cid = self.mobileSession1:SendRPC("SendLocation", params)
+
+    EXPECT_HMICALL("Navigation.SendLocation")
+    :Times(0)
+
+    self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA" })
+    commonSendLocation.delayedExp(1000)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSendLocation.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSendLocation.start)
+runner.Step("RAI, PTU", commonSendLocation.registerApplicationWithPTU)
+runner.Step("Activate App", commonSendLocation.activateApp)
+
+--[[ Test ]]
+--[[ Out lower bound test block ]]
+--[[ Parameters: locationName, locationDescription, addressLines, phoneNumber ]]
+runner.Title("Test")
+runner.Title("Out of lower bound values")
+for _, ArrayValue in pairs(StringParam) do
+    runner.Step("SendLocation_out_lower" .. tostring(ArrayValue), sendLocation,
+        { ArrayValue, outBoundValuesForStrings.outLower })
+end
+
+--[[ Parameter: addressLines ]]
+runner.Step("SendLocation_addressLines_out_lower_array_value", sendLocationAddressLines,
+        {{ outBoundValuesForStrings.outLower }})
+runner.Step("SendLocation_addressLines_out_lower_array size", sendLocationAddressLines,
+        { emptyArray })
+
+--[[ Parameter: timeStamp ]]
+for _, ArrayValue in pairs(DateTimeParams) do
+    if ArrayValue.name ~= "year" then
+        runner.Step("SendLocation_timeStamp_out_lower_" .. tostring(ArrayValue.name), sendLocationTimeStamp,
+            { ArrayValue.name, ArrayValue.outLower })
+    -- check 'year out of lower bound' is ommited because according to corfimmed information before SDL don't have
+    -- lower bound value and don't process any out of lower bound values of year parameter.
+    end
+end
+
+--[[ Out upper bound test block ]]
+--[[ Parameters: locationName, locationDescription, addressLines, phoneNumber ]]
+runner.Title("Out of upper bound values")
+for _, ArrayValue in pairs(StringParam) do
+    runner.Step("SendLocation_out upper" .. tostring(ArrayValue), sendLocation,
+        { ArrayValue, outBoundValuesForStrings.outUpper })
+end
+
+--[[ Parameter: addressLines ]]
+runner.Step("SendLocation_addressLines_out_upper_array_value", sendLocationAddressLines,
+        {{ outBoundValuesForStrings.outUpper }})
+runner.Step("SendLocation_addressLines_out_upper_array_size", sendLocationAddressLines,
+        { addressLinesArrayOutUpperBound })
+
+--[[ Parameter: timeStamp ]]
+for _, ArrayValue in pairs(DateTimeParams) do
+    runner.Step("SendLocation_timeStamp_out_upper_" .. tostring(ArrayValue.name), sendLocationTimeStamp,
+        { ArrayValue.name, ArrayValue.outUpper })
+end
+
+--[[ Parameter: address ]]
+for _, ArrayValue in pairs(addressParams) do
+    runner.Step("SendLocation_address_out_upper_" .. tostring(ArrayValue), sendLocationAddress,
+        { ArrayValue, string201char })
+end
+
+--[[ Parameter: deliveryMode ]]
+runner.Step("SendLocation_deliveryMode_out_bound", sendLocation,
+        { "deliveryMode", "DYNAMIC" })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSendLocation.postconditions)
+

--- a/test_scripts/API/Navigation/SendLocation/022_SendLocation_fake_another_request_params.lua
+++ b/test_scripts/API/Navigation/SendLocation/022_SendLocation_fake_another_request_params.lua
@@ -1,0 +1,148 @@
+---------------------------------------------------------------------------------------------
+-- Requirements: https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/TRS/embedded_navi/SendLocation_TRS.md
+--
+-- Requirement summary:
+-- In case mobile application sends valid SendLocation request, SDL must:
+-- 1) transfer Navigation.SendLocation to HMI
+-- 2) on getting Navigation.SendLocation ("SUCCESS") response from HMI, respond with (resultCode: SUCCESS, success:true)
+-- to mobile application.
+--
+-- Description:
+-- App sends SendLocation request with fake, from another RPC parameters.
+--
+-- Steps:
+-- mobile app requests SendLocation with fake, from another RPC parameters.
+--
+-- Expected:
+-- SDL must:
+-- 1) transfer Navigation.SendLocation to HMI without fake params
+-- 2) on getting Navigation.SendLocation ("SUCCESS") response from HMI, respond with (resultCode: SUCCESS, success:true)
+-- to mobile application.
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSendLocation = require('test_scripts/API/Navigation/commonSendLocation')
+
+--[[ Local Variables ]]
+local requestParamsWithFake = {
+    longitudeDegrees = 1.1,
+	latitudeDegrees = 1.1,
+	locationName ="location Name",
+	locationDescription ="location Description",
+	addressLines = {
+		"line1",
+		"line2"
+	},
+	phoneNumber ="phone Number",
+	locationImage =	{
+		value ="icon.png",
+		imageType ="DYNAMIC",
+		fakeParam ="fakeParam"
+	},
+	fakeParam ="fakeParam",
+	timeStamp = {
+		millisecond = 10,
+		fakeParam ="fakeParam"
+	}
+}
+
+local requetsParamAnotherRequest = {
+	longitudeDegrees = 1.1,
+	latitudeDegrees = 1.1,
+	locationName ="location Name",
+	locationDescription ="location Description",
+	addressLines = {
+		"line1",
+		"line2"
+	},
+	phoneNumber ="phone Number",
+	locationImage =	{
+		value ="icon.png",
+		imageType ="DYNAMIC",
+		cmdID = 10
+	},
+	cmdID = 10,
+	timeStamp = {
+		millisecond = 10,
+		cmdID = 10
+	}
+}
+
+local expectedRequestParams = {
+	longitudeDegrees = 1.1,
+	latitudeDegrees = 1.1,
+	locationName ="location Name",
+	locationDescription ="location Description",
+	addressLines = {
+		"line1",
+		"line2"
+	},
+	phoneNumber ="phone Number",
+	locationImage =	{
+		value ="icon.png",
+		imageType ="DYNAMIC"
+	},
+	timeStamp = {
+		millisecond = 10
+	}
+}
+
+--[[ Local Functions ]]
+local function sendLocation(params, paramsHMI, self)
+    local cid = self.mobileSession1:SendRPC("SendLocation", params)
+    paramsHMI.appID = commonSendLocation.getHMIAppId()
+    local deviceID = commonSendLocation.getDeviceMAC()
+    paramsHMI.locationImage.value = commonSendLocation.getPathToSDL() .. "storage/"
+        .. commonSendLocation.getMobileAppId(1) .. "_" .. deviceID .. "/icon.png"
+
+    EXPECT_HMICALL("Navigation.SendLocation", paramsHMI)
+    :Do(function(_,data)
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+    :ValidIf(function(_, data)
+		local ErrorMessage
+		local CheckStatus = true
+
+		if
+			data.params.fakeParam or
+			data.params.locationImage.fakeParam or
+			data.params.timeStamp.fakeParam then
+				ErrorMessage = "SDL sends to HMI fake parameters"
+				CheckStatus = false
+		elseif
+			data.params.cmdID or
+			data.params.locationImage.cmdID or
+			data.params.timeStamp.cmdID then
+				ErrorMessage = "SDL sends to HMI parameters from another RPC"
+				CheckStatus = false
+		end
+
+	    if CheckStatus == false then
+			return false, ErrorMessage
+	    else
+			return true
+	    end
+    end)
+
+    self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+end
+
+--[[ Scenario ]]
+--[[ Preconditions ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSendLocation.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSendLocation.start)
+runner.Step("RAI, PTU", commonSendLocation.registerApplicationWithPTU)
+runner.Step("Activate App", commonSendLocation.activateApp)
+runner.Step("Upload file", commonSendLocation.putFile, { "icon.png" })
+
+--[[ Test ]]
+runner.Title("Test")
+runner.Step("SendLocation_fake_parameters", sendLocation, { requestParamsWithFake, expectedRequestParams })
+runner.Step("SendLocation_another_request_parameters", sendLocation,
+	{ requetsParamAnotherRequest, expectedRequestParams })
+
+--[[ Postconditions ]]
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSendLocation.postconditions)

--- a/test_scripts/API/Navigation/SendLocation/023_SendLocation_app_not_registered.lua
+++ b/test_scripts/API/Navigation/SendLocation/023_SendLocation_app_not_registered.lua
@@ -33,7 +33,7 @@ local function sendLocation(self)
     :Times(0)
 
     self.mobileSession2:ExpectResponse(cid, { success = false, resultCode = "APPLICATION_NOT_REGISTERED" })
-    commonSendLocation.delayedExp(1000)
+    commonSendLocation.delayedExp()
 end
 
 local function CreationNewSession(self)

--- a/test_scripts/API/Navigation/SendLocation/023_SendLocation_app_not_registered.lua
+++ b/test_scripts/API/Navigation/SendLocation/023_SendLocation_app_not_registered.lua
@@ -1,0 +1,57 @@
+---------------------------------------------------------------------------------------------
+-- Requirements: https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/TRS/embedded_navi/SendLocation_TRS.md
+--
+-- Requirement summary:
+-- 1. Request is invalid: Wrong json, parameters of wrong type, string parameters with empty values or whitespace as the
+-- only symbol, out of bounds, wrong characters, missing mandatory parameters
+-- 2. SDL responds INVALID_DATA, success:false
+--
+-- Description:
+-- SDL receives SendLocation request to not reqistered application
+--
+-- Steps:
+-- SDL receives SendLocation request to not reqistered application
+--
+-- Expected:
+-- SDL responds APPLICATION_NOT_REGISTERED, success:false
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSendLocation = require('test_scripts/API/Navigation/commonSendLocation')
+local mobileSession = require('mobile_session')
+
+--[[ Local Functions ]]
+local function sendLocation(self)
+	local requestParams = {
+	    longitudeDegrees = 1.1,
+	    latitudeDegrees = 1.1
+	}
+
+    local cid = self.mobileSession2:SendRPC("SendLocation", requestParams)
+
+    EXPECT_HMICALL("Navigation.SendLocation")
+    :Times(0)
+
+    self.mobileSession2:ExpectResponse(cid, { success = false, resultCode = "APPLICATION_NOT_REGISTERED" })
+    commonSendLocation.delayedExp(1000)
+end
+
+local function CreationNewSession(self)
+	self.mobileSession2 = mobileSession.MobileSession(
+		self,
+		self.mobileConnection,
+		config.application2.registerAppInterfaceParams
+	)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSendLocation.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile", commonSendLocation.start)
+runner.Step("Start session", CreationNewSession)
+
+runner.Title("Test")
+runner.Step("SendLocation_APPLICATION_NOT_REGISTERED", sendLocation)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSendLocation.postconditions)

--- a/test_scripts/API/Navigation/SendLocation/024_SendLocation_diff_HMI_levels.lua
+++ b/test_scripts/API/Navigation/SendLocation/024_SendLocation_diff_HMI_levels.lua
@@ -1,0 +1,86 @@
+---------------------------------------------------------------------------------------------
+-- Requirements: https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/TRS/embedded_navi/SendLocation_TRS.md
+--
+-- Requirement summary:
+-- 1. Request is sent in NONE, BACKGROUND, FULL, LIMITED levels
+-- 2. SDL responds DISALLOWED, success:false to request in NONE level and SUCCESS, success:true in other ones
+--
+-- Description:
+-- App requests SendLocation in different HMI levels
+--
+-- Steps:
+-- SDL receives SendLocation request in NONE, BACKGROUND, FULL, LIMITED
+--
+-- Expected:
+-- SDL responds DISALLOWED, success:false in NONE level, SUCCESS, success:true in BACKGROUND, FULL, LIMITED levels
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSendLocation = require('test_scripts/API/Navigation/commonSendLocation')
+
+--[[ General configuration parameters ]]
+config.application1.registerAppInterfaceParams.isMediaApplication = true
+config.application1.registerAppInterfaceParams.appHMIType = {"NAVIGATION"}
+config.application2.registerAppInterfaceParams.isMediaApplication = false
+config.application2.registerAppInterfaceParams.appHMIType = {"NAVIGATION"}
+
+--[[ Local Variables ]]
+local requestParams = {
+    longitudeDegrees = 1.1,
+    latitudeDegrees = 1.1
+}
+
+--[[ Local Functions ]]
+local function sendLocationDisallowed(params, self)
+    local cid = self.mobileSession2:SendRPC("SendLocation", params)
+
+    EXPECT_HMICALL("Navigation.SendLocation")
+    :Times(0)
+
+    self.mobileSession2:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED" })
+    commonSendLocation.delayedExp(1000)
+end
+
+local function sendLocationSuccess(params, self)
+    local cid = self.mobileSession1:SendRPC("SendLocation", params)
+    params.appID = commonSendLocation.getHMIAppId()
+
+    EXPECT_HMICALL("Navigation.SendLocation", params)
+    :Do(function(_,data)
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+
+    self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+end
+
+local function BringAppToLimitedLevel(self)
+	self.hmiConnection:SendNotification("BasicCommunication.OnAppDeactivated",
+		{ appID = self.applications["Test Application"] })
+
+	self.mobileSession1:ExpectNotification("OnHMIStatus", { hmiLevel = "LIMITED" })
+end
+
+local function BringAppToBackgroundLevel(self)
+	commonSendLocation.activateApp("2", self)
+
+	self.mobileSession1:ExpectNotification("OnHMIStatus",{ hmiLevel = "BACKGROUND" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSendLocation.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSendLocation.start)
+runner.Step("RAI, PTU first app", commonSendLocation.registerApplicationWithPTU)
+runner.Step("RAI, PTU second app", commonSendLocation.registerApplicationWithPTU, { "2" })
+runner.Step("Activate first App", commonSendLocation.activateApp)
+
+runner.Title("Test")
+runner.Step("SendLocation_in_NONE", sendLocationDisallowed, { requestParams })
+runner.Step("SendLocation_in_FULL", sendLocationSuccess, { requestParams })
+runner.Step("Bring_app_to_limited", BringAppToLimitedLevel)
+runner.Step("SendLocation_in_LIMITED", sendLocationSuccess, { requestParams })
+runner.Step("Bring_app_to_background", BringAppToBackgroundLevel)
+runner.Step("SendLocation_in_BACKGROUND", sendLocationSuccess, { requestParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSendLocation.postconditions)

--- a/test_scripts/API/Navigation/SendLocation/024_SendLocation_diff_HMI_levels.lua
+++ b/test_scripts/API/Navigation/SendLocation/024_SendLocation_diff_HMI_levels.lua
@@ -38,7 +38,7 @@ local function sendLocationDisallowed(params, self)
     :Times(0)
 
     self.mobileSession2:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED" })
-    commonSendLocation.delayedExp(1000)
+    commonSendLocation.delayedExp()
 end
 
 local function sendLocationSuccess(params, self)
@@ -54,14 +54,15 @@ local function sendLocationSuccess(params, self)
 end
 
 local function BringAppToLimitedLevel(self)
+    local appIDval = commonSendLocation.getHMIAppId(1)
 	self.hmiConnection:SendNotification("BasicCommunication.OnAppDeactivated",
-		{ appID = self.applications["Test Application"] })
+		{ appID = appIDval })
 
 	self.mobileSession1:ExpectNotification("OnHMIStatus", { hmiLevel = "LIMITED" })
 end
 
 local function BringAppToBackgroundLevel(self)
-	commonSendLocation.activateApp("2", self)
+	commonSendLocation.activateApp(2, self)
 
 	self.mobileSession1:ExpectNotification("OnHMIStatus",{ hmiLevel = "BACKGROUND" })
 end
@@ -71,7 +72,7 @@ runner.Title("Preconditions")
 runner.Step("Clean environment", commonSendLocation.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSendLocation.start)
 runner.Step("RAI, PTU first app", commonSendLocation.registerApplicationWithPTU)
-runner.Step("RAI, PTU second app", commonSendLocation.registerApplicationWithPTU, { "2" })
+runner.Step("RAI, PTU second app", commonSendLocation.registerApplicationWithPTU, { 2 })
 runner.Step("Activate first App", commonSendLocation.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/API/Navigation/SendLocation/025_SendLocation_duplicated_corr_id.lua
+++ b/test_scripts/API/Navigation/SendLocation/025_SendLocation_duplicated_corr_id.lua
@@ -1,0 +1,72 @@
+---------------------------------------------------------------------------------------------
+-- Requirements: https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/TRS/embedded_navi/SendLocation_TRS.md
+--
+-- Requirement summary:
+-- In case mobile application sends valid SendLocation request, SDL must:
+-- 1) transfer Navigation.SendLocation to HMI
+-- 2) on getting Navigation.SendLocation ("SUCCESS") response from HMI, respond with (resultCode: SUCCESS, success:true)
+-- to mobile application.
+--
+-- Description:
+-- App sends SendLocation request with duplicated correlation ID
+--
+-- Steps:
+-- mobile app requests SendLocation with duplicated correlation ID
+--
+-- Expected:
+-- SDL must:
+-- 1) transfer Navigation.SendLocation to HMI
+-- 2) on getting Navigation.SendLocation ("SUCCESS") response from HMI, respond with (resultCode: SUCCESS, success:true)
+-- to mobile application.
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSendLocation = require('test_scripts/API/Navigation/commonSendLocation')
+
+--[[ Local Variables ]]
+local requestParams = {
+    longitudeDegrees = 1.1,
+    latitudeDegrees = 1.1
+}
+
+--[[ Local Functions ]]
+local function sendLocation(params, self)
+  local cid = self.mobileSession1:SendRPC("SendLocation", params)
+
+  local msg = {
+    serviceType      = 7,
+    frameInfo        = 0,
+    rpcType          = 0,
+    rpcFunctionId    = 39,
+    rpcCorrelationId = cid,
+    payload          = '{"longitudeDegrees":1.1, "latitudeDegrees":1.1}'
+  }
+
+  params.appID = commonSendLocation.getHMIAppId()
+
+  EXPECT_HMICALL("Navigation.SendLocation", params)
+  :Do(function(exp,data)
+      if exp.occurences == 1 then
+          self.mobileSession1:Send(msg)
+      end
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+  end)
+  :Times(2)
+
+  self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+  :Times(2)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSendLocation.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSendLocation.start)
+runner.Step("RAI, PTU", commonSendLocation.registerApplicationWithPTU)
+runner.Step("Activate App", commonSendLocation.activateApp)
+
+runner.Title("Test")
+runner.Step("SendLocation_duplicated_correlation_id", sendLocation, { requestParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSendLocation.postconditions)

--- a/test_scripts/API/Navigation/SendLocation/026_SendLocation_disallowed_by_policies.lua
+++ b/test_scripts/API/Navigation/SendLocation/026_SendLocation_disallowed_by_policies.lua
@@ -1,0 +1,55 @@
+---------------------------------------------------------------------------------------------
+-- Requirements: https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/TRS/embedded_navi/SendLocation_TRS.md
+--
+-- Requirement summary:
+-- 1. Request is valid, SendLocation RPC is not allowed by policies
+-- 2. SDL responds DISALLOWED, success:false to request
+--
+-- Description:
+-- App requests SendLocation in different HMI levels
+--
+-- Steps:
+-- SDL receives SendLocation request in NONE, BACKGROUND, FULL, LIMITED
+--
+-- Expected:
+-- SDL responds DISALLOWED, success:false in NONE level, SUCCESS, success:true in BACKGROUND, FULL, LIMITED levels
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSendLocation = require('test_scripts/API/Navigation/commonSendLocation')
+
+--[[ Local Variables ]]
+local requestParams = {
+    longitudeDegrees = 1.1,
+    latitudeDegrees = 1.1
+}
+
+--[[ Local Functions ]]
+local function ptuUpdateFuncDissalowedRPC(tbl)
+	local SendLocstionRpcs = tbl.policy_table.functional_groupings["SendLocation"].rpcs
+	if SendLocstionRpcs["SendLocation"] then SendLocstionRpcs["SendLocation"] = nil end
+end
+
+--[[ Local Functions ]]
+local function sendLocationDisallowed(params, self)
+    local cid = self.mobileSession1:SendRPC("SendLocation", params)
+
+    EXPECT_HMICALL("Navigation.SendLocation")
+    :Times(0)
+
+    self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED" })
+    commonSendLocation.delayedExp(1000)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSendLocation.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSendLocation.start)
+runner.Step("RAI, PTU", commonSendLocation.registerApplicationWithPTU, { "1", ptuUpdateFuncDissalowedRPC })
+runner.Step("Activate App", commonSendLocation.activateApp)
+
+runner.Title("Test")
+runner.Step("SendLocation_rpc_disallowed", sendLocationDisallowed, { requestParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSendLocation.postconditions)

--- a/test_scripts/API/Navigation/SendLocation/026_SendLocation_disallowed_by_policies.lua
+++ b/test_scripts/API/Navigation/SendLocation/026_SendLocation_disallowed_by_policies.lua
@@ -38,7 +38,7 @@ local function sendLocationDisallowed(params, self)
     :Times(0)
 
     self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED" })
-    commonSendLocation.delayedExp(1000)
+    commonSendLocation.delayedExp()
 end
 
 --[[ Scenario ]]

--- a/test_scripts/API/Navigation/SendLocation/027_SendLocation_invalid_HMI_responses.lua
+++ b/test_scripts/API/Navigation/SendLocation/027_SendLocation_invalid_HMI_responses.lua
@@ -1,0 +1,87 @@
+---------------------------------------------------------------------------------------------
+-- Requirements: https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/TRS/embedded_navi/SendLocation_TRS.md
+--
+-- Requirement summary:
+-- 1. HMI sends invalid response to SDL
+-- 2. SDL responds GENERIC_ERROR, success:false
+--
+-- Description:
+-- SDL responds GENERIC_ERROR, success:false in case of receiving invalid response from HMI
+--
+-- Steps:
+-- App requests SendLocation
+-- HMI responds with invalid respone(mandatory missing, invalid json, invalid value of parametes)
+--
+-- Expected:
+-- SDL responds GENERIC_ERROR, success:false
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSendLocation = require('test_scripts/API/Navigation/commonSendLocation')
+local json = require("json")
+
+--[[ Local Variables ]]
+local HMIresponses = {
+    method_Missing = { jsonrpc = "2.0", result = { code = 0 }},
+    method_WrongType = { jsonrpc = "2.0", result = { method = 3 ,code = 0 }},
+    method_WrongValue = { jsonrpc = "2.0", result = { method = "ANY" ,code = 0 }},
+    method_AnotherRPC = { jsonrpc = "2.0", result = { method = "Navigation.ShowConstantTBT", code = 0 }},
+    code_Missing = { jsonrpc = "2.0", result = { method = "Navigation.SendLocation" }},
+    code_WrongType = { jsonrpc = "2.0", result = { method = "Navigation.SendLocation", code = "0" }},
+    code_WrongValue = { jsonrpc = "2.0", result = { method = "Navigation.SendLocation", code = 1111 }},
+    result_Missing = { jsonrpc = "2.0" },
+    result_WrongType = { jsonrpc = "2.0", result = 0 }
+}
+
+local HMIresponsesIdCheck = {
+    id_Missing = { jsonrpc = "2.0", result = { method = "Navigation.SendLocation", code = 0 }},
+    id_WrongType = { jsonrpc = "2.0", id = "35", result = { method = "Navigation.SendLocation", code = 0 }},
+    id_WrongValue = { jsonrpc = "2.0", id = 1111, result = { method = "Navigation.SendLocation", code = 0 }},
+}
+
+--[[ Local Functions ]]
+local function sendLocation(paramsResponse, idValue, self)
+    local params = {
+        longitudeDegrees = 1.1,
+        latitudeDegrees = 1.1
+    }
+
+    local cid = self.mobileSession1:SendRPC("SendLocation", params)
+
+    EXPECT_HMICALL("Navigation.SendLocation")
+    :Do(function(_,data)
+        if idValue == true then
+            paramsResponse.id = data.id
+        end
+        local text
+        if type(paramsResponse) ~= "string" then
+            text = json.encode(paramsResponse)
+        else text = paramsResponse
+        end
+        self.hmiConnection:Send(text)
+    end)
+
+    self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "GENERIC_ERROR" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSendLocation.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSendLocation.start)
+runner.Step("RAI, PTU first app", commonSendLocation.registerApplicationWithPTU)
+runner.Step("Activate first App", commonSendLocation.activateApp)
+
+runner.Title("Test")
+for key, value in pairs(HMIresponses) do
+    runner.Step("SendLocation_" .. tostring(key), sendLocation, { value, true })
+end
+
+runner.Step("SendLocation_invalid_json", sendLocation,
+    { '"jsonrpc":"2.0","result":{"method""Navigation.SendLocation"}', false })
+
+for key, value in pairs(HMIresponsesIdCheck) do
+    runner.Step("SendLocation_" .. tostring(key), sendLocation, { value, false })
+end
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSendLocation.postconditions)

--- a/test_scripts/API/Navigation/SendLocation/027_SendLocation_invalid_HMI_responses.lua
+++ b/test_scripts/API/Navigation/SendLocation/027_SendLocation_invalid_HMI_responses.lua
@@ -56,7 +56,8 @@ local function sendLocation(paramsResponse, idValue, self)
         local text
         if type(paramsResponse) ~= "string" then
             text = json.encode(paramsResponse)
-        else text = paramsResponse
+        else
+            text = paramsResponse
         end
         self.hmiConnection:Send(text)
     end)


### PR DESCRIPTION
Added checks:
 - our of boundary values 
 - fake parameters
 - application not registered 
 - request in different HMI levels
 - duplicated correlation id
 - API disallowed by policies
 - invalid HMI responses
