### PR TITLE
Script for reproducing issue 1868

### DIFF
--- a/test_scripts/Defects/4_6/1868_SDL_does_not_respond_to_HMI_request_with_empty_string_parameter.lua
+++ b/test_scripts/Defects/4_6/1868_SDL_does_not_respond_to_HMI_request_with_empty_string_parameter.lua
@@ -1,0 +1,44 @@
+---------------------------------------------------------------------------------------------------
+-- User story: https://github.com/SmartDeviceLink/sdl_core/issues/1868
+--
+-- Precondition:
+-- 1) Core, HMI started.
+-- 2) App is registered on HMI.
+-- Description:
+-- SDL does not respond to HMI request with empty string parameter.
+-- Steps to reproduce:
+-- 1) HMI sends SDL.GetUserFriendlyMessage request with empty string in messageCodes.
+-- Expected result:
+-- SDL responds with code INVALID_DATA to HMI.
+-- Actual result:
+-- SDL does not send response to HMI.
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/Defects/commonDefects')
+
+--[[ Local Functions ]]
+local function GetUserFriendlyMessage(self)
+	local RequestId = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = {{""}}} )
+	EXPECT_HMIRESPONSE(RequestId,{result = {code = 11, method = "SDL.GetUserFriendlyMessage"}})
+	:ValidIf(function(_, data)
+		if data.result.code ==11 then
+			return true
+		else
+			return false,"SDL responds with code:".. tostring(data.result.code) .. " to request with invalid characters from HMI"
+		end
+	end)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI, PTU", common.rai_ptu)
+runner.Step("Activate App", common.activate_app)
+
+runner.Title("Test")
+runner.Step("GetUserFriendlyMessage_request_with_empty_string_in_messageCodes", GetUserFriendlyMessage)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Defects/5_0/1868_SDL_does_not_respond_to_HMI_request_with_empty_string_parameter.lua
+++ b/test_scripts/Defects/5_0/1868_SDL_does_not_respond_to_HMI_request_with_empty_string_parameter.lua
@@ -7,7 +7,7 @@
 -- Description:
 -- SDL does not respond to HMI request with empty string parameter.
 -- Steps to reproduce:
--- 1) HMI sends SDL.GetUserFriendlyMessage request with empty string in messageCodes.
+-- 1) HMI sends SDL.GetUserFriendlyMessage request with empty string in messageCodes
 -- Expected result:
 -- SDL responds with code INVALID_DATA to HMI.
 -- Actual result:
@@ -19,15 +19,9 @@ local common = require('test_scripts/Defects/commonDefects')
 
 --[[ Local Functions ]]
 local function GetUserFriendlyMessage(self)
-	local RequestId = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = {{""}}} )
+	local RequestId = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage",
+		{language = "EN-US", messageCodes = {""} })
 	EXPECT_HMIRESPONSE(RequestId,{result = {code = 11, method = "SDL.GetUserFriendlyMessage"}})
-	:ValidIf(function(_, data)
-		if data.result.code ==11 then
-			return true
-		else
-			return false,"SDL responds with code:".. tostring(data.result.code) .. " to request with invalid characters from HMI"
-		end
-	end)
 end
 
 --[[ Scenario ]]
@@ -35,7 +29,6 @@ runner.Title("Preconditions")
 runner.Step("Clean environment", common.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("RAI, PTU", common.rai_ptu)
-runner.Step("Activate App", common.activate_app)
 
 runner.Title("Test")
 runner.Step("GetUserFriendlyMessage_request_with_empty_string_in_messageCodes", GetUserFriendlyMessage)


### PR DESCRIPTION
Script for reproducing issue [SDL does not respond to HMI request with empty string parameter](https://github.com/smartdevicelink/sdl_core/issues/1868)