### PR TITLE
Remove not required parameter 'keepContext' in responses for AUDIO module

### DIFF
--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/006_RPC_parameters_values.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/006_RPC_parameters_values.lua
@@ -81,14 +81,14 @@ local function fakeParam(pModuleType)
     })
   :Do(function(_, data)
       common.getHMIconnection():SendResponse(data.id, data.method, "SUCCESS", {
-          moduleData = common.getModuleControlData(pModuleType),
+          moduleData = common.getModuleControlDataForResponse(pModuleType),
           isSubscribed = true
         })
     end)
 
   mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
       isSubscribed = true,
-      moduleData = common.getModuleControlData(pModuleType)
+      moduleData = common.getModuleControlDataForResponse(pModuleType)
     })
 end
 

--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/012_Transfering_of_HMI_resultCode_to_mobile.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/012_Transfering_of_HMI_resultCode_to_mobile.lua
@@ -40,14 +40,14 @@ local function stepSuccessfull(pModuleType, pResultCode)
     })
   :Do(function(_, data)
       common.getHMIconnection():SendResponse(data.id, data.method, pResultCode, {
-          moduleData = common.getModuleControlData(pModuleType),
+          moduleData = common.getModuleControlDataForResponse(pModuleType),
           isSubscribed = false
         })
     end)
 
   mobileSession:ExpectResponse(cid, { success = true, resultCode = pResultCode,
       isSubscribed = false,
-      moduleData = common.getModuleControlData(pModuleType)
+      moduleData = common.getModuleControlDataForResponse(pModuleType)
     })
 end
 

--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/013_Absence_of_isSubscribed_parameter_in_case_request_from_Mob_app_without_subscribe_parameter_but_response_from_HMI_with_isSubscribed.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/013_Absence_of_isSubscribed_parameter_in_case_request_from_Mob_app_without_subscribe_parameter_but_response_from_HMI_with_isSubscribed.lua
@@ -36,7 +36,7 @@ local function getDataForModule(pModuleType, isSubscriptionActive)
     })
   :Do(function(_, data)
       common.getHMIconnection():SendResponse(data.id, data.method, "SUCCESS", {
-          moduleData = common.getModuleControlData(pModuleType),
+          moduleData = common.getModuleControlDataForResponse(pModuleType),
           isSubscribed = isSubscriptionActive -- return current value of subscription
         })
     end)
@@ -48,7 +48,7 @@ local function getDataForModule(pModuleType, isSubscriptionActive)
     end)
 
   mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-      moduleData = common.getModuleControlData(pModuleType)
+      moduleData = common.getModuleControlDataForResponse(pModuleType)
     })
   :ValidIf(function(_, data) -- no isSubscribed parameter
       if data.payload.isSubscribed == nil then

--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/014_Absence_of_subscribe_parameter_in_request_for_HMI_in_case_of_2nd_Subscription_UnSubscription.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/014_Absence_of_subscribe_parameter_in_request_for_HMI_in_case_of_2nd_Subscription_UnSubscription.lua
@@ -47,7 +47,7 @@ local function subscriptionToModule(pModuleType, pSubscribe)
     })
   :Do(function(_, data)
       common.getHMIconnection():SendResponse(data.id, data.method, "SUCCESS", {
-          moduleData = common.getModuleControlData(pModuleType),
+          moduleData = common.getModuleControlDataForResponse(pModuleType),
           isSubscribed = pSubscribe
         })
     end)
@@ -59,7 +59,7 @@ local function subscriptionToModule(pModuleType, pSubscribe)
     end)
 
   mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-      moduleData = common.getModuleControlData(pModuleType),
+      moduleData = common.getModuleControlDataForResponse(pModuleType),
       isSubscribed = pSubscribe
     })
 end

--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/015_Transfering_of_isSubscribed_parameter_in_case_request_from_Mob_app_with_subscribe_parameter_but_response_from_HMI_without_isSubscribed.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/015_Transfering_of_isSubscribed_parameter_in_case_request_from_Mob_app_with_subscribe_parameter_but_response_from_HMI_without_isSubscribed.lua
@@ -41,7 +41,7 @@ local function getDataForModule(pModuleType, isSubscriptionActive, pSubscribe)
     })
   :Do(function(_, data)
       common.getHMIconnection():SendResponse(data.id, data.method, "SUCCESS", {
-          moduleData = common.getModuleControlData(pModuleType),
+          moduleData = common.getModuleControlDataForResponse(pModuleType),
           -- no isSubscribed parameter
         })
     end)
@@ -54,7 +54,7 @@ local function getDataForModule(pModuleType, isSubscriptionActive, pSubscribe)
 
   mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
       isSubscribed = isSubscriptionActive, -- return current value of subscription
-      moduleData = common.getModuleControlData(pModuleType)
+      moduleData = common.getModuleControlDataForResponse(pModuleType)
     })
 end
 

--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/OnInteriorVehicleData/005_Absence_of_OnIVD_in_case_of_successfull_subscribing_with_isSubscribe_false_from_HMI.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/OnInteriorVehicleData/005_Absence_of_OnIVD_in_case_of_successfull_subscribing_with_isSubscribe_false_from_HMI.lua
@@ -40,13 +40,13 @@ local function subscriptionToModule(pModuleType)
     })
   :Do(function(_, data)
       common.getHMIconnection():SendResponse(data.id, data.method, "SUCCESS", {
-          moduleData = common.getModuleControlData(pModuleType),
+          moduleData = common.getModuleControlDataForResponse(pModuleType),
           isSubscribed = false -- not subscribe
         })
     end)
 
   mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-      moduleData = common.getModuleControlData(pModuleType),
+      moduleData = common.getModuleControlDataForResponse(pModuleType),
       isSubscribed = false
     })
 end

--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/OnInteriorVehicleData/009_Existence_of_OnIVD_in_case_of_successfull_unsubscribing_with_isSubscribe_true_from_HMI.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/OnInteriorVehicleData/009_Existence_of_OnIVD_in_case_of_successfull_unsubscribing_with_isSubscribe_true_from_HMI.lua
@@ -41,13 +41,13 @@ local function unSubscriptionToModule(pModuleType)
     })
   :Do(function(_, data)
       common.getHMIconnection():SendResponse(data.id, data.method, "SUCCESS", {
-          moduleData = common.getModuleControlData(pModuleType),
+          moduleData = common.getModuleControlDataForResponse(pModuleType),
           isSubscribed = true -- HMI responds with true
         })
     end)
 
   mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-      moduleData = common.getModuleControlData(pModuleType),
+      moduleData = common.getModuleControlDataForResponse(pModuleType),
       isSubscribed = true
     })
 end

--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/OnInteriorVehicleData/010_Existence_of_OnIVD_in_case_of_successfull_unsubscribing_without_isSubscribe_from_HMI.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/OnInteriorVehicleData/010_Existence_of_OnIVD_in_case_of_successfull_unsubscribing_without_isSubscribe_from_HMI.lua
@@ -41,13 +41,13 @@ local function unSubscriptionToModule(pModuleType)
     })
   :Do(function(_, data)
       common.getHMIconnection():SendResponse(data.id, data.method, "SUCCESS", {
-          moduleData = common.getModuleControlData(pModuleType),
+          moduleData = common.getModuleControlDataForResponse(pModuleType),
           -- no isSubscribed parameter
         })
     end)
 
   mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-      moduleData = common.getModuleControlData(pModuleType),
+      moduleData = common.getModuleControlDataForResponse(pModuleType),
       isSubscribed = true
     })
 end

--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/commonRCmodules.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/commonRCmodules.lua
@@ -614,4 +614,12 @@ function c.updateDefaultCapabilities(pDisabledModuleTypes)
   commonRC.tableToJsonFile(hmiCapTbl, hmiCapabilitiesFile)
 end
 
+function c.getModuleControlDataForResponse(pModuleType)
+  local moduleData = c.getModuleControlData(pModuleType)
+  if moduleData.audioControlData then
+    moduleData.audioControlData.keepContext = nil
+  end
+  return moduleData
+end
+
 return c


### PR DESCRIPTION
According to proposal 'keepContext' parameter is not required for the responses for AUDIO module, so it's need to be removed.