### PR TITLE
Fix policy script 066 according to clarification

### DIFF
--- a/test_scripts/Policies/build_options/066_ATF_PTU_Validation_Failure_HTTP.lua
+++ b/test_scripts/Policies/build_options/066_ATF_PTU_Validation_Failure_HTTP.lua
@@ -125,12 +125,12 @@ function Test:RAI_PTU()
     function(_, d1)
       log("SDL->HMI: N: BC.OnAppRegistered")
       self.applications[config.application1.registerAppInterfaceParams.appID] = d1.params.application.appID
-      EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }, { status = "UPDATE_NEEDED" }, { status = "UPDATING" })
+      EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }, { status = "UPDATE_NEEDED" })
       :Do(
         function(_, d2)
           log("SDL->HMI: N: SDL.OnStatusUpdate", d2.params.status)
         end)
-      :Times(4)
+      :Times(3)
       -- workaround due to issue in Mobile API: APPLINK-30390
       local onSystemRequestRecieved = false
 


### PR DESCRIPTION
Updates for ATF Test Scripts

### Summary
According to requirements in case if PTU validation failure SDL should send SDL.OnStatusUpdate(UPDATE_NEEDED) to HMI and that`s all.
SDL no need to start any retry in this case.

### ATF version
[develop](https://github.com/smartdevicelink/sdl_atf/tree/develop)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)