### PR TITLE
Make safeguard in getPTUFromPTS

### DIFF
--- a/test_scripts/Security/SSLHandshakeFlow/common.lua
+++ b/test_scripts/Security/SSLHandshakeFlow/common.lua
@@ -186,7 +186,6 @@ function m.policyTableUpdateSuccess(pPTUpdateFunc)
   :Do(function(e, d)
       if e.occurences == 1 then
         m.getHMIConnection():SendResponse(d.id, d.method, "SUCCESS", { })
-        m.setPTUTable(utils.jsonFileToTable(d.params.file))
         m.policyTableUpdate(pPTUpdateFunc, expNotificationFunc)
       end
     end)


### PR DESCRIPTION
Fix for [#2025](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2025)

This PR is **ready** for review.

### Summary
Policy Table Update sequence is used in a lot of test scripts. However this procedure could fail at the very first start due to missing snapshot etc.
This PR implement possibility to create policy table update file from either snapshot or from SDL's preloaded file.

### ATF version
[develop](https://github.com/smartdevicelink/sdl_atf/tree/develop)

### Changelog
##### Enhancements
* Remove `ptuTable` local variable from `actions` module
* Remove unnecessary function `setPTUTable()`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)