### PR TITLE
WIP Feature/mobile version negotiation

### DIFF
--- a/test_scripts/SDL4_6/MobileVersioning/VersionNegotiation/001_register_legacy_app.lua
+++ b/test_scripts/SDL4_6/MobileVersioning/VersionNegotiation/001_register_legacy_app.lua
@@ -1,0 +1,118 @@
+---------------------------------------------------------------------------------------------------
+-- User story: Mobile Versioning
+-- Use case: RegisterAppInterface
+-- Item: Happy path
+--
+-- Requirement summary:
+-- [RegisterAppInterface] SUCCESS: getting SUCCESS:RegisterAppInterface() during reregistration
+-- SyncMsgVersion response from Core should be negotiated to lower app msg version
+--
+-- Description:
+-- Mobile application sends valid RegisterAppInterface request after unregistration and
+-- gets RegisterAppInterface "SUCCESS" response from SDL
+
+-- Pre-conditions:
+-- a. HMI and SDL are started
+-- b. appID is registered and activated on SDL
+-- c. appID is currently in Background, Full or Limited HMI level
+
+-- Steps:
+-- appID requests RegisterAppInterface
+
+-- Expected:
+-- SDL checks if RegisterAppInterface is allowed by Policies
+-- SDL sends the BasicCommunication notification to HMI
+-- SDL responds with (resultCode: SUCCESS, success:true) to mobile application
+-- SDL responds with SyncMsgVersion 2.2 in RAI response
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSmoke = require('test_scripts/Smoke/commonSmoke')
+
+--[[ Local Variables ]]
+local requestParams = {
+	syncMsgVersion = {
+		majorVersion = 2,
+		minorVersion = 2,
+	},
+	appName = "SyncProxyTester",
+	ttsName = {
+		{
+			text ="SyncProxyTester",
+			type ="TEXT",
+		},
+	},
+	ngnMediaScreenAppName = "SPT",
+	vrSynonyms = {
+		"VRSyncProxyTester",
+	},
+	isMediaApplication = true,
+	languageDesired = "EN-US",
+	hmiDisplayLanguageDesired = "EN-US",
+	appHMIType = {
+		"DEFAULT",
+	},
+	appID = "123456",
+	deviceInfo = {
+		hardware = "hardware",
+		firmwareRev = "firmwareRev",
+		os = "os",
+		osVersion = "osVersion",
+		carrier = "carrier",
+		maxNumberRFCOMMPorts = 5
+	}
+}
+
+local function SetNotificationParams()
+	local notificationParams = {
+		application = {}
+	}
+	notificationParams.application.appName = requestParams.appName
+	notificationParams.application.ngnMediaScreenAppName = requestParams.ngnMediaScreenAppName
+	notificationParams.application.isMediaApplication = requestParams.isMediaApplication
+	notificationParams.application.hmiDisplayLanguageDesired = requestParams.hmiDisplayLanguageDesired
+	notificationParams.application.appType = requestParams.appHMIType
+	notificationParams.application.deviceInfo = {
+		name = commonSmoke.getDeviceName(),
+		id = commonSmoke.getDeviceMAC(),
+		transportType = "WIFI",
+		isSDLAllowed = true
+	}
+	notificationParams.application.policyAppID = requestParams.appID
+	notificationParams.ttsName = requestParams.ttsName
+	notificationParams.vrSynonyms = requestParams.vrSynonyms
+	return notificationParams
+end
+
+--[[ Local Functions ]]
+local function unregisterAppInterface(self)
+	local cid = self.mobileSession1:SendRPC("UnregisterAppInterface", { })
+	EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered",
+		{ appID = commonSmoke.getHMIAppId(), unexpectedDisconnect = false })
+	self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+end
+
+local function RegisterAppInterface(self)
+	local CorIdRAI = self.mobileSession1:SendRPC("RegisterAppInterface", requestParams)
+	local notificationParams = SetNotificationParams()
+	EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", notificationParams)
+	self.mobileSession1:ExpectResponse(CorIdRAI, { success = true, resultCode = "SUCCESS", syncMsgVersion = requestParams.syncMsgVersion})
+	self.mobileSession1:ExpectNotification("OnHMIStatus",
+		{ hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+	self.mobileSession1:ExpectNotification("OnPermissionsChange")
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSmoke.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
+runner.Step("RAI", commonSmoke.registerApp)
+runner.Step("Activate App", commonSmoke.activateApp)
+runner.Step("UnregisterAppInterface Positive Case", unregisterAppInterface)
+
+runner.Title("Test")
+runner.Step("RegisterAppInterface Legacy App Case", RegisterAppInterface)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSmoke.postconditions)

--- a/test_scripts/SDL4_6/MobileVersioning/VersionNegotiation/002_register_app_on_legacy_module.lua
+++ b/test_scripts/SDL4_6/MobileVersioning/VersionNegotiation/002_register_app_on_legacy_module.lua
@@ -1,0 +1,124 @@
+---------------------------------------------------------------------------------------------------
+-- User story: Mobile Versioning
+-- Use case: RegisterAppInterface
+-- Item: Happy path
+--
+-- Requirement summary:
+-- [RegisterAppInterface] SUCCESS: getting SUCCESS:RegisterAppInterface() during reregistration
+-- SyncMsgVersion response from Core should be negotiated to highest message version Core supports
+--
+-- Description:
+-- Mobile application sends valid RegisterAppInterface request after unregistration and
+-- gets RegisterAppInterface "SUCCESS" response from SDL
+
+-- Pre-conditions:
+-- a. HMI and SDL are started
+-- b. appID is registered and activated on SDL
+-- c. appID is currently in Background, Full or Limited HMI level
+
+-- Steps:
+-- appID requests RegisterAppInterface
+
+-- Expected:
+-- SDL checks if RegisterAppInterface is allowed by Policies
+-- SDL sends the BasicCommunication notification to HMI
+-- SDL responds with (resultCode: SUCCESS, success:true) to mobile application
+-- SDL responds with negotiated SyncMsgVersion that Core supports
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSmoke = require('test_scripts/Smoke/commonSmoke')
+
+--[[ Local Variables ]]
+local requestParams = {
+	syncMsgVersion = {
+		majorVersion = 9,
+		minorVersion = 0,
+	},
+	appName = "SyncProxyTester",
+	ttsName = {
+		{
+			text ="SyncProxyTester",
+			type ="TEXT",
+		},
+	},
+	ngnMediaScreenAppName = "SPT",
+	vrSynonyms = {
+		"VRSyncProxyTester",
+	},
+	isMediaApplication = true,
+	languageDesired = "EN-US",
+	hmiDisplayLanguageDesired = "EN-US",
+	appHMIType = {
+		"DEFAULT",
+	},
+	appID = "123456",
+	deviceInfo = {
+		hardware = "hardware",
+		firmwareRev = "firmwareRev",
+		os = "os",
+		osVersion = "osVersion",
+		carrier = "carrier",
+		maxNumberRFCOMMPorts = 5
+	}
+}
+
+local responseSyncMsgVersion = {
+		majorVersion = 5,
+		minorVersion = 0,
+		patchVersion = 0
+}
+
+local function SetNotificationParams()
+	local notificationParams = {
+		application = {}
+	}
+	notificationParams.application.appName = requestParams.appName
+	notificationParams.application.ngnMediaScreenAppName = requestParams.ngnMediaScreenAppName
+	notificationParams.application.isMediaApplication = requestParams.isMediaApplication
+	notificationParams.application.hmiDisplayLanguageDesired = requestParams.hmiDisplayLanguageDesired
+	notificationParams.application.appType = requestParams.appHMIType
+	notificationParams.application.deviceInfo = {
+		name = commonSmoke.getDeviceName(),
+		id = commonSmoke.getDeviceMAC(),
+		transportType = "WIFI",
+		isSDLAllowed = true
+	}
+	notificationParams.application.policyAppID = requestParams.appID
+	notificationParams.ttsName = requestParams.ttsName
+	notificationParams.vrSynonyms = requestParams.vrSynonyms
+	return notificationParams
+end
+
+--[[ Local Functions ]]
+local function unregisterAppInterface(self)
+	local cid = self.mobileSession1:SendRPC("UnregisterAppInterface", { })
+	EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered",
+		{ appID = commonSmoke.getHMIAppId(), unexpectedDisconnect = false })
+	self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+end
+
+local function RegisterAppInterface(self)
+	local CorIdRAI = self.mobileSession1:SendRPC("RegisterAppInterface", requestParams)
+	local notificationParams = SetNotificationParams()
+	EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", notificationParams)
+	self.mobileSession1:ExpectResponse(CorIdRAI, { success = true, resultCode = "SUCCESS", syncMsgVersion = responseSyncMsgVersion})
+	self.mobileSession1:ExpectNotification("OnHMIStatus",
+		{ hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+	self.mobileSession1:ExpectNotification("OnPermissionsChange")
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSmoke.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
+runner.Step("RAI", commonSmoke.registerApp)
+runner.Step("Activate App", commonSmoke.activateApp)
+runner.Step("UnregisterAppInterface Positive Case", unregisterAppInterface)
+
+runner.Title("Test")
+runner.Step("RegisterAppInterface New App on Legacy Module Positive Case", RegisterAppInterface)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSmoke.postconditions)

--- a/test_sets/mobile_api_versioning.txt
+++ b/test_sets/mobile_api_versioning.txt
@@ -1,0 +1,2 @@
+./test_scripts/SDL4_6/MobileVersioning/VersionNegotiation/001_register_legacy_app.lua
+./test_scripts/SDL4_6/MobileVersioning/VersionNegotiation/002_register_app_on_legacy_module.lua


### PR DESCRIPTION
WIP. Will continue to add mobile versioning tests as mobile api is updated with history changes.

Test scripts for Mobile API versioning. [Proposal](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0089-mobile-api-versioning.md)

[SDL Core PR](https://github.com/smartdevicelink/sdl_core/pull/2497)

Current Tests:
 - Version negotiation

Upcoming Tests:
- [vrCommand Optional](https://github.com/smartdevicelink/sdl_core/pull/2415)
- [fullAppID](https://github.com/smartdevicelink/sdl_core/pull/2407)
- [Add play_pause enum](https://github.com/smartdevicelink/sdl_core/pull/930)
