### PR TITLE
Script for reproducing issue 1867

### DIFF
--- a/test_scripts/Defects/5_0/1867_SDL_does_not_respond_to_HMI_request_with_wrong_type_of_params.lua
+++ b/test_scripts/Defects/5_0/1867_SDL_does_not_respond_to_HMI_request_with_wrong_type_of_params.lua
@@ -1,0 +1,37 @@
+---------------------------------------------------------------------------------------------------
+-- User story: https://github.com/SmartDeviceLink/sdl_core/issues/1867
+--
+-- Precondition:
+-- 1) Core, HMI started.
+-- 2) App is registered on HMI.
+-- Description:
+-- SDL does not respond to HMI request with wrong type of parameters.
+-- Steps to reproduce:
+-- 1) HMI sends SDL.GetUserFriendlyMessage request with wrong type(Integer) of parameter messageCodes.
+-- Expected:
+-- SDL responds with code INVALID_DATA to HMI.
+-- Actual result
+-- SDL does not send response to HMI.
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/Defects/commonDefects')
+
+-- [[ Local Functions ]]
+local function GetUserFriendlyMessage(self)
+	local RequestId = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = 1} )
+	EXPECT_HMIRESPONSE(RequestId,{result = {code = 11, method = "SDL.GetUserFriendlyMessage"}})
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("App registration, PTU", common.rai_n)
+runner.Step("Activate App", common.activate_app)
+
+runner.Title("Test")
+runner.Step("SDL sends GetUserFriendlyMessage request with wrong type", GetUserFriendlyMessage)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)


### PR DESCRIPTION
Script for reproducing issue [SDL does not respond to HMI request with wrong type of params](https://github.com/smartdevicelink/sdl_core/issues/1867)