### PR TITLE
Expanded coverage with STATIC image type and not PNG file type

### DIFF
--- a/test_scripts/Image_template/001_isTemplate_is_true.lua
+++ b/test_scripts/Image_template/001_isTemplate_is_true.lua
@@ -23,9 +23,9 @@ runner.Step("Clean environment", common.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("Register App", common.registerApp)
 runner.Step("Activate App", common.activateApp)
+runner.Step("Adding PNG file via PutFile", common.putFile)
 
 runner.Title("Test")
-runner.Step("Adding PNG file via PutFile", common.putFile)
 runner.Step("AddCommand with isTemplate = true", common.addCommand, { true })
 runner.Step("Alert with isTemplate = true in SoftButtons", common.alert, { true })
 

--- a/test_scripts/Image_template/003_isTemplate_is_absent.lua
+++ b/test_scripts/Image_template/003_isTemplate_is_absent.lua
@@ -23,9 +23,9 @@ runner.Step("Clean environment", common.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("Register App", common.registerApp)
 runner.Step("Activate App", common.activateApp)
+runner.Step("Adding PNG file via PutFile", common.putFile)
 
 runner.Title("Test")
-runner.Step("Adding PNG file via PutFile", common.putFile)
 runner.Step("AddCommand without isTemplate", common.addCommand)
 runner.Step("Alert without isTemplate in SoftButtons", common.alert)
 

--- a/test_scripts/Image_template/004_isTemplate_invalid_type.lua
+++ b/test_scripts/Image_template/004_isTemplate_invalid_type.lua
@@ -23,9 +23,9 @@ runner.Step("Clean environment", common.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("Register App", common.registerApp)
 runner.Step("Activate App", common.activateApp)
+runner.Step("Adding PNG file via PutFile", common.putFile)
 
 runner.Title("Test")
-runner.Step("Adding PNG file via PutFile", common.putFile)
 runner.Step("AddCommand with isTemplate = 123", common.rpcInvalidData, { 123, "AddCommand" } )
 runner.Step("Alert with isTemplate = '123' in SoftButtons", common.rpcInvalidData, { "123", "Alert" })
 

--- a/test_scripts/Image_template/005_isTemplate_is_true_with_not_png_image.lua
+++ b/test_scripts/Image_template/005_isTemplate_is_true_with_not_png_image.lua
@@ -1,0 +1,60 @@
+---------------------------------------------------------------------------------------------------
+-- User story: TBD
+-- Use case: TBD
+--
+-- Requirement summary: TBD
+--
+-- Description:
+-- In case:
+-- Mobile application sends request with isTemplate = true and not png image
+-- SDL must:
+-- send request with received paramters to HMI
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/Image_template/commonImageTemplate')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local fileName = "action.jpeg"
+
+local putFileParams = {
+	requestParams = {
+	    syncFileName = fileName,
+	    fileType = "GRAPHIC_JPEG",
+	},
+	filePath = "files/" .. fileName
+}
+
+local pathToFile = common.getPathToFileInStorage(fileName)
+
+local paramsAlert = common.alertParams()
+paramsAlert.requestParams.softButtons[1].image.value = fileName
+paramsAlert.requestParams.softButtons[1].image.isTemplate = true
+paramsAlert.responseUiParams.softButtons[1].image.value = pathToFile
+paramsAlert.responseUiParams.softButtons[1].image.isTemplate = true
+
+local paramsAddCommand = common.addCommandParams()
+paramsAddCommand.requestParams.cmdIcon.value = fileName
+paramsAddCommand.requestParams.cmdIcon.isTemplate = true
+paramsAddCommand.responseUiParams.cmdIcon.value = pathToFile
+paramsAddCommand.responseUiParams.cmdIcon.isTemplate = true
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("Register App", common.registerApp)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("Adding JPEG file via PutFile", common.putFile, { putFileParams })
+runner.Step("AddCommand with isTemplate = true with jpeg icon", common.rpcWithCustomResultCode,
+	{ "AddCommand", paramsAddCommand, "WARNINGS", true })
+runner.Step("Alert with isTemplate = true and jpeg icon in SoftButtons", common.rpcWithCustomResultCode,
+	{ "Alert", paramsAlert, "WARNINGS", true })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Image_template/006_isTemplate_is_true_with_STATIC_image.lua
+++ b/test_scripts/Image_template/006_isTemplate_is_true_with_STATIC_image.lua
@@ -6,9 +6,9 @@
 --
 -- Description:
 -- In case:
--- Mobile application sends request with isTemplate = false
+-- Mobile application sends request with isTemplate = true and STATIC image type
 -- SDL must:
--- send isTemplate = false to HMI
+-- send request with received paramters to HMI
 ---------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -16,6 +16,17 @@ local common = require('test_scripts/Image_template/commonImageTemplate')
 
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local fileName = "icon.png"
+
+local paramsAddCommand = common.addCommandParams()
+paramsAddCommand.requestParams.cmdIcon.imageType = "STATIC"
+paramsAddCommand.requestParams.cmdIcon.value = fileName
+paramsAddCommand.requestParams.cmdIcon.isTemplate = true
+paramsAddCommand.responseUiParams.cmdIcon.value = fileName
+paramsAddCommand.responseUiParams.cmdIcon.isTemplate = true
+paramsAddCommand.responseUiParams.cmdIcon.imageType = "STATIC"
 
 --[[ Scenario ]]
 runner.Title("Preconditions")
@@ -26,8 +37,8 @@ runner.Step("Activate App", common.activateApp)
 runner.Step("Adding PNG file via PutFile", common.putFile)
 
 runner.Title("Test")
-runner.Step("AddCommand with isTemplate = false", common.addCommand, { false })
-runner.Step("Alert with isTemplate = false in SoftButtons", common.alert, { false })
+runner.Step("AddCommand with isTemplate = true with STATIC image type", common.rpcWithCustomResultCode,
+	{ "AddCommand", paramsAddCommand, "UNSUPPORTED_RESOURCE", true })
 
 runner.Title("Postconditions")
 runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Image_template/commonImageTemplate.lua
+++ b/test_scripts/Image_template/commonImageTemplate.lua
@@ -22,7 +22,7 @@ local putFileParams = {
 }
 
 --[[ Functions ]]
-local function addCommandParams()
+function m.addCommandParams()
 	local requestParams = {
 		cmdID = 11,
 		menuParams = {
@@ -47,7 +47,7 @@ local function addCommandParams()
 	 return params
 end
 
-local function alertParams()
+function m.alertParams()
 	local requestParams = {
 	alertText1 = "alertText1",
 	alertText2 = "alertText2",
@@ -103,7 +103,7 @@ function m.putFile(pParams)
 end
 
 function m.addCommand(pIsTemplate, pParams)
-	if not pParams then pParams = addCommandParams() end
+	if not pParams then pParams = m.addCommandParams() end
 	if pIsTemplate == true or pIsTemplate == false then
 		pParams.requestParams.cmdIcon.isTemplate = pIsTemplate
 		pParams.responseUiParams.cmdIcon.isTemplate = pIsTemplate
@@ -129,10 +129,10 @@ end
 function m.rpcInvalidData(pIsTemplate, pRpc)
 	local params
 	if "AddCommand" == pRpc then
-		params = addCommandParams()
+		params = m.addCommandParams()
 		params.requestParams.cmdIcon.isTemplate = pIsTemplate
 	else
-		params = alertParams()
+		params = m.alertParams()
 		params.requestParams.softButtons[1].image.isTemplate = pIsTemplate
 	end
 	local mobSession = m.getMobileSession()
@@ -151,7 +151,7 @@ local function sendOnSystemContext(pCtx)
 end
 
 function m.alert(pIsTemplate, pParams)
-	if not pParams then pParams = alertParams() end
+	if not pParams then pParams = m.alertParams() end
 	local mobSession = m.getMobileSession()
 	if pIsTemplate then
 		pParams.requestParams.softButtons[1].image.isTemplate = pIsTemplate
@@ -179,6 +179,18 @@ function m.alert(pIsTemplate, pParams)
         { systemContext = "ALERT"},
         { systemContext = "MAIN"})
 	mobSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS"})
+end
+
+function m.rpcWithCustomResultCode(pRPC, pParams, pResultCode, pSuccess)
+	local mobSession = m.getMobileSession()
+	local hmiConnection = m.getHMIConnection()
+	local cid = mobSession:SendRPC(pRPC, pParams.requestParams)
+	pParams.responseUiParams.appID = m.getHMIAppId()
+	EXPECT_HMICALL("UI." .. pRPC, pParams.responseUiParams)
+	:Do(function(_,data)
+		hmiConnection:SendResponse(data.id, data.method, pResultCode, {})
+	end)
+	mobSession:ExpectResponse(cid, { success = pSuccess, resultCode = pResultCode})
 end
 
 return m

--- a/test_sets/template_images.txt
+++ b/test_sets/template_images.txt
@@ -2,3 +2,5 @@
 ./test_scripts/Image_template/002_isTemplate_is_false.lua
 ./test_scripts/Image_template/003_isTemplate_is_absent.lua
 ./test_scripts/Image_template/004_isTemplate_invalid_type.lua
+./test_scripts/Image_template/005_isTemplate_is_true_with_not_png_image.lua
+./test_scripts/Image_template/006_isTemplate_is_true_with_STATIC_image.lua


### PR DESCRIPTION
Expanded coverage with STATIC image type and not PNG file type according to clarification in https://github.com/smartdevicelink/sdl_requirements/issues/53