### PR TITLE
Update for Policy scripts due to changes introduced by Expandable Design for Proprietary Data Exchange feature

### DIFF
--- a/files/Base4InPreDataConsent_preloaded_pt.json
+++ b/files/Base4InPreDataConsent_preloaded_pt.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/DeviceConsentedAndAppPermissionsForConsent_preloaded_pt.json
+++ b/files/DeviceConsentedAndAppPermissionsForConsent_preloaded_pt.json
@@ -2251,14 +2251,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
              "0000001": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["DrivingCharacteristics-3","Base-4"]
+                "groups": ["DrivingCharacteristics-3","Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/DeviceGroupInPreconsented_preloadedPT.json
+++ b/files/DeviceGroupInPreconsented_preloadedPT.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,
@@ -2259,7 +2260,7 @@
                 "priority": "NONE",
                 "default_hmi": "NONE",
                 "groups": ["DataConsent-2"],
-		"preconsented_groups":["DataConsent-2"]
+                "preconsented_groups":["DataConsent-2"]
             },
             "pre_DataConsent": {
                 "keep_context": false,

--- a/files/FocusContextTrue_preloaded_pt.json
+++ b/files/FocusContextTrue_preloaded_pt.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/GroupsForApp_preloaded_pt.json
+++ b/files/GroupsForApp_preloaded_pt.json
@@ -2252,7 +2252,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "0000001": {
             "keep_context": false,
@@ -2262,7 +2263,8 @@
             "groups": [
               "SendLocation",
               "DataConsent-2"
-            ]
+            ],
+            "RequestType": []
         },
             "device": {
                 "keep_context": false,

--- a/files/KeepContextTrue_preloaded_pt.json
+++ b/files/KeepContextTrue_preloaded_pt.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/PTFromCloud_Nickname_validation.json
+++ b/files/PTFromCloud_Nickname_validation.json
@@ -382,7 +382,8 @@
 				"steal_focus": false,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+        "RequestType": []
 			},
 			"1234567": {
 				"keep_context": false,
@@ -390,7 +391,8 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
-				"nicknames": ["AnotherName"]
+				"nicknames": ["AnotherName"],
+        "RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/PTFromCloud_Nickname_validation.json
+++ b/files/PTFromCloud_Nickname_validation.json
@@ -383,7 +383,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"1234567": {
 				"keep_context": false,
@@ -392,7 +392,7 @@
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
 				"nicknames": ["AnotherName"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/PTU_AppIDAppHMIType.json
+++ b/files/PTU_AppIDAppHMIType.json
@@ -2250,7 +2250,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "0000002": {
                 "keep_context": false,
@@ -2258,7 +2259,8 @@
                 "priority": "NONE",
                 "default_hmi": "NONE",
                 "groups": ["Base-4"],
-                "AppHMIType": ["MEDIA","INFORMATION"]
+                "AppHMIType": ["MEDIA","INFORMATION"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/PTU_AppIDDefaultHMI.json
+++ b/files/PTU_AppIDDefaultHMI.json
@@ -2250,14 +2250,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "0000002": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "BACKGROUND",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/PTU_AppIDGroups.json
+++ b/files/PTU_AppIDGroups.json
@@ -2250,14 +2250,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "0000002": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Location-1", "Navigation-1"]
+                "groups": ["Location-1", "Navigation-1"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/PTU_AppRevokedGroup.json
+++ b/files/PTU_AppRevokedGroup.json
@@ -2293,7 +2293,8 @@
         "steal_focus": false,
         "priority": "NONE",
         "default_hmi": "NONE",
-        "groups": ["Base-4"]
+        "groups": ["Base-4"],
+        "RequestType": []
       },
      "0000001":null,
       "device": {

--- a/files/PTU_BackgroundDefaultHMI_InDefault.json
+++ b/files/PTU_BackgroundDefaultHMI_InDefault.json
@@ -2250,7 +2250,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "BACKGROUND",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/PTU_GetUserFriendlyMessage_without_DE_DE.json
+++ b/files/PTU_GetUserFriendlyMessage_without_DE_DE.json
@@ -41,7 +41,7 @@
 			},
 			"Base-4" : {
 				"rpcs" : {
-				
+
 				"ReadDID": {
 				"hmi_levels": [
 				"BACKGROUND",
@@ -49,8 +49,8 @@
 				"LIMITED"
 				]
 				}
-				, 
-				
+				,
+
 				"GetDTCs": {
 				"hmi_levels": [
 				"BACKGROUND",
@@ -58,8 +58,8 @@
 				"LIMITED"
 				]
 				}
-				, 
-				
+				,
+
 				"DiagnosticMessage": {
 				"hmi_levels": [
 				"BACKGROUND",
@@ -67,8 +67,8 @@
 				"LIMITED"
 				]
 				}
-				, 
-				
+				,
+
 				"SubscribeVehicleData": {
 				"hmi_levels": [
 				"BACKGROUND",
@@ -76,8 +76,8 @@
 				"LIMITED"
 				]
 				}
-				, 
-				
+				,
+
 				"GetVehicleData": {
 				"hmi_levels": [
 				"BACKGROUND",
@@ -85,8 +85,8 @@
 				"LIMITED"
 				]
 				}
-				, 
-				
+				,
+
 				"UnsubscribeVehicleData": {
 				"hmi_levels": [
 				"BACKGROUND",
@@ -94,7 +94,7 @@
 				"LIMITED"
 				]
 				}
-				, 
+				,
 					"AddCommand" : {
 						"hmi_levels" : ["BACKGROUND",
 							"FULL",
@@ -1602,7 +1602,7 @@
 						}
 					}
 				},
-				
+
 				"group1" : {
 					"languages" : {
 						"de-de" : {
@@ -2375,21 +2375,24 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "groupName_11", "groupName_12"]
+                "groups": ["Base-4", "groupName_11", "groupName_12"],
+                "RequestType": []
             },
             "0000002": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "groupName_21", "groupName_22"]
+                "groups": ["Base-4", "groupName_21", "groupName_22"],
+                "RequestType": []
             },
 			"default" : {
 				"keep_context" : false,
 				"steal_focus" : false,
 				"priority" : "NONE",
 				"default_hmi" : "NONE",
-				"groups": ["Base-4", "Location-1", "DrivingCharacteristics-3", "VehicleInfo-3", "Emergency-1", "PropriataryData-1"]
+				"groups": ["Base-4", "Location-1", "DrivingCharacteristics-3", "VehicleInfo-3", "Emergency-1", "PropriataryData-1"],
+				"RequestType": []
 			},
 			"device" : {
 				"keep_context" : false,

--- a/files/PTU_NewDefaultPermissions.json
+++ b/files/PTU_NewDefaultPermissions.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "Location-1"]
+                "groups": ["Base-4", "Location-1"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/PTU_NewPermissionsForUserConsent.json
+++ b/files/PTU_NewPermissionsForUserConsent.json
@@ -2293,7 +2293,8 @@
         "steal_focus": false,
         "priority": "NONE",
         "default_hmi": "NONE",
-        "groups": ["Base-4"]
+        "groups": ["Base-4"],
+        "RequestType": []
       },
       "device": {
         "keep_context": false,
@@ -2316,7 +2317,8 @@
         "steal_focus": false,
         "priority": "NONE",
         "default_hmi": "NONE",
-        "groups": ["Base-4", "Location-1", "DrivingCharacteristics-3"]
+        "groups": ["Base-4", "Location-1", "DrivingCharacteristics-3"],
+        "RequestType": []
       }
     }
   }

--- a/files/PTU_RequestType_for_app_1234567.json
+++ b/files/PTU_RequestType_for_app_1234567.json
@@ -2053,7 +2053,8 @@
 				"steal_focus": false,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/PTU_UpdateDefaultGroups.json
+++ b/files/PTU_UpdateDefaultGroups.json
@@ -2250,7 +2250,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Location-1"]
+                "groups": ["Location-1"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/PTU_UpdateDefaultPreconsentedGroups.json
+++ b/files/PTU_UpdateDefaultPreconsentedGroups.json
@@ -2251,7 +2251,8 @@
                 "priority": "NONE",
                 "default_hmi": "NONE",
                 "groups": ["Base-4"],
-                "preconsented_groups":["Location-1"]
+                "preconsented_groups":["Location-1"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/PTU_with_permissions_for_app_0000001.json
+++ b/files/PTU_with_permissions_for_app_0000001.json
@@ -2047,7 +2047,7 @@
 				"default_hmi": "BACKGROUND",
 				"groups": ["Location-1"],
 				"nicknames": ["Test Application"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"default": {
 				"keep_context": false,
@@ -2055,7 +2055,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/PTU_with_permissions_for_app_0000001.json
+++ b/files/PTU_with_permissions_for_app_0000001.json
@@ -2046,14 +2046,16 @@
 				"priority": "EMERGENCY",
 				"default_hmi": "BACKGROUND",
 				"groups": ["Location-1"],
-				"nicknames": ["Test Application"]
+				"nicknames": ["Test Application"],
+        "RequestType": []
 			},
 			"default": {
 				"keep_context": false,
 				"steal_focus": false,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+        "RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/PTU_with_permissions_for_app_1234567.json
+++ b/files/PTU_with_permissions_for_app_1234567.json
@@ -2045,14 +2045,16 @@
 				"priority": "EMERGENCY",
 				"default_hmi": "BACKGROUND",
 				"groups": ["Permission_for_1234567"],
-				"nicknames": ["SPT"]
+				"nicknames": ["SPT"],
+        "RequestType": []
 			},
 			"default": {
 				"keep_context": false,
 				"steal_focus": false,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+        "RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/PTU_with_permissions_for_app_1234567.json
+++ b/files/PTU_with_permissions_for_app_1234567.json
@@ -2046,7 +2046,7 @@
 				"default_hmi": "BACKGROUND",
 				"groups": ["Permission_for_1234567"],
 				"nicknames": ["SPT"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"default": {
 				"keep_context": false,
@@ -2054,7 +2054,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/PriorityNormal_preloaded_pt.json
+++ b/files/PriorityNormal_preloaded_pt.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/App_Permissions/DisallowedRPCs.json
+++ b/files/jsons/Policies/App_Permissions/DisallowedRPCs.json
@@ -2242,7 +2242,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/App_Permissions/ptu_014.json
+++ b/files/jsons/Policies/App_Permissions/ptu_014.json
@@ -1,12 +1,13 @@
 {
-    "policy_table": {        
-        "app_policies": {            
+    "policy_table": {
+        "app_policies": {
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,
@@ -23,9 +24,9 @@
                 "groups": ["BaseBeforeDataConsent"]
             }
         },
-        "functional_groupings": {            
+        "functional_groupings": {
             "SpecificPermissions": {
-                "rpcs": { 
+                "rpcs": {
 		    "PutFile": {
                         "hmi_levels": [
                             "BACKGROUND",
@@ -33,7 +34,7 @@
                             "LIMITED",
                             "NONE"
                         ]
-                    }                                       
+                    }
                 }
             },
             "BackgroundAPT": {
@@ -57,8 +58,8 @@
             },
             "Base-4": {
                 "rpcs": {
-                    
-                    
+
+
                     "ChangeRegistration": {
                         "hmi_levels": [
                             "BACKGROUND",
@@ -296,7 +297,7 @@
                             "BACKGROUND"
                         ]
                     },
-                   
+
                     "Slider": {
                         "hmi_levels": [
                             "FULL"
@@ -315,7 +316,7 @@
                             "LIMITED"
                         ]
                     },
-                   
+
                     "UnregisterAppInterface": {
                         "hmi_levels": [
                             "BACKGROUND",
@@ -1198,7 +1199,7 @@
                 },
                 "user_consent_prompt": "VehicleInfo"
             }
-        },        
+        },
         "module_config": {
             "endpoints": {
                 "0x04": {

--- a/files/jsons/Policies/PTU_ValidationRules/PTU_has_omitted.json
+++ b/files/jsons/Policies/PTU_ValidationRules/PTU_has_omitted.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/PTU_ValidationRules/PTU_invalid_optional.json
+++ b/files/jsons/Policies/PTU_ValidationRules/PTU_invalid_optional.json
@@ -2545,7 +2545,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4"
-        ]
+        ],
+        "RequestType": []
       }
     },
     "module_config": {

--- a/files/jsons/Policies/PTU_ValidationRules/invalid_PTU_missing_seconds_between_retries.json
+++ b/files/jsons/Policies/PTU_ValidationRules/invalid_PTU_missing_seconds_between_retries.json
@@ -2293,7 +2293,7 @@
         "RequestType":[
         	"PROPRIETARY",
         	"HTTP",
-        	"QUERY_APPS"	
+        	"QUERY_APPS"
         ]
       },
       "device": {
@@ -2314,7 +2314,7 @@
           "BaseBeforeDataConsent"
         ],
         "RequestType":[
-        	"PROPRIETARY"	
+        	"PROPRIETARY"
         ]
       },
       "123456": {
@@ -2329,7 +2329,7 @@
           "TRAFFIC_MESSAGE_CHANNEL",
           "PROPRIETARY",
           "HTTP",
-          "QUERY_APPS"  
+          "QUERY_APPS"
         ]
       }
     },

--- a/files/jsons/Policies/PTU_ValidationRules/preloaded_memory_kb_exist.json
+++ b/files/jsons/Policies/PTU_ValidationRules/preloaded_memory_kb_exist.json
@@ -2252,7 +2252,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/PTU_ValidationRules/ptu_012.json
+++ b/files/jsons/Policies/PTU_ValidationRules/ptu_012.json
@@ -1,5 +1,5 @@
 {
-    "policy_table": {        
+    "policy_table": {
         "app_policies": {
             "0000001": {
 		"keep_context": false,
@@ -7,14 +7,16 @@
                 "priority": "NONE",
                 "default_hmi": "NONE",
                 "groups": ["Base-4", "Base-6"],
-                "nicknames": ["App1"]
+                "nicknames": ["App1"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,
@@ -1225,7 +1227,7 @@
                 },
                 "user_consent_prompt": "VehicleInfo"
             }
-        },        
+        },
         "module_config": {
             "endpoints": {
                 "0x04": {

--- a/files/jsons/Policies/PTU_ValidationRules/ptu_RAI.json
+++ b/files/jsons/Policies/PTU_ValidationRules/ptu_RAI.json
@@ -2296,7 +2296,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4"
-        ]
+        ],
+        "RequestType": []
       },
       "654321": {
         "keep_context": true,
@@ -2306,7 +2307,8 @@
         "groups": [
           "Base-4"
         ],
-      "nicknames":["Tester"]
+      "nicknames":["Tester"],
+      "RequestType": []
       },
       "device": {
         "keep_context": false,

--- a/files/jsons/Policies/PTU_ValidationRules/sdl_preloaded_pt_without_optional_params.json
+++ b/files/jsons/Policies/PTU_ValidationRules/sdl_preloaded_pt_without_optional_params.json
@@ -2556,7 +2556,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4"
-        ]
+        ],
+        "RequestType": []
       },
       "device": {
         "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/endpoints_appId.json
+++ b/files/jsons/Policies/Policy_Table_Update/endpoints_appId.json
@@ -2246,7 +2246,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/exchange_after_1000_kilometers_ptu.json
+++ b/files/jsons/Policies/Policy_Table_Update/exchange_after_1000_kilometers_ptu.json
@@ -2342,7 +2342,8 @@
         "steal_focus" : false,
         "priority" : "NONE",
         "default_hmi" : "NONE",
-        "groups" : ["Base-4"]
+        "groups" : ["Base-4"],
+        "RequestType": []
       },
       "device" : {
         "keep_context" : false,

--- a/files/jsons/Policies/Policy_Table_Update/few_endpoints_appId.json
+++ b/files/jsons/Policies/Policy_Table_Update/few_endpoints_appId.json
@@ -2250,7 +2250,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/few_endpoints_appId_default.json
+++ b/files/jsons/Policies/Policy_Table_Update/few_endpoints_appId_default.json
@@ -17,7 +17,7 @@
                                 "http://policies.telematics.ford.com/api/policies3",
                                 "http://policies.telematics.ford.com/api/policies1",
                                "http://policies.telematics.ford.com/api/policies2"
-                               
+
                                ]
 		        },
                 "0x04": {
@@ -2250,7 +2250,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/few_endpoints_appId_not_registered.json
+++ b/files/jsons/Policies/Policy_Table_Update/few_endpoints_appId_not_registered.json
@@ -2249,7 +2249,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/few_endpoints_appId_registered.json
+++ b/files/jsons/Policies/Policy_Table_Update/few_endpoints_appId_registered.json
@@ -2249,7 +2249,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/preloaded_18192.json
+++ b/files/jsons/Policies/Policy_Table_Update/preloaded_18192.json
@@ -943,7 +943,7 @@
                             "textBody": "TEXTBODY_DataConsent"
                         }
                     }
-                } 
+                }
             }
         },
         "app_policies": {
@@ -952,7 +952,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/ptu.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu.json
@@ -2301,7 +2301,7 @@
         "RequestType":[
         	"PROPRIETARY",
         	"HTTP",
-        	"QUERY_APPS"	
+        	"QUERY_APPS"
         ]
       },
       "device": {
@@ -2322,7 +2322,7 @@
           "BaseBeforeDataConsent"
         ],
         "RequestType":[
-        	"PROPRIETARY"	
+        	"PROPRIETARY"
         ]
       },
        "0000001": {
@@ -2335,7 +2335,7 @@
           "TRAFFIC_MESSAGE_CHANNEL",
           "PROPRIETARY",
           "HTTP",
-          "QUERY_APPS"  
+          "QUERY_APPS"
         ]
       },
       "MyTestApp": {
@@ -2344,7 +2344,8 @@
         "priority": "NONE",
         "default_hmi": "NONE",
         "groups": ["Base-4"],
-        "nicknames": ["Media Application", "MediaApp"]
+        "nicknames": ["Media Application", "MediaApp"],
+        "RequestType": []
       }
     }
   }

--- a/files/jsons/Policies/Policy_Table_Update/ptu_18190.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_18190.json
@@ -9,14 +9,16 @@
                 "groups": ["Base-4", "Base-6"],
                 "heart_beat_timeout_ms": 0,
                 "memory_kb": 0,
-                "nicknames": ["Test Application"]
+                "nicknames": ["Test Application"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/ptu_18192.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_18192.json
@@ -6,14 +6,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "Base-6"]
+                "groups": ["Base-4", "Base-6"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/ptu_18707_1.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_18707_1.json
@@ -6,14 +6,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/ptu_19168.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_19168.json
@@ -6,14 +6,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "Base-6"]
+                "groups": ["Base-4", "Base-6"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/ptu_22420.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_22420.json
@@ -6,14 +6,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "Base-6"]
+                "groups": ["Base-4", "Base-6"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/ptu_22421_1Mb.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_22421_1Mb.json
@@ -6,14 +6,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "Base-6"]
+                "groups": ["Base-4", "Base-6"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/ptu_22734.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_22734.json
@@ -1,19 +1,21 @@
 {
-    "policy_table": {        
+    "policy_table": {
         "app_policies": {
             "0000001": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "Base-6"]
+                "groups": ["Base-4", "Base-6"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,
@@ -30,7 +32,7 @@
                 "groups": ["BaseBeforeDataConsent"]
             }
         },
-        "functional_groupings": {            
+        "functional_groupings": {
             "BackgroundAPT": {
                 "rpcs": {
                     "EndAudioPassThru": {
@@ -1224,7 +1226,7 @@
                 },
                 "user_consent_prompt": "VehicleInfo"
             }
-        },        
+        },
         "module_config": {
             "endpoints": {
                 "0x04": {

--- a/files/jsons/Policies/Policy_Table_Update/ptu_after_n_ign.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_after_n_ign.json
@@ -2265,28 +2265,32 @@
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1"]
+				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1"],
+				"RequestType": []
 			},
 			"0000001": {
 				"keep_context": true,
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"]
+				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"],
+				"RequestType": []
 			},
 			"0000004": {
 				"keep_context": true,
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
-				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"]
+				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"],
+				"RequestType": []
 			},
 			"background": {
 				"keep_context": false,
 				"steal_focus": false,
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
-				"groups": ["Base-4", "Navigation-1"]
+				"groups": ["Base-4", "Navigation-1"],
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/jsons/Policies/Policy_Table_Update/ptu_without_preloaded.json
+++ b/files/jsons/Policies/Policy_Table_Update/ptu_without_preloaded.json
@@ -2346,7 +2346,8 @@
         "priority": "NONE",
         "default_hmi": "NONE",
         "groups": ["Base-4"],
-        "nicknames": ["Media Application", "MediaApp"]
+        "nicknames": ["Media Application", "MediaApp"],
+        "RequestType": []
       }
     }
   }

--- a/files/jsons/Policies/Related_HMI_API/OnAppPermissionConsent.json
+++ b/files/jsons/Policies/Related_HMI_API/OnAppPermissionConsent.json
@@ -2296,7 +2296,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4"
-        ]
+        ],
+        "RequestType": []
       },
 	  "0000001": {
         "keep_context": false,
@@ -2305,7 +2306,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4", "Notifications", "Location-1"
-        ]
+        ],
+        "RequestType": []
       },
       "device": {
         "keep_context": false,

--- a/files/jsons/Policies/Related_HMI_API/OnAppPermissionConsent_ptu.json
+++ b/files/jsons/Policies/Related_HMI_API/OnAppPermissionConsent_ptu.json
@@ -2295,7 +2295,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4"
-        ]
+        ],
+        "RequestType": []
       },
 	  "0000001": {
         "keep_context": false,
@@ -2304,7 +2305,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4", "Notifications", "Location-1"
-        ]
+        ],
+        "RequestType": []
       },
       "device": {
         "keep_context": false,

--- a/files/jsons/Policies/Related_HMI_API/OnAppPermissionConsent_ptu1.json
+++ b/files/jsons/Policies/Related_HMI_API/OnAppPermissionConsent_ptu1.json
@@ -2295,7 +2295,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4"
-        ]
+        ],
+        "RequestType": []
       },
 	  "0000001": {
         "keep_context": false,
@@ -2304,7 +2305,8 @@
         "default_hmi": "NONE",
         "groups": [
           "Base-4", "DrivingCharacteristics-3"
-        ]
+        ],
+        "RequestType": []
       },
       "device": {
         "keep_context": false,

--- a/files/jsons/Policies/appID_Management/ptu_0.json
+++ b/files/jsons/Policies/appID_Management/ptu_0.json
@@ -8,14 +8,16 @@
                 "steal_focus": false,
 				"default_hmi": "NONE",
                 "priority": "NONE",
-                "nicknames": ["Media Application", "MediaApp"]
+                "nicknames": ["Media Application", "MediaApp"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/appID_Management/ptu_01.json
+++ b/files/jsons/Policies/appID_Management/ptu_01.json
@@ -5,9 +5,9 @@
             "123_xyz": {
                 "groups": ["Base-6"],
                 "priority": "NONE",
-				"keep_context": false,
+                "keep_context": false,
                 "steal_focus": false,
-				"default_hmi": "NONE",
+                "default_hmi": "NONE",
                 "nicknames": ["Media Application", "MediaApp"],
                 "RequestType": []
             },

--- a/files/jsons/Policies/appID_Management/ptu_01.json
+++ b/files/jsons/Policies/appID_Management/ptu_01.json
@@ -8,14 +8,16 @@
 				"keep_context": false,
                 "steal_focus": false,
 				"default_hmi": "NONE",
-                "nicknames": ["Media Application", "MediaApp"]
+                "nicknames": ["Media Application", "MediaApp"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/appID_Management/ptu_013_1.json
+++ b/files/jsons/Policies/appID_Management/ptu_013_1.json
@@ -4,10 +4,10 @@
             "0000001": {
                 "groups": ["Base-4", "Base-6"],
                 "priority": "NONE",
-		        "keep_context": false,
+                "keep_context": false,
                 "steal_focus": false,
-		        "default_hmi": "NONE",
-		        "nicknames": ["App1"],
+                "default_hmi": "NONE",
+                "nicknames": ["App1"],
                 "RequestType": []
             },
             "default": {

--- a/files/jsons/Policies/appID_Management/ptu_013_1.json
+++ b/files/jsons/Policies/appID_Management/ptu_013_1.json
@@ -4,17 +4,19 @@
             "0000001": {
                 "groups": ["Base-4", "Base-6"],
                 "priority": "NONE",
-		"keep_context": false,
+		        "keep_context": false,
                 "steal_focus": false,
-		"default_hmi": "NONE",
-		"nicknames": ["App1"]
+		        "default_hmi": "NONE",
+		        "nicknames": ["App1"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/appID_Management/ptu_013_2.json
+++ b/files/jsons/Policies/appID_Management/ptu_013_2.json
@@ -4,9 +4,9 @@
             "0000001": {
                 "groups": ["Base-4", "Base-6"],
                 "priority": "NONE",
-		        "keep_context": false,
+                "keep_context": false,
                 "steal_focus": false,
-		        "default_hmi": "NONE",
+                "default_hmi": "NONE",
                 "nicknames": ["App1"],
                 "RequestType": []
             },

--- a/files/jsons/Policies/appID_Management/ptu_013_2.json
+++ b/files/jsons/Policies/appID_Management/ptu_013_2.json
@@ -4,10 +4,11 @@
             "0000001": {
                 "groups": ["Base-4", "Base-6"],
                 "priority": "NONE",
-		"keep_context": false,
+		        "keep_context": false,
                 "steal_focus": false,
-		"default_hmi": "NONE",
-                "nicknames": ["App1"]
+		        "default_hmi": "NONE",
+                "nicknames": ["App1"],
+                "RequestType": []
             },
             "123_xyz": null,
             "default": {
@@ -15,7 +16,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/appID_Management/ptu_1.json
+++ b/files/jsons/Policies/appID_Management/ptu_1.json
@@ -4,27 +4,27 @@
             "0000001": {
                 "groups": ["Base-4", "Base-6"],
                 "priority": "NONE",
-				"keep_context": false,
+                "keep_context": false,
                 "steal_focus": false,
-				"default_hmi": "NONE",
+                "default_hmi": "NONE",
                 "nicknames": ["App1"],
                 "RequestType": []
             },
             "123_xyz": {
                 "groups": ["Base-6"],
                 "priority": "NONE",
-				"keep_context": false,
+                "keep_context": false,
                 "steal_focus": false,
-				"default_hmi": "NONE",
+                "default_hmi": "NONE",
                 "nicknames": ["Media Application", "MediaApp"],
                 "RequestType": []
             },
             "456_abc": {
                 "groups": ["Base-6"],
                 "priority": "NONE",
-				"keep_context": false,
+                "keep_context": false,
                 "steal_focus": false,
-				"default_hmi": "NONE",
+                "default_hmi": "NONE",
                 "nicknames": ["ABC Application"],
                 "RequestType": []
             },

--- a/files/jsons/Policies/appID_Management/ptu_1.json
+++ b/files/jsons/Policies/appID_Management/ptu_1.json
@@ -7,7 +7,8 @@
 				"keep_context": false,
                 "steal_focus": false,
 				"default_hmi": "NONE",
-                "nicknames": ["App1"]
+                "nicknames": ["App1"],
+                "RequestType": []
             },
             "123_xyz": {
                 "groups": ["Base-6"],
@@ -15,7 +16,8 @@
 				"keep_context": false,
                 "steal_focus": false,
 				"default_hmi": "NONE",
-                "nicknames": ["Media Application", "MediaApp"]
+                "nicknames": ["Media Application", "MediaApp"],
+                "RequestType": []
             },
             "456_abc": {
                 "groups": ["Base-6"],
@@ -23,14 +25,16 @@
 				"keep_context": false,
                 "steal_focus": false,
 				"default_hmi": "NONE",
-                "nicknames": ["ABC Application"]
+                "nicknames": ["ABC Application"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/appID_Management/ptu_19849.json
+++ b/files/jsons/Policies/appID_Management/ptu_19849.json
@@ -6,21 +6,24 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "Base-6"]
+                "groups": ["Base-4", "Base-6"],
+                "RequestType": []
             },
             "123_xyz": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["SpecificPermissions"]
+                "groups": ["SpecificPermissions"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/build_options/ptu_14740.json
+++ b/files/jsons/Policies/build_options/ptu_14740.json
@@ -2307,14 +2307,16 @@
         "steal_focus": false,
         "priority": "NONE",
         "default_hmi": "NONE",
-        "groups": ["Base-6"]
+        "groups": ["Base-6"],
+        "RequestType": []
       },
  "0000001": {
         "keep_context": false,
         "steal_focus": false,
         "priority": "NONE",
         "default_hmi": "NONE",
-        "groups": ["Base-6"]
+        "groups": ["Base-6"],
+        "RequestType": []
       },
       "device": {
         "keep_context": false,

--- a/files/jsons/Policies/build_options/ptu_18269.json
+++ b/files/jsons/Policies/build_options/ptu_18269.json
@@ -6,14 +6,16 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4", "Base-6"]
+                "groups": ["Base-4", "Base-6"],
+                "RequestType": []
             },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/build_options/retry_seq.json
+++ b/files/jsons/Policies/build_options/retry_seq.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/user_consent/OnAppPermissionConsent_1.json
+++ b/files/jsons/Policies/user_consent/OnAppPermissionConsent_1.json
@@ -2250,14 +2250,16 @@
 		"default_hmi": "NONE",
 		"groups": [
 		  "Base-4", "Notifications", "Location-1"
-		]
+		],
+        "RequestType": []
 	      },
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/jsons/Policies/user_consent/OnAppPermissionConsent_1.json
+++ b/files/jsons/Policies/user_consent/OnAppPermissionConsent_1.json
@@ -2251,7 +2251,7 @@
 		"groups": [
 		  "Base-4", "Notifications", "Location-1"
 		],
-        "RequestType": []
+		"RequestType": []
 	      },
             "default": {
                 "keep_context": false,

--- a/files/jsons/Policies/user_consent/pre_dataconsent.json
+++ b/files/jsons/Policies/user_consent/pre_dataconsent.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/ptu_for_navi_app.json
+++ b/files/ptu_for_navi_app.json
@@ -2266,28 +2266,32 @@
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+        "RequestType": []
 			},
 			"0000001": {
 				"keep_context": true,
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+        "RequestType": []
 			},
 			"0000004": {
 				"keep_context": true,
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+        "RequestType": []
 			},
 			"background": {
 				"keep_context": false,
 				"steal_focus": false,
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
-				"groups": ["Base-4", "Navigation-1"]
+				"groups": ["Base-4", "Navigation-1"],
+        "RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/ptu_for_navi_app.json
+++ b/files/ptu_for_navi_app.json
@@ -2267,7 +2267,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"0000001": {
 				"keep_context": true,
@@ -2275,7 +2275,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"0000004": {
 				"keep_context": true,
@@ -2283,7 +2283,7 @@
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
 				"groups": ["Base-4"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"background": {
 				"keep_context": false,
@@ -2291,7 +2291,7 @@
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
 				"groups": ["Base-4", "Navigation-1"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/ptu_general.json
+++ b/files/ptu_general.json
@@ -142,7 +142,8 @@
 					"OnDriverDistraction": {
 						"hmi_levels": ["BACKGROUND",
 						"FULL",
-						"LIMITED"]
+						"LIMITED",
+					  "NONE"]
 					},
 					"OnEncodedSyncPData": {
 						"hmi_levels": ["BACKGROUND",

--- a/files/ptu_general.json
+++ b/files/ptu_general.json
@@ -2265,21 +2265,24 @@
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1"]
+				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1"],
+        "RequestType": []
 			},
 			"0000001": {
 				"keep_context": true,
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"]
+				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"],
+        "RequestType": []
 			},
 			"0000004": {
 				"keep_context": true,
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
-				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"]
+				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"],
+        "RequestType": []
 			},
 			"background": {
 				"keep_context": false,

--- a/files/ptu_general.json
+++ b/files/ptu_general.json
@@ -2267,7 +2267,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"0000001": {
 				"keep_context": true,
@@ -2275,7 +2275,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"0000004": {
 				"keep_context": true,
@@ -2283,7 +2283,7 @@
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
 				"groups": ["Base-4", "Navigation-1","DrivingCharacteristics-3", "Location-1", "VehicleInfo-3", "Emergency-1", "OnKeyboardInputOnlyGroup", "PropriataryData-1", "SendLocation"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"background": {
 				"keep_context": false,
@@ -2291,7 +2291,7 @@
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
 				"groups": ["Base-4", "Navigation-1"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/ptu_general.json
+++ b/files/ptu_general.json
@@ -2289,7 +2289,8 @@
 				"steal_focus": false,
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
-				"groups": ["Base-4", "Navigation-1"]
+				"groups": ["Base-4", "Navigation-1"],
+        "RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/ptu_general_0000001.json
+++ b/files/ptu_general_0000001.json
@@ -1810,14 +1810,16 @@
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+        "RequestType": []
 			},
 			"0000001": {
 				"keep_context": true,
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-8"]
+				"groups": ["Base-8"],
+        "RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/ptu_general_0000001.json
+++ b/files/ptu_general_0000001.json
@@ -1811,7 +1811,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"0000001": {
 				"keep_context": true,
@@ -1819,7 +1819,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-8"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/ptu_general_default_app-1234567.json
+++ b/files/ptu_general_default_app-1234567.json
@@ -2051,14 +2051,16 @@
 				"steal_focus": true,
 				"priority": "NONE",
 				"default_hmi": "NONE",
-				"groups": ["Base-4"]
+				"groups": ["Base-4"],
+        "RequestType": []
 			},
 			"background": {
 				"keep_context": false,
 				"steal_focus": false,
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
-				"groups": ["Base-4", "Navigation-1"]
+				"groups": ["Base-4", "Navigation-1"],
+        "RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/ptu_general_default_app-1234567.json
+++ b/files/ptu_general_default_app-1234567.json
@@ -2052,7 +2052,7 @@
 				"priority": "NONE",
 				"default_hmi": "NONE",
 				"groups": ["Base-4"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"background": {
 				"keep_context": false,
@@ -2060,7 +2060,7 @@
 				"priority": "NONE",
 				"default_hmi": "BACKGROUND",
 				"groups": ["Base-4", "Navigation-1"],
-        "RequestType": []
+				"RequestType": []
 			},
 			"device": {
 				"keep_context": false,

--- a/files/ptu_general_default_keep_context_false.json
+++ b/files/ptu_general_default_keep_context_false.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": true,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/ptu_general_default_keep_context_true.json
+++ b/files/ptu_general_default_keep_context_true.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": true,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/ptu_general_default_steal_focus_false.json
+++ b/files/ptu_general_default_steal_focus_false.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/ptu_general_default_steal_focus_true.json
+++ b/files/ptu_general_default_steal_focus_true.json
@@ -2251,7 +2251,8 @@
                 "steal_focus": true,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/files/sdl_preloaded_pt_AlertOnlyNotifications_1.json
+++ b/files/sdl_preloaded_pt_AlertOnlyNotifications_1.json
@@ -2252,7 +2252,8 @@
                 "steal_focus": false,
                 "priority": "NONE",
                 "default_hmi": "NONE",
-                "groups": ["Base-4"]
+                "groups": ["Base-4"],
+                "RequestType": []
             },
             "device": {
                 "keep_context": false,

--- a/test_scripts/Policies/Validation_of_PolicyTables/253_ATF_merge_preloaded_pt_into_local_pt_usage_and_error_counts.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/253_ATF_merge_preloaded_pt_into_local_pt_usage_and_error_counts.lua
@@ -95,7 +95,7 @@ local function updatePreloadedPt(updaters)
       updateFunc(data)
     end
   end
-
+  data.policy_table.app_policies["0000001"] = "default"
   local dataToWrite = json.encode(data)
   file = io.open(pathToFile, "w")
   file:write(dataToWrite)
@@ -198,7 +198,7 @@ testCasesForPolicyTable.Delete_Policy_table_snapshot()
 commonSteps:DeleteLogsFileAndPolicyTable()
 commonPreconditions:BackupFile(PRELOADED_PT_FILE_NAME)
 prepareInitialPreloadedPT()
-commonPreconditions:Connecttest_without_ExitBySDLDisconnect_WithoutOpenConnectionRegisterApp("connecttest_ConnectMobile.lua")
+-- commonPreconditions:Connecttest_without_ExitBySDLDisconnect_WithoutOpenConnectionRegisterApp("connecttest_ConnectMobile.lua")
 
 --[[ General configuration parameters ]]
 -- Test = require('user_modules/connecttest_ConnectMobile')

--- a/test_scripts/Policies/Validation_of_PolicyTables/309_ATF_Check_count_of_rejected_rpcs_calls.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/309_ATF_Check_count_of_rejected_rpcs_calls.lua
@@ -21,27 +21,21 @@
 ---------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local commonSteps = require('user_modules/shared_testcases/commonSteps')
-local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+local testCasesForPolicyTable = require("user_modules/shared_testcases/testCasesForPolicyTable")
 
 --[[ General Precondition before ATF start ]]
+config.defaultProtocolVersion = 2
 commonSteps:DeleteLogsFileAndPolicyTable()
+testCasesForPolicyTable:Precondition_updatePolicy_By_overwriting_preloaded_pt("files/ptu_general.json")
 
 --[[ General Settings for configuration ]]
-Test = require('connecttest')
-require('cardinalities')
+Test = require("connecttest")
 require('user_modules/AppTypes')
 
 --[[ Test ]]
 function Test:SendDissalowedRpcInNone()
-  local cid = self.mobileSession:SendRPC("AddCommand",
-    {
-      cmdID = 10,
-      menuParams =
-      {
-        position = 0,
-        menuName ="Command"
-      }
-    })
+  local cid = self.mobileSession:SendRPC("GetVehicleData", { gps = true})
   EXPECT_RESPONSE(cid, { success = false, resultCode = "DISALLOWED" })
 end
 
@@ -54,5 +48,7 @@ function Test:CheckDB_updated_count_of_rejected_rpcs_calls()
     self:FailTestCase("DB doesn't include expected value for count_of_rejected_rpcs_calls. Exp: "..exp_result[1])
   end
 end
+
+testCasesForPolicyTable:Restore_preloaded_pt()
 
 return Test

--- a/test_scripts/Policies/Validation_of_PolicyTables/313_ATF_Check_count_of_rpcs_sent_in_hmi_none.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/313_ATF_Check_count_of_rpcs_sent_in_hmi_none.lua
@@ -19,27 +19,21 @@
 ---------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local commonSteps = require('user_modules/shared_testcases/commonSteps')
-local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+local testCasesForPolicyTable = require("user_modules/shared_testcases/testCasesForPolicyTable")
 
 --[[ General Precondition before ATF start ]]
+config.defaultProtocolVersion = 2
 commonSteps:DeleteLogsFileAndPolicyTable()
+testCasesForPolicyTable:Precondition_updatePolicy_By_overwriting_preloaded_pt("files/ptu_general.json")
 
 --[[ General Settings for configuration ]]
-Test = require('connecttest')
-require('cardinalities')
+Test = require("connecttest")
 require('user_modules/AppTypes')
 
 --[[ Test ]]
 function Test:SendDissalowedRpcInNone()
-  local cid = self.mobileSession:SendRPC("AddCommand",
-    {
-      cmdID = 10,
-      menuParams =
-      {
-        position = 0,
-        menuName ="Command"
-      }
-    })
+  local cid = self.mobileSession:SendRPC("GetVehicleData", { gps = true})
   EXPECT_RESPONSE(cid, { success = false, resultCode = "DISALLOWED" })
 end
 
@@ -52,5 +46,7 @@ function Test:CheckDB_updated_count_of_rejections_duplicate_name()
     self:FailTestCase("DB doesn't include expected value for count_of_rpcs_sent_in_hmi_none. Exp: "..exp_result[1])
   end
 end
+
+testCasesForPolicyTable:Restore_preloaded_pt()
 
 return Test

--- a/test_scripts/Policies/user_consent_of_Policies/211_ATF_User_consent_initing_after_PTU_LIMITED.lua
+++ b/test_scripts/Policies/user_consent_of_Policies/211_ATF_User_consent_initing_after_PTU_LIMITED.lua
@@ -35,7 +35,7 @@ function Test:Precondition_Activate_app()
 end
 
 function Test:Precondition_Switch_app_to_LIMITED()
-  self.hmiConnection:SendNotification("BasicCommunication.OnEventChanged",{isActive = true,eventName ="AUDIO_SOURCE"})
+  self.hmiConnection:SendNotification("BasicCommunication.OnAppDeactivated", {appID = self.applications[config.application1.registerAppInterfaceParams.appName] })
   self.mobileSession:ExpectNotification("OnHMIStatus",{hmiLevel ="LIMITED", systemContext = "MAIN"})
 end
 

--- a/user_modules/shared_testcases/testCasesForPolicyTable.lua
+++ b/user_modules/shared_testcases/testCasesForPolicyTable.lua
@@ -873,7 +873,10 @@ function testCasesForPolicyTable:Precondition_updatePolicy_By_overwriting_preloa
               commonPreconditions:BackupFile(pt_fileName)
 
               --Copy new policy table to /sdl/bin folder
-              os.execute(" cp -f " .. PTName .. " " .. commonPreconditions:GetPathToSDL() .. pt_fileName)
+              local cmd = " cp -f " .. PTName .. " " .. commonPreconditions:GetPathToSDL() .. pt_fileName
+              if not os.execute(cmd) then
+                commonFunctions:printError("Preloaded was not updated")
+              end
 
               --Delete policy table
               commonSteps:DeletePolicyTable()

--- a/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
+++ b/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
@@ -131,6 +131,7 @@ function testCasesForPolicyTableSnapshot:verify_PTS(is_created, app_IDs, device_
     { name = "module_config.notifications_per_minute_by_priority.COMMUNICATION", elem_required = "required"},
     { name = "module_config.notifications_per_minute_by_priority.NORMAL", elem_required = "required"},
     { name = "module_config.notifications_per_minute_by_priority.NONE", elem_required = "required"},
+    { name = "module_config.notifications_per_minute_by_priority.PROJECTION", elem_required = "optional"},
     { name = "module_config.certificate", elem_required = "optional"},
     { name = "module_config.vehicle_make", elem_required = "optional"},
     { name = "module_config.vehicle_model", elem_required = "optional"},

--- a/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
+++ b/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
@@ -1,6 +1,7 @@
 local testCasesForPolicyTableSnapshot = {}
 local commonFunctions = require('user_modules/shared_testcases/commonFunctions')
 local commonSteps = require('user_modules/shared_testcases/commonSteps')
+local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
 
 testCasesForPolicyTableSnapshot.preloaded_elements = {}
 testCasesForPolicyTableSnapshot.pts_elements = {}
@@ -80,7 +81,7 @@ end
 function testCasesForPolicyTableSnapshot:extract_preloaded_pt()
   testCasesForPolicyTableSnapshot.preloaded_elements = {}
   testCasesForPolicyTableSnapshot.seconds_between_retries = {}
-  local preloaded_pt = config.pathToSDL ..'sdl_preloaded_pt.json'
+  local preloaded_pt = commonPreconditions:GetPathToSDL() ..'sdl_preloaded_pt.json'
   extract_json(preloaded_pt)
   local k = 1
   for i = 1, #json_elements do


### PR DESCRIPTION
Updates for ATF Test Scripts

### Summary
Within implementation of [0083-Expandable-design-for-proprietary-data-exchange](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0083-Expandable-design-for-proprietary-data-exchange.md) proposal existing Policy scripts needs to be updated.
Mostly update related to `.json` files that are used in scripts for `PTPreloaded` and `PTUpdate`.
New additional `RequestType` field is added .

Update related to the following test sets:
- policies_happy_paths_HTTP
- policies_happy_paths_EXTERNAL_PROPRIETARY
- ExternalUserConsentStatus_Informing_HMI.txt
- External_UCS-related_params.txt
- External_Consent_Status_OFF.txt
- External_Consent_Status_ON.txt

### ATF version
[develop](https://github.com/smartdevicelink/sdl_atf/tree/develop)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)