### PR TITLE
Adopt DTLS and GetSystemTime scripts to EXTERNAL_PROPRIETARY flow

### DIFF
--- a/test_scripts/Security/DTLS/common.lua
+++ b/test_scripts/Security/DTLS/common.lua
@@ -230,4 +230,18 @@ function m.preconditions()
   common.initSDLCertificates("./files/Security/client_credential.pem", false)
 end
 
+local policyTableUpdate_orig = m.policyTableUpdate
+
+function m.policyTableUpdate(pPTUpdateFunc)
+  local function expNotificationFunc()
+    m.getHMIConnection():ExpectRequest("BasicCommunication.DecryptCertificate")
+    :Do(function(_, d)
+        m.getHMIConnection():SendResponse(d.id, d.method, "SUCCESS", { })
+      end)
+    :Times(AnyNumber())
+    m.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { odometer = true })
+  end
+  policyTableUpdate_orig(pPTUpdateFunc, expNotificationFunc)
+end
+
 return m

--- a/test_scripts/Security/GetSystemTime/common.lua
+++ b/test_scripts/Security/GetSystemTime/common.lua
@@ -132,4 +132,18 @@ function m.preconditions()
   common.initSDLCertificates("./files/Security/GetSystemTime_certificates/client_credential.pem", false)
 end
 
+local policyTableUpdate_orig = m.policyTableUpdate
+
+function m.policyTableUpdate(pPTUpdateFunc)
+  local function expNotificationFunc()
+    m.getHMIConnection():ExpectRequest("BasicCommunication.DecryptCertificate")
+    :Do(function(_, d)
+        m.getHMIConnection():SendResponse(d.id, d.method, "SUCCESS", { })
+      end)
+    :Times(AnyNumber())
+    m.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { odometer = true })
+  end
+  policyTableUpdate_orig(pPTUpdateFunc, expNotificationFunc)
+end
+
 return m


### PR DESCRIPTION
Updates for ATF Test Scripts

### Summary
Update DTLS and GetSystemTime security test scripts for EXTERNAL_PROPRIETARY flow of SDL

### ATF version
[develop](https://github.com/smartdevicelink/sdl_atf/tree/develop)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)