### PR TITLE
Fix encryption false for first frame in protocol packet

### DIFF
--- a/test_scripts/Security/DTLS/common.lua
+++ b/test_scripts/Security/DTLS/common.lua
@@ -163,9 +163,7 @@ function m.putFileByFrames(pParams)
     firstFrameMessage.frameType = 0x02
     firstFrameMessage.frameInfo = 0
     firstFrameMessage.binaryData = int32ToBytes(binaryDataSize) .. int32ToBytes(countOfDataFrames)
-    if pParams.isFirstFrameEncrypted ~= nil then
-      firstFrameMessage.encryption = pParams.isFirstFrameEncrypted
-    end
+    firstFrameMessage.encryption = false
     table.insert(frames, 1, firstFrameMessage)
   else
     table.insert(frames, msg)


### PR DESCRIPTION
In current flow SDL do decryption after header verification therefore we shouldn't do encryption of first frame.