### PR TITLE
Correct expected result for LIMITED and keepContext=true

### DIFF
--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/SetInteriorVehicleData/016_Change_audio_source_from_MOBILE_APP_keepContext_true_LIMITED.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/SetInteriorVehicleData/016_Change_audio_source_from_MOBILE_APP_keepContext_true_LIMITED.lua
@@ -12,7 +12,7 @@
 -- 3) App tries to change audio source from MOBILE_APP with keepContext = true
 -- SDL must:
 -- 1) Change audio source successfully
--- 2) Change HMI level to BACKGROUND and change audioStreamingState to "NOT_AUDIBLE"
+-- 2) Not change HMI level, but change audioStreamingState to "NOT_AUDIBLE"
 ---------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -68,7 +68,7 @@ local function setVehicleData()
     end)
   mobSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
   mobSession:ExpectNotification("OnHMIStatus",
-    { hmiLevel = "BACKGROUND", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+    { hmiLevel = "LIMITED", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
 end
 
 local function bringAppToLIMITED()


### PR DESCRIPTION
Originally in [0150-video-streaming-state](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0150-video-streaming-state.md) there was a statement that HMI level has to be changed from LIMITED to BACKGROUND in case both audio and video streaming states set to NOT_STREAMABLE.
However this requirement does not describe the case when context should be kept and HMI level should not be changed.

In https://github.com/smartdevicelink/sdl_core/pull/2607 besides other fixes there was introduced change that LIMITED level should be kept if `SetInteriorVehicleData` was sent with `keepContext=true`
By this change SDL behavior became the same for FULL and LIMITED levels.

So the script needs to be updated accordingly.


