### PR TITLE
Correctly update all functional groups for vehicle data disallowed

### DIFF
--- a/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
@@ -64,6 +64,13 @@ local function ptu_update_func(tbl)
     if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
   end
   tbl.policy_table.functional_groupings["Emergency-1"].rpcs["GetVehicleData"].parameters = newParams
+
+  params = tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["GetVehicleData"].parameters
+  newParams = {}
+  for index, value in pairs(params) do
+    if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
+  end
+  tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["GetVehicleData"].parameters = newParams
 end
 
 local function processRPCSuccess(self)

--- a/test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
@@ -63,6 +63,13 @@ local function ptu_update_func(tbl)
     if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
   end
   tbl.policy_table.functional_groupings["Emergency-1"].rpcs["SubscribeVehicleData"].parameters = newParams
+
+  params = tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["SubscribeVehicleData"].parameters
+  newParams = {}
+  for index, value in pairs(params) do
+    if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
+  end
+  tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["SubscribeVehicleData"].parameters = newParams
 end
 
 local function processRPCFailure(self)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/004_RPC_parameter_disallowed_by_policies_Result_DISALLOWED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/004_RPC_parameter_disallowed_by_policies_Result_DISALLOWED_flow.lua
@@ -62,6 +62,13 @@ local function ptu_update_func(tbl)
     if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
   end
   tbl.policy_table.functional_groupings["Emergency-1"].rpcs["UnsubscribeVehicleData"].parameters = newParams
+
+  params = tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["UnsubscribeVehicleData"].parameters
+  newParams = {}
+  for index, value in pairs(params) do
+    if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
+  end
+  tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["UnsubscribeVehicleData"].parameters = newParams
 end
 
 local function processRPCFailure(self)


### PR DESCRIPTION
The PTU still included these params in the VehicleInfo-3 functional group so policies was not disallowing the RPC. This updates the ptu function so that the parameters are removed from Emergency-1 and VehicleInfo-3