### PR TITLE
Fix external proprietary tests' shutdown and cleanup 

### DIFF
--- a/test_scripts/Policies/Validation_of_PolicyTables/227_ATF_usage_and_error_counts_update_count_sync_out_of_memory.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/227_ATF_usage_and_error_counts_update_count_sync_out_of_memory.lua
@@ -251,6 +251,7 @@ commonFunctions:newTestCasesGroup("Postconditions")
 
 function Test.Postcondition_StopSDL()
   StopSDL()
+  commonSteps:DeletePolicyTable()
 end
 
 return Test

--- a/test_scripts/Policies/Validation_of_PolicyTables/264_ATF_pt_snapshot_creation_rule.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/264_ATF_pt_snapshot_creation_rule.lua
@@ -77,6 +77,7 @@ end
 commonFunctions:newTestCasesGroup("Postconditions")
 function Test.Postcondition_StopSDL()
   StopSDL()
+  commonSteps:DeletePolicyTable()
 end
 
 return Test


### PR DESCRIPTION
Deletes the policy table at the end of the test script. Without this, tests following these tests in the external proprietary test set will fail because of the previous policy state.