### PR TITLE
Correct validation of result on URLs cycling during PTU retry sequence

### DIFF
--- a/test_scripts/Policies/build_options/097_ATF_PTU_Cycleing_Through_The_URLs_During_Retry_Sequence_HTTP.lua
+++ b/test_scripts/Policies/build_options/097_ATF_PTU_Cycleing_Through_The_URLs_During_Retry_Sequence_HTTP.lua
@@ -78,6 +78,12 @@ function Test:Update_LPT()
   EXPECT_RESPONSE(corId, { success = true, resultCode = "SUCCESS" })
 end
 
+function Test:ActivateNewApp()
+  local RequestId = self.hmiConnection:SendRequest("SDL.ActivateApp", { appID = self.applications["Test Application"] })
+  EXPECT_HMIRESPONSE(RequestId)
+  self.mobileSession:ExpectNotification("OnHMIStatus", { hmiLevel = "FULL" })
+end
+
 --[[ Test ]]
 commonFunctions:newTestCasesGroup("Test")
 
@@ -123,20 +129,20 @@ function Test.ShowSequence()
   print("--------------------------------------------------")
 end
 
--- function Test.print()
---   print_table(r_expected)
---   print_table(r_actual)
--- end
-
-for i = 1, 4 do
-  Test["ValidateResult" .. i] = function(self)
-    if(r_actual[i] ~= nil) then
-      if r_expected[i] ~= r_actual[i] then
-        local m = table.concat({"\nExpected url:\n", tostring(r_expected[i]), "\nActual:\n", tostring(r_actual[i]), "\n"})
-        self:FailTestCase(m)
+function Test:ValidateResult()
+  local function contains(pTbl, pItem)
+    for _, e in pairs(pTbl) do
+      if e == pItem then return true end
+    end
+    return false
+  end
+  if #r_actual ~= #r_expected then
+    self:FailTestCase("\nExpected number of requests: " .. #r_expected .. ", actual: " .. #r_actual)
+  else
+    for _, e in pairs(r_expected) do
+      if not contains(r_actual, e) then
+        self:FailTestCase("\nExpected item '" .. e .."' is not found")
       end
-    else
-      self:FailTestCase("Actual url is empty")
     end
   end
 end


### PR DESCRIPTION
There are following improvements in script:
1) Added app1 activation => this allows to perform new PTU cycle only through this app
2) Validation result function corrected due to the fact that array of available URLs could be unsorted (order of elements is changed from run to run)