### PR TITLE
Fix path to PTS in OnSystemRequest

### DIFF
--- a/test_scripts/RC/commonRC.lua
+++ b/test_scripts/RC/commonRC.lua
@@ -99,7 +99,7 @@ local function ptu(self, ptu_update_func)
   local requestId = self.hmiConnection:SendRequest("SDL.GetURLS", { service = 7 })
   EXPECT_HMIRESPONSE(requestId)
   :Do(function()
-      self.hmiConnection:SendNotification("BasicCommunication.OnSystemRequest", { requestType = "PROPRIETARY", fileName = pts_file_name })
+      self.hmiConnection:SendNotification("BasicCommunication.OnSystemRequest", { requestType = "PROPRIETARY", fileName = commonFunctions:pathJoin(policy_file_path, pts_file_name) })
       getPTUFromPTS(ptu_table)
       updatePTU(ptu_table)
       if ptu_update_func then


### PR DESCRIPTION
SDL needs full path to PTS in OnSystemRequst, not only the name of file.