### PR TITLE
Remove timeout

### DIFF
--- a/user_modules/shared_testcases/commonFunctions.lua
+++ b/user_modules/shared_testcases/commonFunctions.lua
@@ -497,7 +497,6 @@ function commonFunctions:verify_Unsuccess_Case(self, Request, ResultCode)
 
   --mobile side: expect the response
   EXPECT_RESPONSE(cid, { success = false, resultCode = ResultCode })
-  :Timeout(50)
 
   messageflag = true
 end


### PR DESCRIPTION
A 50 ms timeout was causing a lot of false negatives for certain test cases. Looking at the blame, I believe that this line had been changed to a higher value but then was readded as 50ms via a copy and paste error. I have decided to remove the timeout entirerly and let ATF use the default timeout instead.