### PR TITLE
Remove dependency on PTU in smoke test scripts

### DIFF
--- a/test_scripts/Smoke/API/001_SetGlobalProperties_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/001_SetGlobalProperties_PositiveCase_SUCCESS.lua
@@ -132,7 +132,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 

--- a/test_scripts/Smoke/API/002_ResetGlobalProperties_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/002_ResetGlobalProperties_PositiveCase_SUCCESS.lua
@@ -114,7 +114,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/003_AddCommand_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/003_AddCommand_PositiveCase_SUCCESS.lua
@@ -113,7 +113,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 

--- a/test_scripts/Smoke/API/004_DeleteCommand_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/004_DeleteCommand_PositiveCase_SUCCESS.lua
@@ -140,7 +140,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 runner.Step("AddCommand", addCommand, {addCommandAllParams})

--- a/test_scripts/Smoke/API/005_AddSubMenu_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/005_AddSubMenu_PositiveCase_SUCCESS.lua
@@ -69,7 +69,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/006_DeleteSubMenu_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/006_DeleteSubMenu_PositiveCase_SUCCESS.lua
@@ -87,7 +87,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("AddSubMenu", addSubMenu, {addSubMenuAllParams})
 

--- a/test_scripts/Smoke/API/007_Alert_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/007_Alert_PositiveCase_SUCCESS.lua
@@ -206,7 +206,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 

--- a/test_scripts/Smoke/API/008_CreateInteractionChoiceSet_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/008_CreateInteractionChoiceSet_PositiveCase_SUCCESS.lua
@@ -99,7 +99,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 

--- a/test_scripts/Smoke/API/009_DeleteInteractionChoiceSet_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/009_DeleteInteractionChoiceSet_PositiveCase_SUCCESS.lua
@@ -126,7 +126,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 runner.Step("CreateInteractionChoiceSet", createInteractionChoiceSet, {createAllParams})

--- a/test_scripts/Smoke/API/010_DeleteFile_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/010_DeleteFile_PositiveCase_SUCCESS.lua
@@ -72,7 +72,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 

--- a/test_scripts/Smoke/API/011_ListFiles_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/011_ListFiles_PositiveCase_SUCCESS.lua
@@ -83,7 +83,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 for i, fileName in ipairs(testFileNamesList) do
 	runner.Step("Upload test file #" .. i, putFile, {fileName})

--- a/test_scripts/Smoke/API/012_PerfomInteraction_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/012_PerfomInteraction_PositiveCase_SUCCESS.lua
@@ -340,7 +340,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 runner.Step("CreateInteractionChoiceSet with id 100", CreateInteractionChoiceSet, {100})

--- a/test_scripts/Smoke/API/013_ScrollableMessage_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/013_ScrollableMessage_PositiveCase_SUCCESS.lua
@@ -112,7 +112,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 

--- a/test_scripts/Smoke/API/014_SetMediaClockTimer_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/014_SetMediaClockTimer_PositiveCase_SUCCESS.lua
@@ -68,7 +68,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/015_Show_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/015_Show_PositiveCase_SUCCESS.lua
@@ -123,7 +123,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, { putFileParams })
 

--- a/test_scripts/Smoke/API/016_ShowConstantTBT_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/016_ShowConstantTBT_PositiveCase_SUCCESS.lua
@@ -111,19 +111,6 @@ local allParams = {
 }
 
 --[[ Local Functions ]]
-local function PTUpdateFuncRPC(tbl)
-  local ShowCTBT = {
-    rpcs = {
-      ShowConstantTBT = {
-        hmi_levels = { "NONE", "BACKGROUND", "FULL", "LIMITED" }
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = ShowCTBT
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function showConstantTBT(params, self)
   local cid = self.mobileSession1:SendRPC("ShowConstantTBT", params.requestParams)
   params.responseUiParams.appID = commonSmoke.getHMIAppId()
@@ -141,7 +128,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { nil, PTUpdateFuncRPC })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 

--- a/test_scripts/Smoke/API/017_Slider_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/017_Slider_PositiveCase_SUCCESS.lua
@@ -64,7 +64,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/018_SendLocation_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/018_SendLocation_PositiveCase_SUCCESS.lua
@@ -59,19 +59,6 @@ local requestParams = {
 }
 
 --[[ Local Functions ]]
-local function ptuUpdateFuncRPC(tbl)
-  local SLgroup = {
-    rpcs = {
-      SendLocation = {
-        hmi_levels = { "NONE", "BACKGROUND", "FULL", "LIMITED" }
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = SLgroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function sendLocation(params, self)
   local cid = self.mobileSession1:SendRPC("SendLocation", params)
   params.appID = commonSmoke.getHMIAppId()
@@ -87,7 +74,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, ptuUpdateFuncRPC })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, { putFileParams })
 

--- a/test_scripts/Smoke/API/019_SetAppIcon_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/019_SetAppIcon_PositiveCase_SUCCESS.lua
@@ -73,7 +73,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, { putFileParams })
 

--- a/test_scripts/Smoke/API/020_SetDisplayLayout_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/020_SetDisplayLayout_PositiveCase_SUCCESS.lua
@@ -230,7 +230,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/021_Speak_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/021_Speak_PositiveCase_SUCCESS.lua
@@ -74,7 +74,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/022_SubscribeButton_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/022_SubscribeButton_PositiveCase_SUCCESS.lua
@@ -61,7 +61,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/023_UnsubscribeButton_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/023_UnsubscribeButton_PositiveCase_SUCCESS.lua
@@ -70,7 +70,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 for _, v in pairs(buttonName) do
   runner.Step("SubscribeButton " .. v .. " Positive Case", subscribeButtons, { v })

--- a/test_scripts/Smoke/API/024_SubscribeVehicleData_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/024_SubscribeVehicleData_PositiveCase_SUCCESS.lua
@@ -68,19 +68,6 @@ local allParams = {
 }
 
 --[[ Local Functions ]]
-local function PTUpdateFunc(tbl)
-  local SVDgroup = {
-    rpcs = {
-      SubscribeVehicleData = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = SVDgroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function setVDRequest()
   local tmp = {}
   for k, _ in pairs(VDValues) do
@@ -121,7 +108,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, PTUpdateFunc })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/025_UnsubscribeVehicleData_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/025_UnsubscribeVehicleData_PositiveCase_SUCCESS.lua
@@ -68,22 +68,6 @@ local allParams = {
 }
 
 --[[ Local Functions ]]
-local function PTUpdateFunc(tbl)
-  local SVDgroup = {
-    rpcs = {
-      SubscribeVehicleData = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      },
-      UnsubscribeVehicleData = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = SVDgroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function setVDRequest()
   local tmp = {}
   for k, _ in pairs(VDValues) do
@@ -134,7 +118,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, PTUpdateFunc })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("SubscribeVehicleData", subscribeVD, { allParams })
 

--- a/test_scripts/Smoke/API/026_GetVehicleData_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/026_GetVehicleData_PositiveCase_SUCCESS.lua
@@ -164,19 +164,6 @@ local allParams = {
 }
 
 --[[ Local Functions ]]
-local function PTUpdateFunc(tbl)
-  local SVDgroup = {
-    rpcs = {
-      GetVehicleData = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = SVDgroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function getVD(pParams, self)
   local cid = self.mobileSession1:SendRPC("GetVehicleData", pParams.requestParams)
   EXPECT_HMICALL("VehicleInfo.GetVehicleData", pParams.requestParams)
@@ -193,7 +180,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, PTUpdateFunc })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/027_UpdateTurnList_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/027_UpdateTurnList_PositiveCase_SUCCESS.lua
@@ -83,19 +83,6 @@ local allParams = {
 }
 
 --[[ Local Functions ]]
-local function ptuUpdateFunc(tbl)
-  local UpdateTurnListGroup = {
-    rpcs = {
-      UpdateTurnList = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = UpdateTurnListGroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function updateTurnList(pParams, self)
   local cid = self.mobileSession1:SendRPC("UpdateTurnList", pParams.requestParams)
   EXPECT_HMICALL("Navigation.UpdateTurnList", pParams.responseUiParams)
@@ -109,7 +96,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, ptuUpdateFunc })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, { putFileParams })
 

--- a/test_scripts/Smoke/API/028_AlertManeuver_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/028_AlertManeuver_PositiveCase_SUCCESS.lua
@@ -107,19 +107,6 @@ local allParams = {
 }
 
 --[[ Local Functions ]]
-local function PTUpdateFunc(tbl)
-  local AlertMgroup = {
-    rpcs = {
-      AlertManeuver = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = AlertMgroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function alertManeuver(pParams, self)
   local cid = self.mobileSession1:SendRPC("AlertManeuver", pParams.requestParams)
   EXPECT_HMICALL("Navigation.AlertManeuver", pParams.responseNaviParams)
@@ -149,7 +136,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, PTUpdateFunc })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, { putFileParams })
 

--- a/test_scripts/Smoke/API/029_OnDriverDistraction_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/029_OnDriverDistraction_PositiveCase_SUCCESS.lua
@@ -43,7 +43,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/030_DialNumber_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/030_DialNumber_PositiveCase_SUCCESS.lua
@@ -37,19 +37,6 @@ local requestParams = {
 }
 
 --[[ Local Functions ]]
-local function PTUpdateFuncRPC(tbl)
-  local DialNumberGroup = {
-    rpcs = {
-      DialNumber = {
-        hmi_levels = { "NONE", "BACKGROUND", "FULL", "LIMITED" }
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = DialNumberGroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function dialNumber(pParams, self)
   local cid = self.mobileSession1:SendRPC("DialNumber", pParams)
   pParams.appID = commonSmoke.getHMIAppId()
@@ -64,7 +51,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, PTUpdateFuncRPC })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/031_PerformAudioPassThru_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/031_PerformAudioPassThru_PositiveCase_SUCCESS.lua
@@ -137,7 +137,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/032_EndAudioPassThru_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/032_EndAudioPassThru_PositiveCase_SUCCESS.lua
@@ -119,7 +119,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/033_ReadDID_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/033_ReadDID_PositiveCase_SUCCESS.lua
@@ -32,19 +32,6 @@ local runner = require('user_modules/script_runner')
 local commonSmoke = require('test_scripts/Smoke/commonSmoke')
 
 --[[ Local Functions ]]
-local function PTUpdateFunc(tbl)
-  local ReadDIDgroup = {
-    rpcs = {
-      ReadDID = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = ReadDIDgroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function setReadDIDRequest()
   local temp = {
     ecuName = 2000,
@@ -88,7 +75,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, PTUpdateFunc})
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/034_GetDTCs_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/034_GetDTCs_PositiveCase_SUCCESS.lua
@@ -31,18 +31,6 @@ local runner = require('user_modules/script_runner')
 local commonSmoke = require('test_scripts/Smoke/commonSmoke')
 
 --[[ Local Functions ]]
-local function PTUpdateFunc(tbl)
-  local GetDTCs = {
-    rpcs = {
-      GetDTCs = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = GetDTCs
-  tbl.policy_table.app_policies[commonSmoke.getMobileAppId()].groups = { "Base-4", "NewTestCaseGroup" }
-end
-
 local function getDTCsSuccess(self)
   local requestParams = {
     ecuName = 2,
@@ -73,7 +61,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, PTUpdateFunc })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/035_ChangeRegistration_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/035_ChangeRegistration_PositiveCase_SUCCESS.lua
@@ -85,7 +85,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/036_UnregisterAppInterface_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/036_UnregisterAppInterface_PositiveCase_SUCCESS.lua
@@ -40,7 +40,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/037_RegisterAppInterface_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/037_RegisterAppInterface_PositiveCase_SUCCESS.lua
@@ -105,7 +105,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("UnregisterAppInterface Positive Case", unregisterAppInterface)
 

--- a/test_scripts/Smoke/API/038_Alert_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/038_Alert_Non_Media_PositiveCase_SUCCESS.lua
@@ -212,7 +212,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 

--- a/test_scripts/Smoke/API/039_PerfomInteraction_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/039_PerfomInteraction_Non_Media_PositiveCase_SUCCESS.lua
@@ -334,7 +334,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, {putFileParams})
 runner.Step("CreateInteractionChoiceSet with id 100", CreateInteractionChoiceSet, {100})

--- a/test_scripts/Smoke/API/040_SetMediaClockTimer_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/040_SetMediaClockTimer_Non_Media_PositiveCase_SUCCESS.lua
@@ -68,7 +68,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/041_Speak_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/041_Speak_Non_Media_PositiveCase_SUCCESS.lua
@@ -74,7 +74,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/042_SubscribeButton_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/042_SubscribeButton_Non_Media_PositiveCase_SUCCESS.lua
@@ -76,7 +76,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/Smoke/API/043_UnsubscribeButton_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/043_UnsubscribeButton_Non_Media_PositiveCase_SUCCESS.lua
@@ -85,7 +85,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 for _, v in pairs(buttonName) do
   runner.Step("SubscribeButton " .. v .. " Positive Case", subscribeButtons, { v })

--- a/test_scripts/Smoke/API/044_AlertManeuver_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/044_AlertManeuver_Non_Media_PositiveCase_SUCCESS.lua
@@ -110,19 +110,6 @@ local allParams = {
 }
 
 --[[ Local Functions ]]
-local function PTUpdateFunc(tbl)
-  local AlertMgroup = {
-    rpcs = {
-      AlertManeuver = {
-        hmi_levels = { "BACKGROUND", "FULL", "LIMITED" },
-      }
-    }
-  }
-  tbl.policy_table.functional_groupings.NewTestCaseGroup = AlertMgroup
-  tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.appID].groups =
-  { "Base-4", "NewTestCaseGroup" }
-end
-
 local function alertManeuver(pParams, self)
   local cid = self.mobileSession1:SendRPC("AlertManeuver", pParams.requestParams)
   EXPECT_HMICALL("Navigation.AlertManeuver", pParams.responseNaviParams)
@@ -150,7 +137,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU, { 1, PTUpdateFunc })
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 runner.Step("Upload icon file", commonSmoke.putFile, { putFileParams })
 

--- a/test_scripts/Smoke/API/045_PerformAudioPassThru_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/045_PerformAudioPassThru_Non_Media_PositiveCase_SUCCESS.lua
@@ -138,7 +138,7 @@ end
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
-runner.Step("RAI, PTU", commonSmoke.registerApplicationWithPTU)
+runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")


### PR DESCRIPTION
Sometimes PTU sequence may fail due to issues in SDL.
Currently this sequence is included in most of the smoke test scripts.
This PR removes this PTU sequence from most of the smoke script. This makes scripts more specific and they all won't fail due to PTU issue in SDL.