### PR TITLE
Add `secondaryGraphic` to SetDisplayLayout smoke test

### DIFF
--- a/test_scripts/Smoke/API/020_SetDisplayLayout_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/020_SetDisplayLayout_PositiveCase_SUCCESS.lua
@@ -87,6 +87,7 @@ local function getDisplayCapImageFieldsValues()
 		"menuIcon",
 		"cmdIcon",
 		"graphic",
+		"secondaryGraphic",
 		"showConstantTBTIcon",
 		"showConstantTBTNextTurnIcon"
 	}


### PR DESCRIPTION
Tests for [SDL-0151](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0151-imagefieldname-for-secondary-image.md)