### PR TITLE
Fix check priority of events

### DIFF
--- a/test_scripts/Smoke/Registration/001_Register_5_connection.lua
+++ b/test_scripts/Smoke/Registration/001_Register_5_connection.lua
@@ -37,6 +37,7 @@ local mobile_session = require('mobile_session')
 local mobile  = require('mobile_connection')
 local tcp = require('tcp_connection')
 local file_connection  = require('file_connection')
+local events = require("events")
 
 --[[ General Settings for configuration ]]
 Test = require('user_modules/dummy_connecttest')

--- a/test_scripts/Smoke/Resumption/008_Resumption_heartbeat_disconnect.lua
+++ b/test_scripts/Smoke/Resumption/008_Resumption_heartbeat_disconnect.lua
@@ -27,6 +27,7 @@ local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
 local commonSteps = require('user_modules/shared_testcases/commonSteps')
 local commonStepsResumption = require('user_modules/shared_testcases/commonStepsResumption')
 local mobile_session = require('mobile_session')
+local events = require("events")
 
 --[[ General Settings for configuration ]]
 Test = require('user_modules/dummy_connecttest')
@@ -89,7 +90,7 @@ function Test:Wait_20_sec()
   :Timeout(20000)
   EXPECT_EVENT(events.disconnectedEvent, "Disconnected")
   :Do(function()
-      print("Disconnected!!!")      
+      print("Disconnected!!!")
     end)
   :Timeout(20000)
 end

--- a/user_modules/dummy_connecttest.lua
+++ b/user_modules/dummy_connecttest.lua
@@ -366,7 +366,7 @@ function module:initHMI_onReady(hmi_table)
       return
     end
     local event = events.Event()
-    event.level = 2
+    event.level = 1
     event.matches = function(self, data)
       return data.method == name
     end


### PR DESCRIPTION
Since it's possible to register the same expectations several times, user expectations have to have higher priority over system expectations.
Eg.: ```BC.UpdateAppList``` which is registered twice: 
1) in ```initHMI_onReady()``` of ```dummy_connecttest``` module
2) in ```Smoke/Registration/006_Reregister_App_if_two_apps_are_registered.lua```