### PR TITLE
ATF Script for defect 1401

### DIFF
--- a/test_scripts/Defects/5_0/1939_SDL_responds_with_wrong_result_in_case_receives_GetURLs_request_from_HMI_with_unknown_"service".lua
+++ b/test_scripts/Defects/5_0/1939_SDL_responds_with_wrong_result_in_case_receives_GetURLs_request_from_HMI_with_unknown_"service".lua
@@ -1,0 +1,46 @@
+---------------------------------------------------------------------------------------------------
+-- User story: https://github.com/SmartDeviceLink/sdl_core/issues/1401
+--
+-- Description:
+-- SDL responds with wrong result in case receives GetURLs request from HMI with unknown "service"
+--
+-- Preconditions:
+-- 1) Core and HMI started
+-- 2) "Endpoint" table in Policy DB has next records for 0x07 service: 
+--    7 | http://test.api.policies | default
+-- 3) App is registered on HMI
+--
+-- Steps:
+-- 1) On HMI click Settings button -> Request GetUrls
+-- 2) Enter service id "25"
+-- 3) Send GetUrls request -> GetURLs(service 25) is sent to SDL
+--
+-- Expected result: 
+-- In case SDL receives GetURLs request from HMI AND is not defined in "endpoint" table, 
+-- SDL must repond with SUCCESS result code and without "urls" param
+-- 
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('user_modules/sequences/actions')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Functions ]]
+local function testGetURLsRequest()
+	local requestId = common.getHMIConnection():SendRequest("SDL.GetURLS", { service = 25 })
+	common.getHMIConnection():ExpectResponse(requestId, {result = {code = 0, method = "SDL.GetURLS", urls = nil}})
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+
+runner.Title("Test")
+runner.Step("Send GetURLs request", testGetURLsRequest)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)


### PR DESCRIPTION
Added ATF script for defect [#1401](https://github.com/SmartDeviceLink/sdl_core/issues/1401) _SDL responds with wrong result in case receives GetURLs request from HMI with unknown "service"_.

This PR is **ready** for review.

**Summary**
A test script to verify that issue is fixed