### PR TITLE
Fix issue regarding long executuion of Postconditions

### DIFF
--- a/test_scripts/Smoke/Resumption/ATF_Resumption_3rd_ignition_cycle.lua
+++ b/test_scripts/Smoke/Resumption/ATF_Resumption_3rd_ignition_cycle.lua
@@ -99,7 +99,10 @@ function Test:IGNITION_OFF()
     EXPECT_NOTIFICATION("OnAppInterfaceUnregistered", { reason = "IGNITION_OFF" })
     EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
     EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-    SDL:DeleteFile()
+    :Do(function()
+        SDL:DeleteFile()
+        SDL:StopSDL()
+      end)
   end)
 end
 
@@ -114,7 +117,10 @@ function Test:IGNITION_OFF()
     self.hmiConnection:SendNotification("BasicCommunication.OnExitAllApplications",
       { reason = "IGNITION_OFF" })
     EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-    SDL:DeleteFile()
+    :Do(function()
+        SDL:DeleteFile()
+        SDL:StopSDL()
+      end)
   end)
 end
 

--- a/test_scripts/Smoke/Resumption/ATF_Resumption_FULL_IGNITION_OFF.lua
+++ b/test_scripts/Smoke/Resumption/ATF_Resumption_FULL_IGNITION_OFF.lua
@@ -79,7 +79,10 @@ function Test:IGNITION_OFF()
   end)
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
   EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-  SDL:DeleteFile()
+  :Do(function()
+      SDL:DeleteFile()
+      SDL:StopSDL()
+    end)
 end
 
 function Test:Restart_SDL_And_Add_Mobile_Connection()

--- a/test_scripts/Smoke/Resumption/ATF_Resumption_LIMITED_IGNITION_OFF.lua
+++ b/test_scripts/Smoke/Resumption/ATF_Resumption_LIMITED_IGNITION_OFF.lua
@@ -75,7 +75,10 @@ function Test:IGNITION_OFF()
   end)
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
   EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-  SDL:DeleteFile()
+  :Do(function()
+      SDL:DeleteFile()
+      SDL:StopSDL()
+    end)
 end
 
 function Test:Restart_SDL_And_Add_Mobile_Connection()

--- a/test_scripts/Smoke/Resumption/ATF_Resumption_app_registered_in_more_than_30sec_after_BC.OnReady.lua
+++ b/test_scripts/Smoke/Resumption/ATF_Resumption_app_registered_in_more_than_30sec_after_BC.OnReady.lua
@@ -75,7 +75,10 @@ function Test:IGNITION_OFF()
   end)
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
   EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-  SDL:DeleteFile()
+  :Do(function()
+      SDL:DeleteFile()
+      SDL:StopSDL()
+    end)
 end
 
 function Test:Restart_SDL_And_Add_Mobile_Connection()

--- a/test_scripts/Smoke/Resumption/ATF_Resumption_disconnect_more_than_30s_before_SUSPEND.lua
+++ b/test_scripts/Smoke/Resumption/ATF_Resumption_disconnect_more_than_30s_before_SUSPEND.lua
@@ -84,7 +84,10 @@ function Test:IGNITION_OFF()
       { reason = "IGNITION_OFF" })
   end)
   EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-  SDL:DeleteFile()
+  :Do(function()
+      SDL:DeleteFile()
+      SDL:StopSDL()
+    end)
 end
 
 function Test:Restart_SDL_And_Add_Mobile_Connection()

--- a/test_scripts/Smoke/ShutDown/ATF_ShutDown_IGNITION_OFF.lua
+++ b/test_scripts/Smoke/ShutDown/ATF_ShutDown_IGNITION_OFF.lua
@@ -68,7 +68,10 @@ function Test:ShutDown_IGNITION_OFF()
     EXPECT_NOTIFICATION("OnAppInterfaceUnregistered", { reason = "IGNITION_OFF" })
     EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
     EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-    SDL:DeleteFile()
+    :Do(function()
+        SDL:DeleteFile()
+        SDL:StopSDL()
+      end)
   end)
 end
 

--- a/test_scripts/Smoke/ShutDown/ATF_ShutDown_MASTER_RESET.lua
+++ b/test_scripts/Smoke/ShutDown/ATF_ShutDown_MASTER_RESET.lua
@@ -98,7 +98,10 @@ function Test:ShutDown_MASTER_RESET()
   EXPECT_NOTIFICATION("OnAppInterfaceUnregistered", { reason = "MASTER_RESET" })
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
   EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-  SDL:DeleteFile()
+  :Do(function()
+      SDL:DeleteFile()
+      SDL:StopSDL()
+    end)
 end
 
 --- Start SDL again then add mobile connection


### PR DESCRIPTION
Fix is related to the case when Postconditions step was executed a long time.
ATF did not close SDL logger in case if SDL was stopped successfully (Ignition Off, Factory Reset etc.)
There is also fix on ATF side in PR [#111](https://github.com/smartdevicelink/sdl_atf/pull/111) 