### PR TITLE
Remove defaulting of 2nd version of SDL protocol

### DIFF
--- a/user_modules/shared_testcases/commonTestCases.lua
+++ b/user_modules/shared_testcases/commonTestCases.lua
@@ -7,7 +7,6 @@
 local commonTestCases = {}
 local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
 local commonSteps = require('user_modules/shared_testcases/commonSteps')
-local policyTable = require('user_modules/shared_testcases/testCasesForPolicyTable')
 local mobile_session = require('mobile_session')
 local events = require('events')
 


### PR DESCRIPTION
```testCasesForPolicyTable``` module is not used in ```commonTestCases``` module.
But in ```testCasesForPolicyTable``` module 2nd version of SDL protocol is defaulted.
So removing of this module from required list solves an issues with smoke tests.