### PR TITLE
SDL_0042 tests for image not available in storage

### DIFF
--- a/test_scripts/API/ATF_AddCommand.lua
+++ b/test_scripts/API/ATF_AddCommand.lua
@@ -1276,6 +1276,56 @@ end
 				end		
 			--End Test case CommonRequestCheck.4.9
 			
+      -----------------------------------------------------------------------------------------
+
+      --Begin Test case CommonRequestCheck.4.10
+      --Description: Mandatory missing - vrCommands
+        function Test:AddCommand_iconNotSent()
+          --mobile side: sending AddCommand request
+          local cid = self.mobileSession:SendRPC("AddCommand",
+                              {
+                                cmdID = 511,
+                                menuParams =
+                                {
+                                  parentID = 1,
+                                  position = 0,
+                                  menuName ="Command511"
+                                },
+                                cmdIcon =
+                                {
+                                  value ="missed_icon.png",
+                                  imageType ="DYNAMIC"
+                                }
+                              })
+
+          --hmi side: expect UI.AddCommand request
+          EXPECT_HMICALL("UI.AddCommand",
+                  {
+                    cmdID = 511,
+                    menuParams =
+                    {
+                      parentID = 1,
+                      position = 0,
+                      menuName ="Command511"
+                    },
+                    cmdIcon =
+                    {
+                      value ="missed_icon.png",
+                      imageType ="DYNAMIC"
+                    }
+                  })
+          :Do(function(_,data)
+            --hmi side: sending UI.AddCommand response
+            self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {info = "Requested image(s) not found."})
+          end)
+
+          --mobile side: expect AddCommand response
+          EXPECT_RESPONSE(cid, { success = true, resultCode = "WARNINGS" })
+
+          --mobile side: expect OnHashChange notification
+          EXPECT_NOTIFICATION("OnHashChange")
+        end
+      --End Test case CommonRequestCheck.4.10
 		--End Test case CommonRequestCheck.4
 		
 		-----------------------------------------------------------------------------------------

--- a/test_scripts/API/ATF_AlertManeuver.lua
+++ b/test_scripts/API/ATF_AlertManeuver.lua
@@ -1328,6 +1328,309 @@ end
 
 		--End Test case CommonRequestCheck.6
 
+    --Begin Test case CommonRequestCheck.7
+    --Description: Positive case and in boundary conditions (with conditional parameters) and invalid image
+    
+      function Test:AlertManeuver_InvalidImage() 
+
+        --mobile side: AlertManeuver request 
+        local CorIdAlertM = self.mobileSession:SendRPC("AlertManeuver",
+                                {
+                                     
+                                  ttsChunks = 
+                                  { 
+                                    
+                                    { 
+                                      text ="FirstAlert",
+                                      type ="TEXT",
+                                    }, 
+                                    
+                                    { 
+                                      text ="SecondAlert",
+                                      type ="TEXT",
+                                    }, 
+                                  }, 
+                                  softButtons = 
+                                  { 
+                                    
+                                    { 
+                                      type = "BOTH",
+                                      text = "Close",
+                                       image = 
+                                
+                                      { 
+                                        value = "icon.png",
+                                        imageType = "DYNAMIC",
+                                      }, 
+                                      isHighlighted = true,
+                                      softButtonID = 7821,
+                                      systemAction = "DEFAULT_ACTION",
+                                    }, 
+                                    
+                                    { 
+                                      type = "BOTH",
+                                      text = "AnotherClose",
+                                       image = 
+                                
+                                      { 
+                                        value = "notavailable.png",
+                                        imageType = "DYNAMIC",
+                                      }, 
+                                      isHighlighted = false,
+                                      softButtonID = 7822,
+                                      systemAction = "DEFAULT_ACTION",
+                                    },
+                                  }
+                                
+                                })
+
+        local AlertId
+        --hmi side: Navigation.AlertManeuver request 
+        EXPECT_HMICALL("Navigation.AlertManeuver", 
+                { 
+                  appID = self.applications["Test Application"],
+                  softButtons = 
+                  { 
+                    
+                    { 
+                      type = "BOTH",
+                      text = "Close",
+                        --[[ TODO: update after resolving APPLINK-16052
+
+                       image = 
+                
+                      { 
+                        value = pathToIconFolder .. "/icon.png",
+                        imageType = "DYNAMIC",
+                      },]] 
+                      isHighlighted = true,
+                      softButtonID = 7821,
+                      systemAction = "DEFAULT_ACTION",
+                    }, 
+                    
+                    { 
+                      type = "BOTH",
+                      text = "AnotherClose",
+                        --[[ TODO: update after resolving APPLINK-16052
+
+                       image = 
+                
+                      { 
+                        value = pathToIconFolder.. "/notavailable.png",
+                        imageType = "DYNAMIC",
+                      },]] 
+                      isHighlighted = false,
+                      softButtonID = 7822,
+                      systemAction = "DEFAULT_ACTION",
+                    } 
+                  }
+                })
+          :Do(function(_,data)
+            AlertId = data.id
+            local function alertResponse()
+              self.hmiConnection:SendResponse(AlertId, "Navigation.AlertManeuver", "WARNINGS", {info = "Requested image(s) not found."})
+            end
+
+            RUN_AFTER(alertResponse, 2000)
+          end)
+
+        local SpeakId
+        --hmi side: TTS.Speak request 
+        EXPECT_HMICALL("TTS.Speak", 
+                { 
+                  ttsChunks = 
+                    { 
+                      
+                      { 
+                        text ="FirstAlert",
+                        type ="TEXT",
+                      }, 
+                      
+                      { 
+                        text ="SecondAlert",
+                        type ="TEXT",
+                      }
+                    },
+                  speakType = "ALERT_MANEUVER",
+
+                })
+          :Do(function(_,data)
+            self.hmiConnection:SendNotification("TTS.Started")
+            SpeakId = data.id
+
+            local function speakResponse()
+              self.hmiConnection:SendResponse(SpeakId, "TTS.Speak", "SUCCESS", { })
+
+              self.hmiConnection:SendNotification("TTS.Stopped")
+            end
+
+            RUN_AFTER(speakResponse, 1000)
+
+          end)
+           
+
+        --mobile side: OnHMIStatus notifications
+        ExpectOnHMIStatusWithAudioStateChanged(self)
+
+          --mobile side: expect AlertManeuver response
+          EXPECT_RESPONSE(CorIdAlertM, { success = true, resultCode = "WARNINGS",info = "Requested image(s) not found." })
+            :Timeout(11000)
+
+      end
+
+    --End Test case CommonRequestCheck.7
+    
+    --Begin Test case CommonRequestCheck.8
+    --Description: Positive case and in boundary conditions (with conditional parameters) and invalid image
+    
+      function Test:AlertManeuver_InvalidImage_SoftButton() 
+
+        --mobile side: AlertManeuver request 
+        local CorIdAlertM = self.mobileSession:SendRPC("AlertManeuver",
+                                {
+                                     
+                                  ttsChunks = 
+                                  { 
+                                    
+                                    { 
+                                      text ="FirstAlert",
+                                      type ="TEXT",
+                                    }, 
+                                    
+                                    { 
+                                      text ="SecondAlert",
+                                      type ="TEXT",
+                                    }, 
+                                  }, 
+                                  softButtons = 
+                                  { 
+                                    
+                                    { 
+                                      type = "BOTH",
+                                      text = "Close",
+                                       image = 
+                                
+                                      { 
+                                        value = "notavailable.png",
+                                        imageType = "DYNAMIC",
+                                      }, 
+                                      isHighlighted = true,
+                                      softButtonID = 8821,
+                                      systemAction = "DEFAULT_ACTION",
+                                    }, 
+                                    
+                                    { 
+                                      type = "BOTH",
+                                      text = "AnotherClose",
+                                       image = 
+                                
+                                      { 
+                                        value = "icon.png",
+                                        imageType = "DYNAMIC",
+                                      }, 
+                                      isHighlighted = false,
+                                      softButtonID = 8822,
+                                      systemAction = "DEFAULT_ACTION",
+                                    },
+                                  }
+                                
+                                })
+
+        local AlertId
+        --hmi side: Navigation.AlertManeuver request 
+        EXPECT_HMICALL("Navigation.AlertManeuver", 
+                { 
+                  appID = self.applications["Test Application"],
+                  softButtons = 
+                  { 
+                    
+                    { 
+                      type = "BOTH",
+                      text = "Close",
+                        --[[ TODO: update after resolving APPLINK-16052
+
+                       image = 
+                
+                      { 
+                        value = pathToIconFolder .. "/notavailable.png",
+                        imageType = "DYNAMIC",
+                      },]] 
+                      isHighlighted = true,
+                      softButtonID = 8821,
+                      systemAction = "DEFAULT_ACTION",
+                    }, 
+                    
+                    { 
+                      type = "BOTH",
+                      text = "AnotherClose",
+                        --[[ TODO: update after resolving APPLINK-16052
+
+                       image = 
+                
+                      { 
+                        value = pathToIconFolder.. "/icon.png",
+                        imageType = "DYNAMIC",
+                      },]] 
+                      isHighlighted = false,
+                      softButtonID = 8822,
+                      systemAction = "DEFAULT_ACTION",
+                    } 
+                  }
+                })
+          :Do(function(_,data)
+            AlertId = data.id
+            local function alertResponse()
+              self.hmiConnection:SendResponse(AlertId, "Navigation.AlertManeuver", "WARNINGS", {info = "Requested image(s) not found."})
+            end
+
+            RUN_AFTER(alertResponse, 2000)
+          end)
+
+        local SpeakId
+        --hmi side: TTS.Speak request 
+        EXPECT_HMICALL("TTS.Speak", 
+                { 
+                  ttsChunks = 
+                    { 
+                      
+                      { 
+                        text ="FirstAlert",
+                        type ="TEXT",
+                      }, 
+                      
+                      { 
+                        text ="SecondAlert",
+                        type ="TEXT",
+                      }
+                    },
+                  speakType = "ALERT_MANEUVER",
+
+                })
+          :Do(function(_,data)
+            self.hmiConnection:SendNotification("TTS.Started")
+            SpeakId = data.id
+
+            local function speakResponse()
+              self.hmiConnection:SendResponse(SpeakId, "TTS.Speak", "SUCCESS", { })
+
+              self.hmiConnection:SendNotification("TTS.Stopped")
+            end
+
+            RUN_AFTER(speakResponse, 1000)
+
+          end)
+           
+
+        --mobile side: OnHMIStatus notifications
+        ExpectOnHMIStatusWithAudioStateChanged(self)
+
+          --mobile side: expect AlertManeuver response
+          EXPECT_RESPONSE(CorIdAlertM, { success = true, resultCode = "WARNINGS",info = "Requested image(s) not found." })
+            :Timeout(11000)
+
+      end
+
+    --End Test case CommonRequestCheck.8
 
 	--End Test suit CommonRequestCheck
 

--- a/test_scripts/API/ATF_CreateInteractionChoiceSet.lua
+++ b/test_scripts/API/ATF_CreateInteractionChoiceSet.lua
@@ -651,6 +651,57 @@ end
 				end
 			--End Test case CommonRequestCheck.3.10
 			
+		  --Begin Test case CommonRequestCheck.4
+   
+      function Test:CreateInteractionChoiceSet_InvalidImage()
+          --mobile side: sending CreateInteractionChoiceSet request
+          local cid = self.mobileSession:SendRPC("CreateInteractionChoiceSet",
+                              {
+                                interactionChoiceSetID = 1108,
+                                choiceSet = 
+                                { 
+                                  
+                                  { 
+                                    choiceID = 1108,
+                                    menuName ="Choice1108",
+                                    vrCommands = 
+                                    { 
+                                      "Choice1108",
+                                    }, 
+                                    image =
+                                    { 
+                                      value ="notavailable.png",
+                                      imageType ="DYNAMIC",
+                                    }, 
+                                  }
+                                }
+                              })
+          
+            
+          --hmi side: expect VR.AddCommand request
+          EXPECT_HMICALL("VR.AddCommand", 
+                  { 
+                    cmdID = 1108,
+                    appID = applicationID,
+                    type = "Choice",
+                    vrCommands = {"Choice1108" }
+                  })
+          :Do(function(_,data)
+            --hmi side: sending VR.AddCommand response
+            grammarIDValue = data.params.grammarID
+            self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {info="Requested image(s) not found."})
+          end)
+          
+          --mobile side: expect CreateInteractionChoiceSet response
+          EXPECT_RESPONSE(cid, { success = true, resultCode = "WARNINGS",info="Requested image(s) not found." })
+
+          --mobile side: expect OnHashChange notification
+          EXPECT_NOTIFICATION("OnHashChange")
+        end
+    --End Test case CommonRequestCheck.4
+    
+    -----------------------------------------------------------------------------------------
+			
 		--Begin Test case CommonRequestCheck.3
 		
 		-----------------------------------------------------------------------------------------

--- a/test_scripts/API/ATF_PerformInteraction.lua
+++ b/test_scripts/API/ATF_PerformInteraction.lua
@@ -187,6 +187,44 @@ function setChoiseSet(choiceIDValue, size)
         return temp
 	end	
 end
+
+function setChoiseSetWithInvalidImage(choiceIDValue, size)
+  if (size == nil) then
+    local temp = {{ 
+        choiceID = choiceIDValue,
+        menuName ="Choice" .. tostring(choiceIDValue),
+        vrCommands = 
+        { 
+          "VrChoice" .. tostring(choiceIDValue),
+        }, 
+        image =
+        { 
+          value ="notavailable.png",
+          imageType ="STATIC",
+        }
+    }}
+    return temp
+  else  
+    local temp = {}   
+        for i = 1, size do
+        temp[i] = { 
+            choiceID = choiceIDValue+i-1,
+        menuName ="Choice" .. tostring(choiceIDValue+i-1),
+        vrCommands = 
+        { 
+          "VrChoice" .. tostring(choiceIDValue+i-1),
+        }, 
+        image =
+        { 
+          value ="notavailable.png",
+          imageType ="STATIC",
+        }
+      } 
+        end
+        return temp
+  end 
+end
+
 function setImage()
     local temp = {
 					value = "icon.png",
@@ -1068,6 +1106,35 @@ function Test:activationApp(appIDValue)
 			end
 		end
 	--End Precondition.6
+  -----------------------------------------------------------------------------------------
+
+  --Begin Precondition.7
+  --Description: CreateInteractionChoiceSet 
+        Test["CreateInteractionChoiceSetWithInValidImage"] = function(self)
+              --mobile side: sending CreateInteractionChoiceSet request
+              local infoText = "Requested image(s) not found."
+               cid = self.mobileSession:SendRPC("CreateInteractionChoiceSet",
+                      {
+                        interactionChoiceSetID = 500,
+                        choiceSet = setChoiseSetWithInvalidImage(500),
+                      })
+  
+              --hmi side: expect VR.AddCommand
+              EXPECT_HMICALL("VR.AddCommand", 
+                    { 
+                      cmdID = 500,
+                      type = "Choice",
+                      vrCommands = {"VrChoice"..tostring(500) }
+                    })
+              :Do(function(_,data)            
+                --hmi side: sending VR.AddCommand response
+                self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {})
+              end)    
+  
+            --mobile side: expect CreateInteractionChoiceSet response
+            EXPECT_RESPONSE(cid, { success = true,resultCode = "SUCCESS"  })
+        end
+ --End Precondition.7
 
 -- ----------------------------------------------------------------------------------------------
 -- -----------------------------------------VI TEST BLOCK----------------------------------------

--- a/test_scripts/API/ATF_ScrollableMessage.lua
+++ b/test_scripts/API/ATF_ScrollableMessage.lua
@@ -192,6 +192,67 @@ function Test:verify_SUCCESS_Case(Request, HmiLevel)
 end
 
 ---------------------------------------------------------------------------------------------
+
+--This function sends a request from mobile and verify result on HMI and mobile for WARNINGS resultCode cases.
+function Test:verify_WARNINGS_Case(Request, HmiLevel)
+
+  local cid = commonFunctions:sendRequest(self, Request, APIName, APIId)
+
+  --TODO: update after resolving APPLINK-16052
+  if Request.softButtons then
+    for i=1,#Request.softButtons do
+      if Request.softButtons[i].image then
+        Request.softButtons[i].image = nil
+      end
+    end
+  end
+
+  local UIParams = self:createUIParameters(Request)
+
+  --hmi side: expect UI.ScrollableMessage request
+  EXPECT_HMICALL("UI.ScrollableMessage", UIParams)
+  :Do(function(_,data)
+
+    --HMI sends UI.OnSystemContext
+    self.hmiConnection:SendNotification("UI.OnSystemContext",{ appID = self.applications["Test Application"], systemContext = "HMI_OBSCURED" })
+    scrollableMessageId = data.id
+
+    local function scrollableMessageResponse()
+
+      --hmi sends response
+      self.hmiConnection:SendResponse(scrollableMessageId, "UI.ScrollableMessage", "WARNINGS", {info = "Requested image(s) not found."})
+
+      --HMI sends UI.OnSystemContext
+      self.hmiConnection:SendNotification("UI.OnSystemContext",{ appID = self.applications["Test Application"], systemContext = "MAIN" })
+    end
+    RUN_AFTER(scrollableMessageResponse, 1000)
+
+  end)
+
+
+  --mobile side: expect OnHMIStatus notification
+  if HmiLevel == nil then
+    HmiLevel = "FULL"
+  end
+  if
+    HmiLevel == "BACKGROUND" or
+    HmiLevel == "LIMITED" then
+    EXPECT_NOTIFICATION("OnHMIStatus",{})
+    :Times(0)
+  else
+
+    EXPECT_NOTIFICATION("OnHMIStatus",
+        {systemContext = "HMI_OBSCURED", hmiLevel = HmiLevel, audioStreamingState = audibleState},
+        {systemContext = "MAIN", hmiLevel = HmiLevel, audioStreamingState = audibleState}
+    )
+    :Times(2)
+  end
+
+  --mobile side: expect the response
+  EXPECT_RESPONSE(cid, { success = true, resultCode = "WARNINGS",info = "Requested image(s) not found." })
+
+end
+---------------------------------------------------------------------------------------------
 -------------------------------------------Preconditions-------------------------------------
 ---------------------------------------------------------------------------------------------
 
@@ -242,6 +303,7 @@ end
 --1. Positive request
 --2. All parameters are lower bound
 --3. All parameters are upper bound
+--4. Positive request with invalid image
 
 function Test:ScrollableMessage_PositiveRequest()
 	local Request =
@@ -278,6 +340,43 @@ function Test:ScrollableMessage_PositiveRequest()
 	}
 
 	self:verify_SUCCESS_Case(Request)
+end
+
+function Test:ScrollableMessage_PositiveRequest_WithInvalidImage()
+  local Request =
+  {
+    scrollableMessageBody = "abc",
+    softButtons =
+    {
+      {
+        softButtonID = 1,
+        text = "Button1",
+        type = "IMAGE",
+        image =
+        {
+          value = "notavailable.png",
+          imageType = "DYNAMIC"
+        },
+        isHighlighted = false,
+        systemAction = "DEFAULT_ACTION"
+      },
+      {
+        softButtonID = 2,
+        text = "Button2",
+        type = "IMAGE",
+        image =
+        {
+          value = "action.png",
+          imageType = "DYNAMIC"
+        },
+        isHighlighted = false,
+        systemAction = "DEFAULT_ACTION"
+      }
+    },
+    timeout = 5000
+  }
+
+  self:verify_WARNINGS_Case(Request)
 end
 
 function Test:ScrollableMessage_AllParametersLowerBound()

--- a/test_scripts/API/ATF_SetGlobalProperties.lua
+++ b/test_scripts/API/ATF_SetGlobalProperties.lua
@@ -310,7 +310,7 @@ end
 	--Verification criteria:
 		--SetGlobalProperties sets-up global properties for the current application.
 		--SDL sets-up default values for "vrHelpTitle" and "vrHelp" parameters if they both don't exist in request.
-		--VRHelpTitle and VRHelpItems are sent with SetGlobalProperties request for setting app’s help items. HMI will open by itself a top level HelpList as a result of VR activation.
+		--VRHelpTitle and VRHelpItems are sent with SetGlobalProperties request for setting appï¿½s help items. HMI will open by itself a top level HelpList as a result of VR activation.
 
 
 	--Begin test case CommonRequestCheck.1
@@ -2033,7 +2033,213 @@ end
 
 	--End test case CommonRequestCheck.20
 	-----------------------------------------------------------------------------------------
+   --Begin test case CommonRequestCheck.21
+  --Description: Check request with all parameters
 
+    function Test:SetGlobalProperties_ImageNotAvailableInStorag_WARNINGS()
+    
+      --mobile side: sending SetGlobalProperties request
+      local cid = self.mobileSession:SendRPC("SetGlobalProperties",
+      {
+        menuTitle = "Menu Title",
+        timeoutPrompt = 
+        {
+          {
+            text = "Timeout prompt duplicate",
+            type = "TEXT"
+          }
+        },
+        vrHelp = 
+        {
+          {
+            position = 1,
+            image = 
+            {
+              value = "action.png",
+              imageType = "DYNAMIC"
+            },
+            text = "VR help item"
+          }
+        },
+        menuIcon = 
+        {
+          value = "imagenotavailable.png",
+          imageType = "DYNAMIC"
+        },
+        helpPrompt = 
+        {
+          {
+            text = "Help prompt",
+            type = "TEXT"
+          }
+        },
+        vrHelpTitle = "VR help title",
+        keyboardProperties = 
+        {
+          keyboardLayout = "QWERTY",
+          keypressMode = "SINGLE_KEYPRESS",
+          limitedCharacterList = 
+          {
+            "a"
+          },
+          language = "EN-US",
+          autoCompleteText = "Daemon, Freedom"
+        }
+      })
+    
+
+      --hmi side: expect TTS.SetGlobalProperties request
+      EXPECT_HMICALL("TTS.SetGlobalProperties")
+      :Times(2)
+      :Do(function(_,data)
+        --hmi side: sending UI.SetGlobalProperties response
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+      end)
+
+    
+
+      --hmi side: expect UI.SetGlobalProperties request
+      EXPECT_HMICALL("UI.SetGlobalProperties")
+      :Times(2)
+      :Do(function(_,data)
+        --hmi side: sending UI.SetGlobalProperties response
+        self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {info ="Requested image(s) not found."})
+      end)
+      :Do(function(exp,data)
+        if exp.occurences == 1 then 
+          local msg = 
+            {
+              serviceType      = 7,
+              frameInfo        = 0,
+              rpcType          = 0,
+              rpcFunctionId    = 3, --SetGlobalPropertiesID  
+              rpcCorrelationId = cid,
+              payload          = '{"vrHelp":[{"image":{"imageType":"DYNAMIC","value":"action.png"},"position":1,"text":"VR help item"}],"helpPrompt":[{"type":"TEXT","text":"Help prompt"}],"menuTitle":"Menu Title","vrHelpTitle":"VR help title","timeoutPrompt":[{"type":"TEXT","text":"Timeout prompt duplicate"}],"menuIcon":{"imageType":"DYNAMIC","value":"action.png"}}'
+            }
+      
+          self.mobileSession:Send(msg)
+        end
+
+        --hmi side: sending UI.SetGlobalProperties response
+        self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {info ="Requested image(s) not found."})          
+        
+      end)
+        
+
+      --mobile side: expect SetGlobalProperties response
+      EXPECT_RESPONSE(cid, { success = true, resultCode = "WARNINGS",info ="Requested image(s) not found."})
+      :Times(2)
+            
+      --mobile side: expect OnHashChange notification
+      EXPECT_NOTIFICATION("OnHashChange")
+      :Times(2)
+    end
+    --End test case CommonRequestCheck.21
+ -----------------------------------------------------------------------------------------
+    
+  --Begin test case CommonRequestCheck.22
+  --Description: Check request with all parameters
+
+    function Test:SetGlobalProperties_VRImageNotAvailableInStorag_WARNINGS()
+    
+      --mobile side: sending SetGlobalProperties request
+      local cid = self.mobileSession:SendRPC("SetGlobalProperties",
+      {
+        menuTitle = "Menu Title",
+        timeoutPrompt = 
+        {
+          {
+            text = "Timeout prompt duplicate",
+            type = "TEXT"
+          }
+        },
+        vrHelp = 
+        {
+          {
+            position = 1,
+            image = 
+            {
+              value = "imagenotavailable.png",
+              imageType = "DYNAMIC"
+            },
+            text = "VR help item"
+          }
+        },
+        menuIcon = 
+        {
+          value = "action.png",
+          imageType = "DYNAMIC"
+        },
+        helpPrompt = 
+        {
+          {
+            text = "Help prompt",
+            type = "TEXT"
+          }
+        },
+        vrHelpTitle = "VR help title",
+        keyboardProperties = 
+        {
+          keyboardLayout = "QWERTY",
+          keypressMode = "SINGLE_KEYPRESS",
+          limitedCharacterList = 
+          {
+            "a"
+          },
+          language = "EN-US",
+          autoCompleteText = "Daemon, Freedom"
+        }
+      })
+    
+
+      --hmi side: expect TTS.SetGlobalProperties request
+      EXPECT_HMICALL("TTS.SetGlobalProperties")
+      :Times(2)
+      :Do(function(_,data)
+        --hmi side: sending UI.SetGlobalProperties response
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+      end)
+
+    
+
+      --hmi side: expect UI.SetGlobalProperties request
+      EXPECT_HMICALL("UI.SetGlobalProperties")
+      :Times(2)
+      :Do(function(_,data)
+        --hmi side: sending UI.SetGlobalProperties response
+        self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {info ="Requested image(s) not found."})
+      end)
+      :Do(function(exp,data)
+        if exp.occurences == 1 then 
+          local msg = 
+            {
+              serviceType      = 7,
+              frameInfo        = 0,
+              rpcType          = 0,
+              rpcFunctionId    = 3, --SetGlobalPropertiesID  
+              rpcCorrelationId = cid,
+              payload          = '{"vrHelp":[{"image":{"imageType":"DYNAMIC","value":"action.png"},"position":1,"text":"VR help item"}],"helpPrompt":[{"type":"TEXT","text":"Help prompt"}],"menuTitle":"Menu Title","vrHelpTitle":"VR help title","timeoutPrompt":[{"type":"TEXT","text":"Timeout prompt duplicate"}],"menuIcon":{"imageType":"DYNAMIC","value":"action.png"}}'
+            }
+      
+          self.mobileSession:Send(msg)
+        end
+
+        --hmi side: sending UI.SetGlobalProperties response
+        self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {info ="Requested image(s) not found."})          
+        
+      end)
+        
+
+      --mobile side: expect SetGlobalProperties response
+      EXPECT_RESPONSE(cid, { success = true, resultCode = "WARNINGS",info ="Requested image(s) not found."})
+      :Times(2)
+            
+      --mobile side: expect OnHashChange notification
+      EXPECT_NOTIFICATION("OnHashChange")
+      :Times(2)
+    end
+    --End test case CommonRequestCheck.22
+  -----------------------------------------------------------------------------------------
 
 
 ---------------------------------------------------------------------------------------------
@@ -35873,7 +36079,7 @@ end
 		-----------------------------------------------------------------------------------------
 
 		--Begin test case SequenceCheck.3
-		--Description: Check for manual test case TC_SetGlobalProperties_02: SDL sends TTS.SetGlobalProperties request in 20 seconds from activation to FULL with the default list of HelpPrompts is a list of TTSChunks ( UI commands) defined as “TEXT” type, which are the list of the commands.
+		--Description: Check for manual test case TC_SetGlobalProperties_02: SDL sends TTS.SetGlobalProperties request in 20 seconds from activation to FULL with the default list of HelpPrompts is a list of TTSChunks ( UI commands) defined as ï¿½TEXTï¿½ type, which are the list of the commands.
 
 		function Test:Begin_TC_SetGlobalProperties_03()
 			print("--------------------------------------------------------")
@@ -36099,7 +36305,7 @@ end
 		--[[
 		Description: Check for manual test case TC_SetGlobalProperties_02, extra check, not covered in original: 
 		SDL sends TTS.SetGlobalProperties request in 20 seconds from activation to LIMITED with the default list of
-		HelpPrompts is a list of TTSChunks ( UI commands) defined as “TEXT” type, which are the list of the commands.
+		HelpPrompts is a list of TTSChunks ( UI commands) defined as ï¿½TEXTï¿½ type, which are the list of the commands.
 		--]]
 
 		function Test:Begin_TC_SetGlobalProperties_3_1()
@@ -36726,7 +36932,7 @@ end
 	--[[TODO: Next test suit is blocked by defect APPLINK-21931, after resolving the issue need to uncomment suit]]
 	--[[
 	--Begin test case SequenceCheck.6.1
-	--Description:Check for manual test case TC_SetGlobalProperties_02: SDL sends TTS.SetGlobalProperties request in 20 seconds from activation to LIMITED with the default list of HelpPrompts is a list of TTSChunks ( UI commands) defined as “TEXT” type, which are the list of the commands.
+	--Description:Check for manual test case TC_SetGlobalProperties_02: SDL sends TTS.SetGlobalProperties request in 20 seconds from activation to LIMITED with the default list of HelpPrompts is a list of TTSChunks ( UI commands) defined as ï¿½TEXTï¿½ type, which are the list of the commands.
 
 
 		function Test:Begin_TC_SetGlobalProperties_6_1()
@@ -37010,7 +37216,7 @@ end
 	--[[TODO: Next test suit is blocked by defect APPLINK-21931, after resolving the issue need to uncomment suit]]
 	--[[
 	-- Begin test case SequenceCheck.6.2
-	--Description:Check for manual test case TC_SetGlobalProperties_02: SDL sends TTS.SetGlobalProperties request in 20 seconds from activation to LIMITED with the default list of HelpPrompts is a list of TTSChunks ( UI commands) defined as “TEXT” type, which are the list of the commands.
+	--Description:Check for manual test case TC_SetGlobalProperties_02: SDL sends TTS.SetGlobalProperties request in 20 seconds from activation to LIMITED with the default list of HelpPrompts is a list of TTSChunks ( UI commands) defined as ï¿½TEXTï¿½ type, which are the list of the commands.
 
 
 		function Test:Begin_TC_SetGlobalProperties_6_2()

--- a/test_scripts/API/ATF_Show.lua
+++ b/test_scripts/API/ATF_Show.lua
@@ -38,6 +38,7 @@ require('user_modules/AppTypes')
 ---------------------------------------------------------------------------------------------
 APIName = "Show" -- set request name
 strMaxLengthFileName255 = string.rep("a", 251)  .. ".png" -- set max length file name
+strMaxLengthInvalidFileName255 = string.rep("a", 251)  .. ".png" -- set max length file name
 --local storagePath = config.pathToSDL .. SDLConfig:GetValue("AppStorageFolder") .. "/" .. tostring(config.application1.registerAppInterfaceParams.appID .. "_" .. tostring(config.deviceMAC) .. "/")
 
 --Debug = {"graphic", "value"} --use to print request before sending to SDL.
@@ -271,6 +272,87 @@ function Test:verify_SUCCESS_Case(Request)
 	EXPECT_RESPONSE(cid, { success = true, resultCode = "SUCCESS" })
 			
 end
+
+--This function sends a request from mobile and verify result on HMI and mobile for WARNINGS resultCode cases.
+function Test:verify_WARNINGS_invalid_image_Case(Request)
+
+  local temp = json.encode(Request)
+  local cid = 0
+  if string.find(temp, "{}") ~= nil or string.find(temp, "{{}}") ~= nil then            
+    temp = string.gsub(temp, "{}", "[]")
+    temp = string.gsub(temp, "{{}}", "[{}]")
+    
+    self.mobileSession.correlationId = self.mobileSession.correlationId + 1
+
+    local msg = 
+    {
+      serviceType      = 7,
+      frameInfo        = 0,
+      rpcType          = 0,
+      rpcFunctionId    = 13,
+      rpcCorrelationId = self.mobileSession.correlationId,        
+      payload          = temp
+    }
+
+    cid = self.mobileSession.correlationId
+
+    self.mobileSession:Send(msg)
+  else
+    --mobile side: sending Show request
+    cid = self.mobileSession:SendRPC("Show", Request)
+  end
+
+  -- TODO: remove after resolving APPLINK-16094
+  ---------------------------------------------
+  if 
+    (Request.graphic and
+    #Request.graphic == 0) then
+      Request.graphic = nil
+  end
+
+  if 
+    (Request.secondaryGraphic and
+    #Request.secondaryGraphic == 0) then
+      Request.secondaryGraphic = nil
+  end
+
+  if 
+    (Request.softButtons and
+    #Request.softButtons == 0) then
+      Request.softButtons = nil
+  end
+
+  if 
+    (Request.customPresets and
+    #Request.customPresets == 0) then
+      Request.customPresets = nil
+  end
+
+  if Request.softButtons then
+    for i=1,#Request.softButtons do
+      if Request.softButtons[i].image then
+        Request.softButtons[i].image = nil
+      end
+    end
+
+  end
+  ---------------------------------------------
+  
+  UIParams = self:createUIParameters(Request)
+
+  
+  --hmi side: expect UI.Show request
+  EXPECT_HMICALL("UI.Show", UIParams)
+  :Do(function(_,data)
+    --hmi side: sending UI.Show response
+    self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {info = "Requested image(s) not found."})
+  end)
+
+
+  --mobile side: expect SetGlobalProperties response
+  EXPECT_RESPONSE(cid, { success = true, resultCode = "WARNINGS",info = "Requested image(s) not found." })
+      
+end
 ---------------------------------------------------------------------------------------------
 
 
@@ -329,6 +411,44 @@ end
 --1. All parameters are lower bound
 --2. All parameters are upper bound
 -----------------------------------------------------------------------------------------------
+
+    Test["Show_AllParametersWithInvalidImage_WARNINGS"] = function(self)
+  
+    --mobile side: request parameters
+    local RequestParams = 
+    {
+      mainField1 = "a",
+      mainField2 = "a",
+      mainField3 = "a",
+      mainField4 = "a",
+      statusBar= "a",
+      mediaClock = "a",
+      mediaTrack = "a",
+      alignment = "CENTERED",
+      graphic = 
+      { 
+        imageType = "DYNAMIC",
+        value = "invalidimange.png"
+      },
+      secondaryGraphic = 
+      { 
+        imageType = "DYNAMIC",
+        value = "invalidimange.png"
+      },
+      softButtons = {},
+      customPresets = {},
+      metadataTags =
+      {
+        mainField1 = {},
+        mainField2 = {},
+        mainField3 = {},
+        mainField4 = {}
+      }
+    }
+    
+    self:verify_WARNINGS_invalid_image_Case(RequestParams)
+    
+  end
 
 	Test["Show_AllParametersLowerBound_SUCCESS"] = function(self)
 	
@@ -546,6 +666,184 @@ end
 	end
 	-----------------------------------------------------------------------------------------
 
+  -----------------------------------------------------------------------------------------
+  
+  Test["Show_AllParametersUpperBound_WARNINGS"] = function(self)
+  
+    --mobile side: request parameters
+    local string500Characters = commonFunctions:createString(500)
+    local string499Characters = commonFunctions:createString(499)
+    local RequestParams = 
+    {
+      mainField1 = string500Characters,
+      mainField2 = string500Characters,
+      mainField3 = string500Characters,
+      mainField4 = string500Characters,
+      statusBar= string500Characters,
+      mediaClock = string500Characters,
+      mediaTrack = string500Characters,
+      alignment = "CENTERED",
+      graphic = 
+      { 
+        imageType = "DYNAMIC",
+        value = strMaxLengthFileName255
+      },
+      secondaryGraphic = 
+      { 
+        imageType = "DYNAMIC",
+        value = strMaxLengthFileName255
+      },
+      softButtons = 
+      {
+        {
+          text = "1" .. string499Characters,
+          systemAction = "KEEP_CONTEXT",
+          type = "BOTH",
+          isHighlighted = true,                               
+          image =
+          {
+             imageType = "DYNAMIC",
+             value = strMaxLengthFileName255
+          },                                
+          softButtonID = 1
+        },
+        {
+          text = "2" .. string499Characters,
+          systemAction = "KEEP_CONTEXT",
+          type = "BOTH",
+          isHighlighted = true,                               
+          image =
+          {
+             imageType = "DYNAMIC",
+             value = strMaxLengthFileName255
+          },                                
+          softButtonID = 2
+        },
+        {
+          text = "3" .. string499Characters,
+          systemAction = "KEEP_CONTEXT",
+          type = "BOTH",
+          isHighlighted = true,                               
+          image =
+          {
+             imageType = "DYNAMIC",
+             value = strMaxLengthFileName255
+          },                                
+          softButtonID = 3
+        },
+        {
+          text = "4" .. string499Characters,
+          systemAction = "KEEP_CONTEXT",
+          type = "BOTH",
+          isHighlighted = true,                               
+          image =
+          {
+             imageType = "DYNAMIC",
+             value = strMaxLengthInvalidFileName255
+          },                                
+          softButtonID = 4
+        },
+        {
+          text = "5" .. string499Characters,
+          systemAction = "KEEP_CONTEXT",
+          type = "BOTH",
+          isHighlighted = true,                               
+          image =
+          {
+             imageType = "DYNAMIC",
+             value = strMaxLengthInvalidFileName255
+          },                                
+          softButtonID = 5
+        },
+        {
+          text = "6" .. string499Characters,
+          systemAction = "KEEP_CONTEXT",
+          type = "BOTH",
+          isHighlighted = true,                               
+          image =
+          {
+             imageType = "DYNAMIC",
+             value = strMaxLengthInvalidFileName255
+          },                                
+          softButtonID = 6
+        },
+        {
+          text = "7" .. string499Characters,
+          systemAction = "KEEP_CONTEXT",
+          type = "BOTH",
+          isHighlighted = true,                               
+          image =
+          {
+             imageType = "DYNAMIC",
+             value = strMaxLengthInvalidFileName255
+          },                                
+          softButtonID = 7
+        },
+        {
+          text = "8" .. string499Characters,
+          systemAction = "KEEP_CONTEXT",
+          type = "BOTH",
+          isHighlighted = true,                               
+          image =
+          {
+             imageType = "DYNAMIC",
+             value = strMaxLengthFileName255
+          },                                
+          softButtonID = 8
+        }
+      },
+      customPresets = 
+      {
+        "1" .. string499Characters,
+        "2" .. string499Characters,
+        "3" .. string499Characters,
+        "4" .. string499Characters,
+        "5" .. string499Characters,
+        "6" .. string499Characters,
+        "7" .. string499Characters,
+        "8" .. string499Characters,
+      },  
+      metadataTags =
+      {
+        mainField1 =
+        {
+          "mediaTitle",
+          "mediaArtist",
+          "mediaAlbum",
+          "mediaYear",
+          "mediaGenre"
+        },
+        mainField2 =
+        {
+          "mediaTitle",
+          "mediaArtist",
+          "mediaAlbum",
+          "mediaYear",
+          "mediaGenre"
+        },
+        mainField3 =
+        {
+          "mediaTitle",
+          "mediaArtist",
+          "mediaAlbum",
+          "mediaYear",
+          "mediaGenre"
+        },
+        mainField4 =
+        {
+          "mediaTitle",
+          "mediaArtist",
+          "mediaAlbum",
+          "mediaYear",
+          "mediaGenre"
+        }
+       }
+    }
+    
+    self:verify_WARNINGS_invalid_image_Case(RequestParams)
+    
+  end
+  -----------------------------------------------------------------------------------------
 
 -----------------------------------------------------------------------------------------------
 --Test cases for parameter 1-7: mainField1, mainField2, mainField3, mainField4, statusBar, mediaClock, mediaTrack: type=String, maxlength=500, mandatory=false

--- a/test_scripts/API/ATF_ShowConstantTBT.lua
+++ b/test_scripts/API/ATF_ShowConstantTBT.lua
@@ -253,6 +253,71 @@ end
 
 ---------------------------------------------------------------------------------------------
 
+
+--This function sends a request from mobile and verify result on HMI and mobile for WARNINGS resultCode cases.
+function Test:verify_WARNINGS_Case(RequestParams)
+  --Check if send any empty array or empty struct
+  local temp = json.encode(RequestParams)
+  local cid = 0
+  if string.find(temp, "{}") ~= nil or string.find(temp, "{{}}") ~= nil then
+    temp = string.gsub(temp, "{}", "[]")
+    temp = string.gsub(temp, "{{}}", "[{}]")
+
+    self.mobileSession.correlationId = self.mobileSession.correlationId + 1
+
+    local msg =
+    {
+      serviceType      = 7,
+      frameInfo        = 0,
+      rpcType          = 0,
+      rpcFunctionId    = 27,
+      rpcCorrelationId = self.mobileSession.correlationId,
+      payload          = temp
+    }
+
+    cid = self.mobileSession.correlationId
+
+    self.mobileSession:Send(msg)
+
+  else
+    --mobile side: sending ShowConstantTBT request
+    cid = self.mobileSession:SendRPC("ShowConstantTBT", RequestParams)
+  end
+
+  -- TODO: remove after resolving APPLINK-16094
+  ---------------------------------------------
+
+  if
+    (RequestParams.softButtons and
+    #RequestParams.softButtons == 0) then
+      RequestParams.softButtons = nil
+  end
+
+  if RequestParams.softButtons then
+    for i=1,#RequestParams.softButtons do
+      if RequestParams.softButtons[i].image then
+        RequestParams.softButtons[i].image = nil
+      end
+    end
+
+  end
+  ---------------------------------------------
+
+  UIParams = self:createUIParameters(RequestParams)
+
+  --hmi side: expect Navigation.ShowConstantTBT request
+  EXPECT_HMICALL("Navigation.ShowConstantTBT", UIParams)
+  :Do(function(_,data)
+    --hmi side: sending Navigation.ShowConstantTBT response
+    self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS", {info = "Requested image(s) not found."})
+  end)
+
+  --mobile side: expect SetGlobalProperties response
+  EXPECT_RESPONSE(cid, { success = true, resultCode = "WARNINGS",info = "Requested image(s) not found." })
+end
+
+---------------------------------------------------------------------------------------------
+--
 --This function sends a request from mobile with INVALID_DATA and verify result on mobile.
 function Test:verify_INVALID_DATA_Case(RequestParams)
 	--Check if send any empty array or empty struct
@@ -523,6 +588,162 @@ end
 	function Test:ShowConstantTBT_Positive()
 		self:verify_SUCCESS_Case(Request)
 	end
+	
+	 local Request = {
+            navigationText1 ="navigationText1",
+            navigationText2 ="navigationText2",
+            eta ="12:34",
+            totalDistance ="100miles",
+            turnIcon =
+            {
+              value ="notavailable.png",
+              imageType ="DYNAMIC",
+            },
+            nextTurnIcon =
+            {
+              value ="notavailable.png",
+              imageType ="DYNAMIC",
+            },
+            distanceToManeuver = 50.5,
+            distanceToManeuverScale = 100.5,
+            maneuverComplete = false,
+            softButtons =
+            {
+
+              {
+                type ="BOTH",
+                text ="Close",
+                image =
+                {
+                  value ="notavailable.png",
+                  imageType ="DYNAMIC",
+                },
+                isHighlighted = true,
+                softButtonID = 44,
+                systemAction ="DEFAULT_ACTION",
+              },
+            },
+          }
+  function Test:ShowConstantTBT_Positive_InvalidImage()
+    self:verify_WARNINGS_Case(Request)
+  end
+  
+     local Request = {
+            navigationText1 ="navigationText1",
+            navigationText2 ="navigationText2",
+            eta ="12:34",
+            totalDistance ="100miles",
+            turnIcon =
+            {
+              value ="notavailable.png",
+              imageType ="DYNAMIC",
+            },
+            nextTurnIcon =
+            {
+              value ="icon.png",
+              imageType ="DYNAMIC",
+            },
+            distanceToManeuver = 50.5,
+            distanceToManeuverScale = 100.5,
+            maneuverComplete = false,
+            softButtons =
+            {
+
+              {
+                type ="BOTH",
+                text ="Close",
+                image =
+                {
+                  value ="icon.png",
+                  imageType ="DYNAMIC",
+                },
+                isHighlighted = true,
+                softButtonID = 44,
+                systemAction ="DEFAULT_ACTION",
+              },
+            },
+          }
+  function Test:ShowConstantTBT_Positive_InvalidImage_TurnIcon()
+    self:verify_WARNINGS_Case(Request)
+  end
+  
+       local Request = {
+            navigationText1 ="navigationText1",
+            navigationText2 ="navigationText2",
+            eta ="12:34",
+            totalDistance ="100miles",
+            turnIcon =
+            {
+              value ="icon.png",
+              imageType ="DYNAMIC",
+            },
+            nextTurnIcon =
+            {
+              value ="icon.png",
+              imageType ="DYNAMIC",
+            },
+            distanceToManeuver = 50.5,
+            distanceToManeuverScale = 100.5,
+            maneuverComplete = false,
+            softButtons =
+            {
+
+              {
+                type ="BOTH",
+                text ="Close",
+                image =
+                {
+                  value ="notavailable.png",
+                  imageType ="DYNAMIC",
+                },
+                isHighlighted = true,
+                softButtonID = 44,
+                systemAction ="DEFAULT_ACTION",
+              },
+            },
+          }
+  function Test:ShowConstantTBT_Positive_InvalidImage_SoftButton()
+    self:verify_WARNINGS_Case(Request)
+  end
+  
+         local Request = {
+            navigationText1 ="navigationText1",
+            navigationText2 ="navigationText2",
+            eta ="12:34",
+            totalDistance ="100miles",
+            turnIcon =
+            {
+              value ="icon.png",
+              imageType ="DYNAMIC",
+            },
+            nextTurnIcon =
+            {
+              value ="notavailable.png",
+              imageType ="DYNAMIC",
+            },
+            distanceToManeuver = 50.5,
+            distanceToManeuverScale = 100.5,
+            maneuverComplete = false,
+            softButtons =
+            {
+
+              {
+                type ="BOTH",
+                text ="Close",
+                image =
+                {
+                  value ="icon.png",
+                  imageType ="DYNAMIC",
+                },
+                isHighlighted = true,
+                softButtonID = 44,
+                systemAction ="DEFAULT_ACTION",
+              },
+            },
+          }
+  function Test:ShowConstantTBT_Positive_InvalidImage_NextTurnIcon()
+    self:verify_WARNINGS_Case(Request)
+  end
 
 	local Request = {
 						navigationText1 ="navigationText1",

--- a/test_scripts/API/ATF_UpdateTurnList.lua
+++ b/test_scripts/API/ATF_UpdateTurnList.lua
@@ -194,6 +194,49 @@ function Test:updateTurnListSuccess(paramsSend)
 	EXPECT_RESPONSE(CorIdUpdateTurnList, { success = true, resultCode = "SUCCESS" })
 end
 
+function Test:updateTurnListWARNINGS(paramsSend)
+  --mobile side: send UpdateTurnList request
+  local CorIdUpdateTurnList = self.mobileSession:SendRPC("UpdateTurnList", paramsSend)
+
+  --Set location for DYNAMIC image
+  if paramsSend.softButtons then
+    --If type is IMAGE -> text parameter is omitted and vice versa
+    if paramsSend.softButtons[1].type == "IMAGE" then
+      paramsSend.softButtons[1].text = nil
+    else
+      if paramsSend.softButtons[1].type == "TEXT" then
+        paramsSend.softButtons[1].image = nil
+      end
+    end
+
+    --TODO: update after resolving APPLINK-16052
+    -- if paramsSend.softButtons[1].image then
+    --  paramsSend.softButtons[1].image.value = storagePath..paramsSend.softButtons[1].image.value
+    -- end
+    if paramsSend.softButtons then
+      for i=1,#paramsSend.softButtons do
+        if paramsSend.softButtons[i].image then
+          paramsSend.softButtons[i].image = nil
+        end
+      end
+    end
+  end
+
+  --hmi side: expect Navigation.UpdateTurnList request
+  EXPECT_HMICALL("Navigation.UpdateTurnList",
+  {
+    turnList = setExTurnList(1),
+    softButtons = paramsSend.softButtons
+  })
+  :Do(function(_,data)
+    --hmi side: send Navigation.UpdateTurnList response
+    self.hmiConnection:SendResponse(data.id, data.method, "WARNINGS",{info = "Requested image(s) not found."})
+  end)
+
+  --mobile side: expect UpdateTurnList response
+  EXPECT_RESPONSE(CorIdUpdateTurnList, { success = true, resultCode = "WARNINGS",info = "Requested image(s) not found." })
+end
+
 ---------------------------------------------------------------------------------------------
 -------------------------------------------Preconditions-------------------------------------
 ---------------------------------------------------------------------------------------------
@@ -957,6 +1000,116 @@ commonSteps:DeleteLogsFileAndPolicyTable()
 			end
 		--End Test case CommonRequestCheck.8
 ]]
+
+    --Begin Test case CommonRequestCheck.9
+      --Description: This test is intended to check positive cases and when all parameters are in boundary conditions and with Invalid Image
+
+
+      function Test:UpdateTurnList_InvalidImage()
+        local request = {
+          turnList =
+          {
+            {
+              navigationText ="Text",
+              turnIcon =
+              {
+                value ="notavailable.png",
+                imageType ="DYNAMIC",
+              }
+            }
+          },
+          softButtons =
+          {
+            {
+              type ="BOTH",
+              text ="Close",
+              image =
+              {
+                value ="notavailable.png",
+                imageType ="DYNAMIC",
+              },
+              isHighlighted = true,
+              softButtonID = 111,
+              systemAction ="DEFAULT_ACTION",
+            }
+          }
+        }
+        self:updateTurnListWARNINGS(request)
+      end
+    --End Test case CommonRequestCheck.9
+    
+     --Begin Test case CommonRequestCheck.10
+      --Description: This test is intended to check positive cases and when all parameters are in boundary conditions and with Invalid Image
+
+
+      function Test:UpdateTurnList_InvalidImage_SoftButton()
+        local request = {
+          turnList =
+          {
+            {
+              navigationText ="Text",
+              turnIcon =
+              {
+                value ="icon.png",
+                imageType ="DYNAMIC",
+              }
+            }
+          },
+          softButtons =
+          {
+            {
+              type ="BOTH",
+              text ="Close",
+              image =
+              {
+                value ="notavailable.png",
+                imageType ="DYNAMIC",
+              },
+              isHighlighted = true,
+              softButtonID = 111,
+              systemAction ="DEFAULT_ACTION",
+            }
+          }
+        }
+        self:updateTurnListWARNINGS(request)
+      end
+    --End Test case CommonRequestCheck.10
+       --Begin Test case CommonRequestCheck.11
+      --Description: This test is intended to check positive cases and when all parameters are in boundary conditions and with Invalid Image
+
+      function Test:UpdateTurnList_InvalidImage_TurnIcon()
+        local request = {
+          turnList =
+          {
+            {
+              navigationText ="Text",
+              turnIcon =
+              {
+                value ="icon.png",
+                imageType ="DYNAMIC",
+              }
+            }
+          },
+          softButtons =
+          {
+            {
+              type ="BOTH",
+              text ="Close",
+              image =
+              {
+                value ="notavailable.png",
+                imageType ="DYNAMIC",
+              },
+              isHighlighted = true,
+              softButtonID = 111,
+              systemAction ="DEFAULT_ACTION",
+            }
+          }
+        }
+        self:updateTurnListWARNINGS(request)
+      end
+    --End Test case CommonRequestCheck.11
+    
 	--End Test suit CommonRequestCheck
 
 ---------------------------------------------------------------------------------------------

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/001_AddCommand.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/001_AddCommand.lua
@@ -1,0 +1,120 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests AddCommand with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  menuParams = {
+    position = 0,
+    menuName ="Commandpositive"
+  },
+  cmdIcon = {
+    value = "missed_icon.png",
+    imageType = "DYNAMIC"
+  }
+}
+
+local requestUiParams = {
+  cmdID = requestParams.cmdID,
+  cmdIcon = requestParams.cmdIcon,
+  menuParams = requestParams.menuParams
+}
+
+local requestVrParams = {
+  cmdID = requestParams.cmdID,
+  type = "Command",
+  vrCommands = requestParams.vrCommands
+}
+
+local allParams = {
+  requestParams = requestParams,
+  responseUiParams = requestUiParams,
+  responseVrParams = requestVrParams
+}
+
+--[[ Local Functions ]]
+local function addCommand(pId, pParams)
+  pParams.requestParams.cmdID = pId
+  pParams.requestParams.menuParams.menuName = requestParams.menuParams.menuName .. pId
+  pParams.responseUiParams.cmdIcon.value = common.getPathToFileInStorage("missed_icon.png")
+  pParams.responseUiParams.appID = common.getHMIAppId()
+
+  local cid = common.getMobileSession():SendRPC("AddCommand", pParams.requestParams)
+
+  EXPECT_HMICALL("UI.AddCommand", pParams.responseUiParams)
+  :Do(function(_,data)
+      common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+    end)
+
+  common.getMobileSession():ExpectResponse(cid,
+    { success = true, resultCode = "WARNINGS", info = "Requested image(s) not found" })
+
+  common.getMobileSession():ExpectNotification("OnHashChange")
+end
+
+local function addCommandVR(pId, pParams)
+  pParams.requestParams.cmdID = pId
+  pParams.requestParams.menuParams.menuName = requestParams.menuParams.menuName .. pId
+  pParams.responseUiParams.cmdIcon.value = common.getPathToFileInStorage("missed_icon.png")
+  pParams.responseUiParams.appID = common.getHMIAppId()
+  pParams.requestParams.vrCommands = {
+    "VRCommandonepositive",
+    "VRCommandonepositivedouble"
+  }
+  pParams.responseVrParams.appID = common.getHMIAppId()
+
+  EXPECT_HMICALL("VR.AddCommand", pParams.responseVrParams)
+  :Do(function(_,data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+  :ValidIf(function(_,data)
+      if data.params.grammarID ~= nil then
+        return true
+      else
+        return false, "grammarID should not be empty"
+      end
+    end)
+
+
+  local cid = common.getMobileSession():SendRPC("AddCommand", pParams.requestParams)
+
+  EXPECT_HMICALL("UI.AddCommand", pParams.responseUiParams)
+  :Do(function(_,data)
+      common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+    end)
+
+  common.getMobileSession():ExpectResponse(cid,
+    { success = true, resultCode = "WARNINGS", info = "Requested image(s) not found" })
+
+  common.getMobileSession():ExpectNotification("OnHashChange")
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("AddCommand with invalid image only UI interface", addCommand, { 1, allParams })
+runner.Step("AddCommand with invalid image with VR interface", addCommandVR, { 2, allParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/002_AddSubMenu.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/002_AddSubMenu.lua
@@ -1,0 +1,72 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests AddSubMenu with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  menuID = 1000,
+  position = 500,
+  menuName ="SubMenupositive",
+  menuIcon = {
+    value ="missed_icon.png",
+    imageType ="DYNAMIC"
+  }
+}
+
+local requestUiParams = {
+  menuID = requestParams.menuID,
+  menuParams = {
+    position = requestParams.position,
+    menuName = requestParams.menuName
+  },
+  menuIcon = requestParams.menuIcon
+}
+
+local allParams = {
+  requestParams = requestParams,
+  requestUiParams = requestUiParams
+}
+
+--[[ Local Functions ]]
+local function addSubMenu(pParams)
+  local cid = common.getMobileSession():SendRPC("AddSubMenu", pParams.requestParams)
+  pParams.requestUiParams.menuIcon.value = common.getPathToFileInStorage(requestParams.menuIcon.value)
+  pParams.requestUiParams.appID = common.getHMIAppId()
+  EXPECT_HMICALL("UI.AddSubMenu", pParams.requestUiParams)
+  :Do(function(_,data)
+    common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+  end)
+
+  common.getMobileSession():ExpectResponse(cid,
+    { success = true, resultCode = "WARNINGS", info = "Requested image(s) not found" })
+  common.getMobileSession():ExpectNotification("OnHashChange")
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("AddSubMenu with invalid image", addSubMenu, { allParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/003_Alert.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/003_Alert.lua
@@ -1,0 +1,183 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests Alert with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variable s ]]
+local softButtons  = {
+  softButtons = {
+    {
+      type = "BOTH",
+      text = "Close",
+      image = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC",
+      },
+      isHighlighted = true,
+      softButtonID = 3,
+      systemAction = "DEFAULT_ACTION",
+    },
+    {
+      type = "TEXT",
+      text = "Keep",
+      isHighlighted = true,
+      softButtonID = 4,
+      systemAction = "KEEP_CONTEXT",
+    },
+    {
+      type = "IMAGE",
+      image = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC",
+      },
+      softButtonID = 5,
+      systemAction = "STEAL_FOCUS",
+    }
+  }
+}
+
+local requestParams = {
+  alertText1 = "alertText1",
+  alertText2 = "alertText2",
+  alertText3 = "alertText3",
+  ttsChunks = {
+    {
+        text = "TTSChunk",
+        type = "TEXT",
+    }
+  },
+  playTone = true,
+  progressIndicator = true
+}
+
+local responseUiParams = {
+  alertStrings = {
+    {
+        fieldName = requestParams.alertText1,
+        fieldText = requestParams.alertText1
+    },
+    {
+        fieldName = requestParams.alertText2,
+        fieldText = requestParams.alertText2
+    },
+    {
+        fieldName = requestParams.alertText3,
+        fieldText = requestParams.alertText3
+    }
+  },
+  alertType = "BOTH",
+  progressIndicator = requestParams.progressIndicator,
+}
+
+local ttsSpeakRequestParams = {
+  ttsChunks = requestParams.ttsChunks,
+  speakType = "ALERT",
+  playTone = requestParams.playTone
+}
+
+local allParams = {
+  requestParams = requestParams,
+  responseUiParams = responseUiParams,
+  ttsSpeakRequestParams = ttsSpeakRequestParams
+}
+
+--[[ Local Functions ]]
+local function sendOnSystemContext(pCtx)
+  common.getHMIConnection():SendNotification("UI.OnSystemContext",
+  {
+    appID = common.getHMIAppId(),
+    systemContext = pCtx
+  })
+end
+
+local function prepareAlertParams(pParams, pAdditionalParams)
+  pParams.responseUiParams.appID = common.getHMIAppId()
+  pParams.requestParams.duration = nil
+  pParams.requestParams.softButtons = pAdditionalParams.softButtons
+  pParams.responseUiParams.duration = nil;
+  pParams.responseUiParams.softButtons = pAdditionalParams.softButtons
+  pParams.responseUiParams.softButtons[1].image.value =
+    common.getPathToFileInStorage(pAdditionalParams.softButtons[1].image.value)
+  pParams.responseUiParams.softButtons[3].image.value =
+    common.getPathToFileInStorage(pAdditionalParams.softButtons[3].image.value)
+end
+
+local function alert(pParams, pAdditionalParams)
+  prepareAlertParams(pParams, pAdditionalParams)
+
+  local responseDelay = 3000
+  local cid = common.getMobileSession():SendRPC("Alert", pParams.requestParams)
+
+  EXPECT_HMICALL("UI.Alert", pParams.responseUiParams)
+  :Do(function(_,data)
+      sendOnSystemContext("ALERT")
+
+      local alertId = data.id
+      local function alertResponse()
+        common.getHMIConnection():SendError(alertId, "UI.Alert", "WARNINGS", "Requested image(s) not found")
+        sendOnSystemContext("MAIN")
+      end
+
+      RUN_AFTER(alertResponse, responseDelay)
+    end)
+
+  pParams.ttsSpeakRequestParams.appID = common.getHMIAppId()
+  EXPECT_HMICALL("TTS.Speak", pParams.ttsSpeakRequestParams)
+  :Do(function(_,data)
+      common.getHMIConnection():SendNotification("TTS.Started")
+
+      local speakId = data.id
+      local function speakResponse()
+        common.getHMIConnection():SendResponse(speakId, "TTS.Speak", "SUCCESS", { })
+        common.getHMIConnection():SendNotification("TTS.Stopped")
+      end
+
+      RUN_AFTER(speakResponse, responseDelay - 1000)
+    end)
+  :ValidIf(function(_,data)
+      if #data.params.ttsChunks == 1 then
+        return true
+      else
+        return false, "ttsChunks array in TTS.Speak request has wrong element number." ..
+        " Expected 1, actual " .. tostring(#data.params.ttsChunks)
+      end
+    end)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus",
+    { systemContext = "ALERT", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" },
+    { systemContext = "ALERT", hmiLevel = "FULL", audioStreamingState = "ATTENUATED" },
+    { systemContext = "ALERT", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" },
+    { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
+  :Times(4)
+
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS",
+    info = "Requested image(s) not found" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("Alert with soft buttons with invalid image", alert, { allParams, softButtons })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/004_CreateInteractionChoiceSet.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/004_CreateInteractionChoiceSet.lua
@@ -1,0 +1,83 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests createInteractionChoiceSet with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  interactionChoiceSetID = 1001,
+  choiceSet = {
+    {
+      choiceID = 1001,
+      menuName ="Choice1001",
+      vrCommands = {
+        "Choice1001"
+      },
+      image = {
+        value ="missed_icon.png",
+        imageType ="DYNAMIC"
+      }
+    }
+  }
+}
+
+local responseVrParams = {
+  cmdID = requestParams.interactionChoiceSetID,
+  type = "Choice",
+  vrCommands = requestParams.vrCommands
+}
+
+local allParams = {
+  requestParams = requestParams,
+  responseVrParams = responseVrParams
+}
+
+--[[ Local Functions ]]
+local function createInteractionChoiceSet(pParams)
+  local cid = common.getMobileSession():SendRPC("CreateInteractionChoiceSet", pParams.requestParams)
+
+  pParams.responseVrParams.appID = common.getHMIAppId()
+  EXPECT_HMICALL("VR.AddCommand", pParams.responseVrParams)
+  :Do(function(_,data)
+    common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+  end)
+  :ValidIf(function(_,data)
+    if data.params.grammarID ~= nil then
+      return true
+    else
+      return false, "grammarID should not be empty"
+    end
+  end)
+
+  common.getMobileSession():ExpectResponse(cid, { resultCode = "WARNINGS", success = true,
+    info = "Requested image(s) not found." })
+  common.getMobileSession():ExpectNotification("OnHashChange")
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("CreateInteractionChoiceSet with invalid image", createInteractionChoiceSet, { allParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/004_CreateInteractionChoiceSet.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/004_CreateInteractionChoiceSet.lua
@@ -8,7 +8,7 @@
 -- 1. Mobile app requests createInteractionChoiceSet with image that is absent on file system
 -- SDL must:
 -- 1. transfer this RPC to HMI for processing
--- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+-- 2. transfer the received from HMI response (WARNINGS) to mobile app
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
@@ -64,8 +64,7 @@ local function createInteractionChoiceSet(pParams)
     end
   end)
 
-  common.getMobileSession():ExpectResponse(cid, { resultCode = "WARNINGS", success = true,
-    info = "Requested image(s) not found." })
+  common.getMobileSession():ExpectResponse(cid, { resultCode = "WARNINGS", success = true })
   common.getMobileSession():ExpectNotification("OnHashChange")
 end
 

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
@@ -64,11 +64,11 @@ local requestParams = {
 
 --[[ Local Functions ]]
 
---! @setChoiseSet: Creates Choice structure
+--! @setChoiceSet: Creates Choice structure
 --! @parameters:
 --! choiceIDValue - Id for created choice
 --! @return: table of created choice structure
-local function setChoiseSet(choiceIDValue)
+local function setChoiceSet(choiceIDValue)
   local temp = {
     {
       choiceID = choiceIDValue,
@@ -94,11 +94,11 @@ local function SendOnSystemContext(ctx)
     { appID = common.getHMIAppId(), systemContext = ctx })
 end
 
---! @setExChoiseSet: ChoiceSet structure for UI.PerformInteraction request
+--! @setExChoiceSet: ChoiceSet structure for UI.PerformInteraction request
 --! @parameters:
 --! choiceIDValues - value of choice id
 --! @return: none
-local function setExChoiseSet(choiceIDValues)
+local function setExChoiceSet(choiceIDValues)
   local exChoiceSet = { }
   for i = 1, #choiceIDValues do
     exChoiceSet[i] = {
@@ -154,7 +154,7 @@ local function CreateInteractionChoiceSet(choiceSetID)
   local choiceID = choiceSetID
   local cid = common.getMobileSession():SendRPC("CreateInteractionChoiceSet", {
       interactionChoiceSetID = choiceSetID,
-      choiceSet = setChoiseSet(choiceID),
+      choiceSet = setChoiceSet(choiceID),
     })
   EXPECT_HMICALL("VR.AddCommand", {
       cmdID = choiceID,
@@ -228,7 +228,7 @@ local function PI_PerformViaMANUAL_ONLY(paramsSend)
     end)
   EXPECT_HMICALL("UI.PerformInteraction", {
       timeout = paramsSend.timeout,
-      choiceSet = setExChoiseSet(paramsSend.interactionChoiceSetIDList),
+      choiceSet = setExChoiceSet(paramsSend.interactionChoiceSetIDList),
       initialText = {
         fieldName = "initialInteractionText",
         fieldText = paramsSend.initialText
@@ -280,7 +280,7 @@ local function PI_PerformViaBOTH(paramsSend)
     end)
   EXPECT_HMICALL("UI.PerformInteraction", {
       timeout = paramsSend.timeout,
-      choiceSet = setExChoiseSet(paramsSend.interactionChoiceSetIDList),
+      choiceSet = setExChoiceSet(paramsSend.interactionChoiceSetIDList),
       initialText = {
         fieldName = "initialInteractionText",
         fieldText = paramsSend.initialText

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
@@ -164,8 +164,7 @@ local function CreateInteractionChoiceSet(choiceSetID)
   :Do(function(_,data)
       common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
     end)
-  common.getMobileSession():ExpectResponse(cid, { resultCode = "WARNINGS", success = true,
-    info = "Requested image(s) not found." })
+  common.getMobileSession():ExpectResponse(cid, { resultCode = "WARNINGS", success = true })
 end
 
 --! @PI_PerformViaVR_ONLY: Processing PI with interaction mode VR_ONLY with performing selection

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
@@ -1,0 +1,324 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests PerfromInteraction with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local ImageValue = {
+  value = common.getPathToFileInStorage("missed_icon.png"),
+  imageType = "DYNAMIC",
+}
+
+local function PromptValue(text)
+  local tmp = {
+    {
+      text = text,
+      type = "TEXT"
+    }
+  }
+  return tmp
+end
+
+local initialPromptValue = PromptValue(" Make your choice ")
+
+local helpPromptValue = PromptValue(" Help Prompt ")
+
+local timeoutPromptValue = PromptValue(" Time out ")
+
+local vrHelpvalue = {
+  {
+    text = " New VRHelp ",
+    position = 1,
+    image = ImageValue
+  }
+}
+
+local requestParams = {
+  initialText = "StartPerformInteraction",
+  initialPrompt = initialPromptValue,
+  interactionMode = "BOTH",
+  interactionChoiceSetIDList = {
+    100, 200, 300
+  },
+  helpPrompt = helpPromptValue,
+  timeoutPrompt = timeoutPromptValue,
+  timeout = 5000,
+  vrHelp = vrHelpvalue,
+  interactionLayout = "ICON_ONLY"
+}
+
+--[[ Local Functions ]]
+
+--! @setChoiseSet: Creates Choice structure
+--! @parameters:
+--! choiceIDValue - Id for created choice
+--! @return: table of created choice structure
+local function setChoiseSet(choiceIDValue)
+  local temp = {
+    {
+      choiceID = choiceIDValue,
+      menuName ="Choice" .. tostring(choiceIDValue),
+      vrCommands = {
+        "VrChoice" .. tostring(choiceIDValue)
+      },
+      image = {
+        value ="missed_icon.png",
+        imageType ="DYNAMIC"
+      }
+    }
+  }
+  return temp
+end
+
+--! @SendOnSystemContext: OnSystemContext notification
+--! @parameters:
+--! ctx - systemContext value
+--! @return: none
+local function SendOnSystemContext(ctx)
+  common.getHMIConnection():SendNotification("UI.OnSystemContext",
+    { appID = common.getHMIAppId(), systemContext = ctx })
+end
+
+--! @setExChoiseSet: ChoiceSet structure for UI.PerformInteraction request
+--! @parameters:
+--! choiceIDValues - value of choice id
+--! @return: none
+local function setExChoiseSet(choiceIDValues)
+  local exChoiceSet = { }
+  for i = 1, #choiceIDValues do
+    exChoiceSet[i] = {
+      choiceID = choiceIDValues[i],
+      image = {
+        value = common.getPathToFileInStorage("missed_icon.png"),
+        imageType = "DYNAMIC",
+      },
+      menuName = "Choice" .. choiceIDValues[i]
+    }
+  end
+  return exChoiceSet
+end
+
+--! @ExpectOnHMIStatusWithAudioStateChanged_PI: Expectations of OnHMIStatus notification depending on the application
+--! type, HMI level and interaction mode
+--! @parameters:
+--! request - interaction mode,
+--! @return: none
+local function ExpectOnHMIStatusWithAudioStateChanged_PI(request)
+  if "BOTH" == request then
+    common.getMobileSession():ExpectNotification("OnHMIStatus",
+      { hmiLevel = "FULL", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" },
+      { hmiLevel = "FULL", audioStreamingState = "NOT_AUDIBLE", systemContext = "VRSESSION" },
+      { hmiLevel = "FULL", audioStreamingState = "ATTENUATED", systemContext = "VRSESSION" },
+      { hmiLevel = "FULL", audioStreamingState = "ATTENUATED", systemContext = "HMI_OBSCURED" },
+      { hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "HMI_OBSCURED" },
+      { hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN" })
+    :Times(6)
+  elseif "VR" == request then
+    common.getMobileSession():ExpectNotification("OnHMIStatus",
+      { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "ATTENUATED" },
+      { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "NOT_AUDIBLE" },
+      { systemContext = "VRSESSION", hmiLevel = "FULL", audioStreamingState = "NOT_AUDIBLE" },
+      { systemContext = "VRSESSION", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" },
+      { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
+    :Times(5)
+  elseif "MANUAL" == request then
+    common.getMobileSession():ExpectNotification("OnHMIStatus",
+      { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "ATTENUATED" },
+      { systemContext = "HMI_OBSCURED", hmiLevel = "FULL", audioStreamingState = "ATTENUATED" },
+      { systemContext = "HMI_OBSCURED", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" },
+      { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
+    :Times(4)
+  end
+end
+
+--! @CreateInteractionChoiceSet: Creation of Choice Set
+--! @parameters:
+--! choiceSetID - id for choice set
+--! @return: none
+local function CreateInteractionChoiceSet(choiceSetID)
+  local choiceID = choiceSetID
+  local cid = common.getMobileSession():SendRPC("CreateInteractionChoiceSet", {
+      interactionChoiceSetID = choiceSetID,
+      choiceSet = setChoiseSet(choiceID),
+    })
+  EXPECT_HMICALL("VR.AddCommand", {
+      cmdID = choiceID,
+      type = "Choice",
+      vrCommands = { "VrChoice" .. tostring(choiceID) }
+    })
+  :Do(function(_,data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
+  common.getMobileSession():ExpectResponse(cid, { resultCode = "WARNINGS", success = true,
+    info = "Requested image(s) not found." })
+end
+
+--! @PI_PerformViaVR_ONLY: Processing PI with interaction mode VR_ONLY with performing selection
+--! @parameters:
+--! paramsSend - parameters for PI request
+--! @return: none
+local function PI_PerformViaVR_ONLY(paramsSend)
+  paramsSend.interactionMode = "VR_ONLY"
+  local cid = common.getMobileSession():SendRPC("PerformInteraction",paramsSend)
+  EXPECT_HMICALL("VR.PerformInteraction", {
+      helpPrompt = paramsSend.helpPrompt,
+      initialPrompt = paramsSend.initialPrompt,
+      timeout = paramsSend.timeout,
+      timeoutPrompt = paramsSend.timeoutPrompt
+    })
+  :Do(function(_,data)
+      local function vrResponse()
+        common.getHMIConnection():SendNotification("TTS.Started")
+        common.getHMIConnection():SendNotification("VR.Started")
+        SendOnSystemContext("VRSESSION")
+        common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS",
+          { choiceID = paramsSend.interactionChoiceSetIDList[1] })
+        common.getHMIConnection():SendNotification("TTS.Stopped")
+        common.getHMIConnection():SendNotification("VR.Stopped")
+        SendOnSystemContext("MAIN")
+      end
+      RUN_AFTER(vrResponse, 1000)
+    end)
+
+  EXPECT_HMICALL("UI.PerformInteraction", {
+      timeout = paramsSend.timeout,
+      vrHelp = paramsSend.vrHelp,
+      vrHelpTitle = paramsSend.initialText,
+    })
+  :Do(function(_,data)
+      common.getHMIConnection():SendError( data.id, data.method, "WARNINGS", "Requested image(s) not found" )
+    end)
+  ExpectOnHMIStatusWithAudioStateChanged_PI("VR")
+  common.getMobileSession():ExpectResponse(cid,
+    { success = true, resultCode = "WARNINGS", choiceID = paramsSend.interactionChoiceSetIDList[1],
+    info = "Requested image(s) not found" })
+end
+
+--! @PI_PerformViaMANUAL_ONLY: Processing PI with interaction mode MANUAL_ONLY with performing selection
+--! @parameters:
+--! paramsSend - parameters for PI request
+--! @return: none
+local function PI_PerformViaMANUAL_ONLY(paramsSend)
+  paramsSend.interactionMode = "MANUAL_ONLY"
+  local cid = common.getMobileSession():SendRPC("PerformInteraction", paramsSend)
+  EXPECT_HMICALL("VR.PerformInteraction", {
+      helpPrompt = paramsSend.helpPrompt,
+      initialPrompt = paramsSend.initialPrompt,
+      timeout = paramsSend.timeout,
+      timeoutPrompt = paramsSend.timeoutPrompt
+    })
+  :Do(function(_,data)
+      common.getHMIConnection():SendNotification("TTS.Started")
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
+  EXPECT_HMICALL("UI.PerformInteraction", {
+      timeout = paramsSend.timeout,
+      choiceSet = setExChoiseSet(paramsSend.interactionChoiceSetIDList),
+      initialText = {
+        fieldName = "initialInteractionText",
+        fieldText = paramsSend.initialText
+      }
+    })
+  :Do(function(_,data)
+      SendOnSystemContext("HMI_OBSCURED")
+      local function uiResponse()
+        common.getHMIConnection():SendResponse(data.id, data.method, "WARNINGS",
+          { choiceID = paramsSend.interactionChoiceSetIDList[1], info = "Requested image(s) not found." } )
+        common.getHMIConnection():SendNotification("TTS.Stopped")
+        SendOnSystemContext("MAIN")
+      end
+      RUN_AFTER(uiResponse, 1000)
+    end)
+  ExpectOnHMIStatusWithAudioStateChanged_PI("MANUAL")
+  common.getMobileSession():ExpectResponse(cid,
+    { success = true, resultCode = "WARNINGS", choiceID = paramsSend.interactionChoiceSetIDList[1],
+    info = "Requested image(s) not found." })
+end
+
+--! @PI_PerformViaBOTH: Processing PI with interaction mode BOTH with timeout on VR and IU
+--! @parameters:
+--! paramsSend - parameters for PI request
+--! @return: none
+local function PI_PerformViaBOTH(paramsSend)
+  paramsSend.interactionMode = "BOTH"
+  local cid = common.getMobileSession():SendRPC("PerformInteraction",paramsSend)
+  EXPECT_HMICALL("VR.PerformInteraction", {
+      helpPrompt = paramsSend.helpPrompt,
+      initialPrompt = paramsSend.initialPrompt,
+      timeout = paramsSend.timeout,
+      timeoutPrompt = paramsSend.timeoutPrompt
+    })
+  :Do(function(_,data)
+      common.getHMIConnection():SendNotification("VR.Started")
+      common.getHMIConnection():SendNotification("TTS.Started")
+      SendOnSystemContext("VRSESSION")
+      local function firstSpeakTimeOut()
+        common.getHMIConnection():SendNotification("TTS.Stopped")
+        common.getHMIConnection():SendNotification("TTS.Started")
+      end
+      RUN_AFTER(firstSpeakTimeOut, 5)
+      local function vrResponse()
+        common.getHMIConnection():SendError(data.id, data.method, "TIMED_OUT", "Perform Interaction error response.")
+        common.getHMIConnection():SendNotification("VR.Stopped")
+      end
+      RUN_AFTER(vrResponse, 20)
+    end)
+  EXPECT_HMICALL("UI.PerformInteraction", {
+      timeout = paramsSend.timeout,
+      choiceSet = setExChoiseSet(paramsSend.interactionChoiceSetIDList),
+      initialText = {
+        fieldName = "initialInteractionText",
+        fieldText = paramsSend.initialText
+      },
+      vrHelp = paramsSend.vrHelp,
+      vrHelpTitle = paramsSend.initialText
+    })
+  :Do(function(_,data)
+      local function choiceIconDisplayed()
+        SendOnSystemContext("HMI_OBSCURED")
+      end
+      RUN_AFTER(choiceIconDisplayed, 25)
+      local function uiResponse()
+        common.getHMIConnection():SendNotification("TTS.Stopped")
+        common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+        SendOnSystemContext("MAIN")
+      end
+      RUN_AFTER(uiResponse, 30)
+    end)
+  ExpectOnHMIStatusWithAudioStateChanged_PI("BOTH")
+  common.getMobileSession():ExpectResponse(cid, { success = false, resultCode = "WARNINGS",
+    info = "Requested image(s) not found, Perform Interaction error response." })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+runner.Step("CreateInteractionChoiceSet with id 100", CreateInteractionChoiceSet, {100})
+runner.Step("CreateInteractionChoiceSet with id 200", CreateInteractionChoiceSet, {200})
+runner.Step("CreateInteractionChoiceSet with id 300", CreateInteractionChoiceSet, {300})
+
+runner.Title("Test")
+runner.Step("PerformInteraction with VR_ONLY interaction mode with invalid image", PI_PerformViaVR_ONLY, {requestParams})
+runner.Step("PerformInteraction with MANUAL_ONLY interaction mode with invalid image", PI_PerformViaMANUAL_ONLY, {requestParams})
+runner.Step("PerformInteraction with BOTH interaction mode with invalid image", PI_PerformViaBOTH, {requestParams})
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/006_ScrollableMessage.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/006_ScrollableMessage.lua
@@ -1,0 +1,99 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests ScrollableMessage with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  scrollableMessageBody = "abc",
+  softButtons = {
+    {
+      softButtonID = 1,
+      text = "Button1",
+      type = "BOTH",
+      image = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC"
+      },
+      isHighlighted = false,
+      systemAction = "DEFAULT_ACTION"
+      },
+    {
+      softButtonID = 2,
+      text = "Button2",
+      type = "TEXT",
+      isHighlighted = false,
+      systemAction = "DEFAULT_ACTION"
+    }
+  },
+  timeout = 5000
+}
+
+local responseUiParams = {
+  messageText = {
+    fieldName = "scrollableMessageBody",
+    fieldText = requestParams.scrollableMessageBody
+  },
+  softButtons = requestParams.softButtons
+}
+
+local allParams = {
+  requestParams = requestParams,
+  responseUiParams = responseUiParams,
+}
+
+--[[ Local Functions ]]
+local function ScrollableMessage(pParams)
+  local cid = common.getMobileSession():SendRPC("ScrollableMessage", pParams.requestParams)
+  pParams.responseUiParams.appID = common.getHMIAppId()
+  for _, v in pairs(pParams.responseUiParams.softButtons) do
+    if v.image then
+      v.image.value = common.getPathToFileInStorage("missed_icon.png")
+    end
+  end
+  EXPECT_HMICALL("UI.ScrollableMessage", pParams.responseUiParams)
+  :Do(function(_,data)
+	common.getHMIConnection():SendNotification("UI.OnSystemContext",
+	  { appID = pParams.responseUiParams.appID, systemContext = "HMI_OBSCURED" })
+	local function uiResponse()
+      common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+      common.getHMIConnection():SendNotification("UI.OnSystemContext",
+        { appID = pParams.responseUiParams.appID, systemContext = "MAIN" })
+    end
+    RUN_AFTER(uiResponse, 1000)
+  end)
+  common.getMobileSession():ExpectNotification("OnHMIStatus",
+    { systemContext = "HMI_OBSCURED", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" },
+    { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
+  :Times(2)
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS",
+    info = "Requested image(s) not found" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("ScrollableMessage with invalid image", ScrollableMessage, { allParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/007_Show.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/007_Show.lua
@@ -1,0 +1,111 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests Show with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  mainField1 = "a",
+  mainField2 = "a",
+  mainField3 = "a",
+  mainField4 = "a",
+  statusBar = "a",
+  mediaClock = "a",
+  mediaTrack = "a",
+  alignment = "CENTERED",
+  graphic = {
+    imageType = "DYNAMIC",
+    value = "missed_icon.png"
+  },
+  secondaryGraphic = {
+    imageType = "DYNAMIC",
+    value = "missed_icon.png"
+  },
+}
+
+local responseUiParams = {
+  showStrings = {
+    {
+      fieldName = "mainField1",
+      fieldText = requestParams.mainField1
+    },
+    {
+      fieldName = "mainField2",
+      fieldText = requestParams.mainField2
+    },
+    {
+      fieldName = "mainField3",
+      fieldText = requestParams.mainField3
+    },
+    {
+      fieldName = "mainField4",
+      fieldText = requestParams.mainField4
+    },
+    {
+      fieldName = "mediaClock",
+      fieldText = requestParams.mediaClock
+    },
+    {
+      fieldName = "mediaTrack",
+      fieldText = requestParams.mediaTrack
+    },
+    {
+      fieldName = "statusBar",
+      fieldText = requestParams.statusBar
+    }
+  },
+  alignment = requestParams.alignment,
+  graphic = {
+    imageType = requestParams.graphic.imageType,
+    value = common.getPathToFileInStorage(requestParams.graphic.value)
+  },
+  secondaryGraphic = {
+    imageType = requestParams.secondaryGraphic.imageType,
+    value = common.getPathToFileInStorage(requestParams.secondaryGraphic.value)
+  }
+}
+
+local allParams = {
+  requestParams = requestParams,
+  responseUiParams = responseUiParams,
+}
+
+--[[ Local Functions ]]
+local function Show(pParams)
+  local cid = common.getMobileSession():SendRPC("Show", pParams.requestParams)
+  pParams.responseUiParams.appID = common.getHMIAppId()
+  EXPECT_HMICALL("UI.Show", pParams.responseUiParams)
+  :Do(function(_,data)
+      common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+    end)
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS",
+    info = "Requested image(s) not found" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("Show with invalid image", Show, { allParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/008_ShowConstantTBT.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/008_ShowConstantTBT.lua
@@ -1,0 +1,116 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests ShowConstantTBT with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  navigationText1 = "navigationText1",
+  navigationText2 = "navigationText2",
+  eta = "12:34",
+  totalDistance = "100miles",
+  timeToDestination = "10 minutes",
+  turnIcon = {
+    value = "missed_icon.png",
+    imageType = "DYNAMIC",
+  },
+  nextTurnIcon = {
+    value = "missed_icon.png",
+    imageType = "DYNAMIC",
+  },
+  distanceToManeuver = 50.5,
+  distanceToManeuverScale = 100.5,
+  maneuverComplete = false,
+  softButtons = {
+    {
+      type = "BOTH",
+      text = "Close",
+      image = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC",
+      },
+      isHighlighted = true,
+      softButtonID = 44,
+      systemAction ="DEFAULT_ACTION",
+    },
+  },
+}
+
+local responseUiParams = {
+  navigationTexts = {
+    {
+      fieldName = "navigationText1",
+      fieldText = requestParams.navigationText1
+    },
+    {
+      fieldName = "navigationText2",
+      fieldText = requestParams.navigationText2
+    },
+    {
+      fieldName = "ETA",
+      fieldText = requestParams.eta
+    },
+    {
+      fieldName = "totalDistance",
+      fieldText = requestParams.totalDistance
+    },
+    {
+      fieldName = "timeToDestination",
+      fieldText = requestParams.timeToDestination
+    }
+  },
+  turnIcon = requestParams.turnIcon,
+  nextTurnIcon = requestParams.nextTurnIcon,
+  distanceToManeuver = requestParams.distanceToManeuver,
+  distanceToManeuverScale = requestParams.distanceToManeuverScale,
+  maneuverComplete = requestParams.maneuverComplete,
+  softButtons = requestParams.softButtons
+}
+
+local allParams = {
+  requestParams = requestParams,
+  responseUiParams = responseUiParams
+}
+
+--[[ Local Functions ]]
+local function showConstantTBT(pParams)
+  local cid = common.getMobileSession():SendRPC("ShowConstantTBT", pParams.requestParams)
+  pParams.responseUiParams.appID = common.getHMIAppId()
+  pParams.responseUiParams.turnIcon.value = common.getPathToFileInStorage(pParams.requestParams.turnIcon.value)
+  pParams.responseUiParams.nextTurnIcon.value = common.getPathToFileInStorage(pParams.requestParams.nextTurnIcon.value)
+  pParams.responseUiParams.softButtons[1].image.value = common.getPathToFileInStorage(pParams.requestParams.softButtons[1].image.value)
+  EXPECT_HMICALL("Navigation.ShowConstantTBT", pParams.responseUiParams)
+  :Do(function(_,data)
+      common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+    end)
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS",
+    info = "Requested image(s) not found" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("ShowConstantTBT with invalid image", showConstantTBT, {allParams})
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/009_SendLocation.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/009_SendLocation.lua
@@ -1,0 +1,62 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests SendLocation with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  longitudeDegrees = 1.1,
+  latitudeDegrees = 1.1,
+  locationName = "location Name",
+  locationDescription = "location Description",
+  addressLines = {
+    "line1",
+    "line2",
+  },
+  phoneNumber = "phone Number",
+  locationImage ={
+    value = "missed_icon.png",
+    imageType = "DYNAMIC"
+  }
+}
+
+--[[ Local Functions ]]
+local function sendLocation(pParams)
+  local cid = common.getMobileSession():SendRPC("SendLocation", pParams)
+  pParams.appID = common.getHMIAppId()
+  pParams.locationImage.value = common.getPathToFileInStorage(pParams.locationImage.value)
+  EXPECT_HMICALL("Navigation.SendLocation", pParams)
+  :Do(function(_, data)
+      common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+    end)
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS",
+    info =  "Requested image(s) not found"})
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("SendLocation with invalid image", sendLocation, { requestParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/010_SetAppIcon.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/010_SetAppIcon.lua
@@ -1,0 +1,57 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests SetAppIcon with image that is absent on file system
+-- SDL must:
+-- 1. responds INVALID_DATA to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  syncFileName = "missed_icon.png"
+}
+
+local requestUiParams = {
+  syncFileName = {
+    imageType = "DYNAMIC",
+    value = common.getPathToFileInStorage(requestParams.syncFileName)
+  }
+}
+
+local allParams = {
+  requestParams = requestParams,
+  requestUiParams = requestUiParams
+}
+
+--[[ Local Functions ]]
+local function setAppIcon(pParams)
+  local cid = common.getMobileSession():SendRPC("SetAppIcon", pParams.requestParams)
+  pParams.requestUiParams.appID = common.getHMIAppId()
+  EXPECT_HMICALL("UI.SetAppIcon", pParams.requestUiParams)
+  :Times(0)
+  common.getMobileSession():ExpectResponse(cid, { success = false, resultCode = "INVALID_DATA"})
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("SetAppIcon with invalid image", setAppIcon, { allParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/011_UpdateTurnList.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/011_UpdateTurnList.lua
@@ -1,0 +1,82 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests UpdateTurnList with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  turnList = {
+    {
+      navigationText = "Text",
+      turnIcon = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC",
+      }
+    }
+  },
+  softButtons = {
+    {
+      type = "BOTH",
+      text = "Close",
+      image = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC",
+      },
+      isHighlighted = true,
+      softButtonID = 111,
+      systemAction = "DEFAULT_ACTION",
+    }
+  }
+}
+
+local responseUiParams = commonFunctions:cloneTable(requestParams)
+responseUiParams.turnList[1].navigationText = {
+  fieldText = requestParams.turnList[1].navigationText,
+  fieldName = "turnText"
+}
+responseUiParams.turnList[1].turnIcon.value = common.getPathToFileInStorage(requestParams.turnList[1].turnIcon.value)
+responseUiParams.softButtons[1].image.value = common.getPathToFileInStorage(requestParams.softButtons[1].image.value)
+
+local allParams = {
+  requestParams = requestParams,
+  responseUiParams = responseUiParams,
+}
+
+--[[ Local Functions ]]
+local function updateTurnList(pParams)
+  local cid = common.getMobileSession():SendRPC("UpdateTurnList", pParams.requestParams)
+  EXPECT_HMICALL("Navigation.UpdateTurnList", pParams.responseUiParams)
+  :Do(function(_,data)
+    common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+  end)
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS", info =  "Requested image(s) not found"})
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("UpdateTurnList with invalid image", updateTurnList, { allParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/012_AlertManeuver.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/012_AlertManeuver.lua
@@ -1,0 +1,121 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests AlertManeuver with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  ttsChunks = {
+    {
+      text = "FirstAlert",
+      type = "TEXT",
+    },
+    {
+      text = "SecondAlert",
+      type = "TEXT",
+    },
+  },
+  softButtons = {
+    {
+      type = "BOTH",
+      text = "Close",
+      image = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC",
+      },
+      isHighlighted = true,
+      softButtonID = 821,
+      systemAction = "DEFAULT_ACTION",
+    },
+    {
+      type = "BOTH",
+      text = "AnotherClose",
+      image = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC",
+      },
+      isHighlighted = false,
+      softButtonID = 822,
+      systemAction = "DEFAULT_ACTION",
+    },
+  }
+}
+
+local function naviParamsSet(tbl)
+  local Params = commonFunctions:cloneTable(tbl)
+  for k, _ in pairs(Params) do
+    if Params[k].image then
+      Params[k].image.value = common.getPathToFileInStorage(Params[k].image.value)
+    end
+  end
+  return Params
+end
+
+local responseNaviParams = {
+  softButtons = naviParamsSet(requestParams.softButtons)
+}
+
+local responseTtsParams = {
+  ttsChunks = requestParams.ttsChunks
+}
+
+local allParams = {
+  requestParams = requestParams,
+  responseNaviParams = responseNaviParams,
+  responseTtsParams = responseTtsParams
+}
+
+--[[ Local Functions ]]
+local function alertManeuver(pParams)
+  local cid = common.getMobileSession():SendRPC("AlertManeuver", pParams.requestParams)
+  EXPECT_HMICALL("Navigation.AlertManeuver", pParams.responseNaviParams)
+  :Do(function(_, data)
+    local function alertResp()
+      common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+    end
+    RUN_AFTER(alertResp, 2000)
+  end)
+  EXPECT_HMICALL("TTS.Speak", pParams.responseTtsParams)
+  :Do(function(_, data)
+    common.getHMIConnection():SendNotification("TTS.Started")
+    local function SpeakResp()
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+      common.getHMIConnection():SendNotification("TTS.Stopped")
+    end
+    RUN_AFTER(SpeakResp, 1000)
+  end)
+  common.getMobileSession():ExpectNotification("OnHMIStatus",
+    { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "ATTENUATED" },
+    { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
+  :Times(2)
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS", info = "Requested image(s) not found" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("AlertManeuver with invalid image", alertManeuver, { allParams })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/013_GetWayPoints.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/013_GetWayPoints.lua
@@ -41,8 +41,8 @@ local responseParams = {
       phoneNumber = "Phone39300434",
       locationImage =
       {
-        value ="missed_icon.png",
-        imageType ="DYNAMIC",
+        value = common.getPathToFileInStorage("missed_icon.png"),
+        imageType = "DYNAMIC",
       },
       searchAddress =
       {

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/013_GetWayPoints.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/013_GetWayPoints.lua
@@ -5,10 +5,10 @@
 --
 -- Description:
 -- In case:
--- 1. Mobile app requests GetWayPoints with image that is absent on file system
+-- 1. Mobile app requests GetWayPoints
+-- 2. HMI sends Navigation.GetWayPoints with image that is absent on file system
 -- SDL must:
--- 1. transfer this RPC to HMI for processing
--- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+-- 1. transfer the received from HMI response to mobile app
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
@@ -67,13 +67,13 @@ local function getWayPoints()
   responseParams.appID = common.getHMIAppId()
   EXPECT_HMICALL("Navigation.GetWayPoints", requestParams)
   :Do(function(_,data)
-      common.getHMIConnection():SendResponse(data.id, data.method, "WARNINGS", responseParams)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", responseParams)
     end)
 
   local ExpectedResponse = common.cloneTable(responseParams)
   ExpectedResponse.appID = nil
   ExpectedResponse["success"] = true
-  ExpectedResponse["resultCode"] = "WARNINGS"
+  ExpectedResponse["resultCode"] = "SUCCESS"
   common.getMobileSession():ExpectResponse(cid, ExpectedResponse)
 end
 

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/013_GetWayPoints.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/013_GetWayPoints.lua
@@ -1,0 +1,91 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests GetWayPoints with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  wayPointType = "DESTINATION"
+}
+
+local responseParams = {
+  wayPoints = {
+    {
+      coordinate =
+      {
+        latitudeDegrees = 1.1,
+        longitudeDegrees = 1.1
+      },
+      locationName = "Hotel",
+      addressLines =
+      {
+        "Hotel Bora",
+        "Hotel 5 stars"
+      },
+      locationDescription = "VIP Hotel",
+      phoneNumber = "Phone39300434",
+      locationImage =
+      {
+        value ="missed_icon.png",
+        imageType ="DYNAMIC",
+      },
+      searchAddress =
+      {
+        countryName = "countryName",
+        countryCode = "countryCode",
+        postalCode = "postalCode",
+        administrativeArea = "administrativeArea",
+        subAdministrativeArea = "subAdministrativeArea",
+        locality = "locality",
+        subLocality = "subLocality",
+        thoroughfare = "thoroughfare",
+        subThoroughfare = "subThoroughfare"
+      }
+    }
+  }
+}
+
+--[[ Local Functions ]]
+local function getWayPoints()
+  local cid = common.getMobileSession():SendRPC("GetWayPoints", requestParams)
+  requestParams.appID = common.getHMIAppId()
+  responseParams.appID = common.getHMIAppId()
+  EXPECT_HMICALL("Navigation.GetWayPoints", requestParams)
+  :Do(function(_,data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "WARNINGS", responseParams)
+    end)
+
+  local ExpectedResponse = common.cloneTable(responseParams)
+  ExpectedResponse.appID = nil
+  ExpectedResponse["success"] = true
+  ExpectedResponse["resultCode"] = "WARNINGS"
+  common.getMobileSession():ExpectResponse(cid, ExpectedResponse)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("GetWayPoints with invalid image", getWayPoints)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/014_OnWayPointChange.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/014_OnWayPointChange.lua
@@ -1,0 +1,80 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. HMI sends OnWayPointChange with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to mobile app for processing
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local notifParams = {
+  wayPoints =
+  {
+    {
+      coordinate = {
+        latitudeDegrees = -90,
+        longitudeDegrees = -180
+       },
+      locationName = "Ho Chi Minh",
+      addressLines = {"182 Le Dai Hanh"},
+      locationDescription = "Toa nha Flemington",
+      phoneNumber = "1231414",
+      locationImage = {
+        value = common.getPathToFileInStorage("missed_icon.png"),
+        imageType = "DYNAMIC"
+      },
+      searchAddress = {
+        countryName = "aaa",
+        countryCode = "084",
+        postalCode = "test",
+        administrativeArea = "aa",
+        subAdministrativeArea = "a",
+        locality = "a",
+        subLocality = "a",
+        thoroughfare = "a",
+        subThoroughfare = "a"
+      }
+    }
+  }
+}
+
+--[[ Local Functions ]]
+local function subcribleWayPoints()
+  local cid = common.getMobileSession():SendRPC("SubscribeWayPoints",{})
+  EXPECT_HMICALL("Navigation.SubscribeWayPoints")
+  :Do(function(_,data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS",{})
+    end)
+  common.getMobileSession():ExpectResponse(cid, {success = true , resultCode = "SUCCESS"})
+  common.getMobileSession():ExpectNotification("OnHashChange")
+end
+
+local function onWayPointChange()
+  common.getHMIConnection():SendNotification("Navigation.OnWayPointChange", notifParams)
+  common.getMobileSession():ExpectNotification("OnWayPointChange", notifParams)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+runner.Step("SubcribleWayPoints", subcribleWayPoints)
+
+runner.Title("Test")
+runner.Step("OnWayPointChange with invalid image", onWayPointChange)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/014_OnWayPointChange.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/014_OnWayPointChange.lua
@@ -50,7 +50,7 @@ local notifParams = {
 }
 
 --[[ Local Functions ]]
-local function subcribleWayPoints()
+local function subscribeWayPoints()
   local cid = common.getMobileSession():SendRPC("SubscribeWayPoints",{})
   EXPECT_HMICALL("Navigation.SubscribeWayPoints")
   :Do(function(_,data)
@@ -71,7 +71,7 @@ runner.Step("Clean environment", common.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("RAI", common.registerAppWOPTU)
 runner.Step("Activate App", common.activateApp)
-runner.Step("SubcribleWayPoints", subcribleWayPoints)
+runner.Step("SubcribleWayPoints", subscribeWayPoints)
 
 runner.Title("Test")
 runner.Step("OnWayPointChange with invalid image", onWayPointChange)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/015_SetGlobalProperties.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/015_SetGlobalProperties.lua
@@ -1,0 +1,112 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0042-transfer-invalid-image-rpc.md
+--
+-- Requirement summary:TBD
+--
+-- Description:
+-- In case:
+-- 1. Mobile app requests SetGlobalProperties with image that is absent on file system
+-- SDL must:
+-- 1. transfer this RPC to HMI for processing
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/Transfer_RPC_with_invalid_image/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local requestParams = {
+  helpPrompt = {
+    {
+      text = "Help prompt",
+      type = "TEXT"
+    }
+  },
+  timeoutPrompt = {
+    {
+      text = "Timeout prompt",
+      type = "TEXT"
+    }
+  },
+  vrHelpTitle = "VR help title",
+  vrHelp = {
+    {
+      position = 1,
+      image = {
+        value = "missed_icon.png",
+        imageType = "DYNAMIC"
+      },
+      text = "VR help item"
+    }
+  },
+  menuTitle = "Menu Title",
+  menuIcon = {
+    value = "missed_icon.png",
+    imageType = "DYNAMIC"
+  },
+  keyboardProperties = {
+    keyboardLayout = "QWERTY",
+    keypressMode = "SINGLE_KEYPRESS",
+    limitedCharacterList = {"a"},
+    language = "EN-US",
+    autoCompleteText = "Daemon, Freedom"
+  }
+}
+
+local responseUiParams = {
+  vrHelpTitle = requestParams.vrHelpTitle,
+  vrHelp = requestParams.vrHelp,
+  menuTitle = requestParams.menuTitle,
+  menuIcon = requestParams.menuIcon,
+  keyboardProperties = requestParams.keyboardProperties
+}
+
+local responseTtsParams = {
+  timeoutPrompt = requestParams.timeoutPrompt,
+  helpPrompt = requestParams.helpPrompt
+}
+
+local allParams = {
+  requestParams = requestParams,
+  responseUiParams = responseUiParams,
+  responseTtsParams = responseTtsParams
+}
+
+--[[ Local Functions ]]
+local function setGlobalProperties(pParams)
+  local cid = common.getMobileSession():SendRPC("SetGlobalProperties", pParams.requestParams)
+
+  pParams.responseUiParams.appID = common.getHMIAppId()
+  pParams.responseUiParams.vrHelp[1].image.value = common.getPathToFileInStorage("missed_icon.png")
+  pParams.responseUiParams.menuIcon.value = common.getPathToFileInStorage("missed_icon.png")
+  EXPECT_HMICALL("UI.SetGlobalProperties", pParams.responseUiParams)
+  :Do(function(_,data)
+    common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+  end)
+
+  pParams.responseTtsParams.appID = common.getHMIAppId()
+  EXPECT_HMICALL("TTS.SetGlobalProperties", pParams.responseTtsParams)
+  :Do(function(_,data)
+    common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+  end)
+
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS",
+    info = "Requested image(s) not found"})
+  common.getMobileSession():ExpectNotification("OnHashChange")
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerAppWOPTU)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("SetGlobalProperties with invalid image", setGlobalProperties, {allParams})
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/Transfer_RPC_with_invalid_image/common.lua
+++ b/test_scripts/API/Transfer_RPC_with_invalid_image/common.lua
@@ -1,0 +1,56 @@
+---------------------------------------------------------------------------------------------------
+-- common module
+---------------------------------------------------------------------------------------------------
+--[[ General configuration parameters ]]
+config.defaultProtocolVersion = 2
+
+--[[ Required Shared libraries ]]
+local actions = require("user_modules/sequences/actions")
+local utils = require('user_modules/utils')
+local json = require("modules/json")
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+local commonSteps = require("user_modules/shared_testcases/commonSteps")
+local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
+
+--[[ Local Variables ]]
+local common = actions
+common.cloneTable = utils.cloneTable
+local preloadedPT = commonFunctions:read_parameter_from_smart_device_link_ini("PreloadedPT")
+
+--[[Module functions]]
+function common.preconditions()
+  commonFunctions:SDLForceStop()
+  commonSteps:DeletePolicyTable()
+  commonSteps:DeleteLogsFiles()
+  commonPreconditions:BackupFile(preloadedPT)
+  common.updatePreloadedPT()
+end
+
+function common.postconditions()
+  StopSDL()
+  commonPreconditions:RestoreFile(preloadedPT)
+end
+
+function common.updatePreloadedPT()
+  local preloadedFile = commonPreconditions:GetPathToSDL() .. preloadedPT
+  local pt = utils.jsonFileToTable(preloadedFile)
+  pt.policy_table.functional_groupings["DataConsent-2"].rpcs = json.null
+  local additionalRPCs = {
+    "SendLocation", "SubscribeVehicleData", "UnsubscribeVehicleData", "GetVehicleData", "UpdateTurnList",
+    "AlertManeuver", "DialNumber", "ReadDID", "GetDTCs", "ShowConstantTBT", "GetWayPoints", "SubscribeWayPoints",
+    "OnWayPointChange"
+  }
+  pt.policy_table.functional_groupings.NewTestCaseGroup = { rpcs = { } }
+  for _, v in pairs(additionalRPCs) do
+    pt.policy_table.functional_groupings.NewTestCaseGroup.rpcs[v] = {
+      hmi_levels = { "BACKGROUND", "FULL", "LIMITED" }
+    }
+  end
+  pt.policy_table.app_policies["0000001"] = common.cloneTable(pt.policy_table.app_policies.default)
+  pt.policy_table.app_policies["0000001"].groups = { "Base-4", "NewTestCaseGroup" }
+  pt.policy_table.app_policies["0000001"].keep_context = true
+  pt.policy_table.app_policies["0000001"].steal_focus = true
+  utils.tableToJsonFile(pt, preloadedFile)
+end
+
+return common

--- a/test_sets/SDL_0042_Transfer_RPC_with_Invalid_Image.txt
+++ b/test_sets/SDL_0042_Transfer_RPC_with_Invalid_Image.txt
@@ -1,0 +1,15 @@
+./test_scripts/API/Transfer_RPC_with_invalid_image/001_AddCommand.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/002_AddSubMenu.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/003_Alert.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/004_CreateInteractionChoiceSet.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/006_ScrollableMessage.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/007_Show.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/008_ShowConstantTBT.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/009_SendLocation.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/010_SetAppIcon.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/011_UpdateTurnList.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/012_AlertManeuver.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/013_GetWayPoints.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/014_OnWayPointChange.lua
+./test_scripts/API/Transfer_RPC_with_invalid_image/015_SetGlobalProperties.lua


### PR DESCRIPTION
ATF Test Scripts to check invalid image RPC transfer

This PR is ready for review.

### Summary
Scripts for 'RPC’s with invalid image reference parameters to the HMI' feature.

### ATF version
[Develop branch](https://github.com/smartdevicelink/sdl_atf_test_scripts/tree/develop)

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)