### PR TITLE
Exclude failed test scripts from Mobile Projection test sets and add link to GitHub issue

### DIFF
--- a/test_sets/SDL5_0/mobile_projection_2.txt
+++ b/test_sets/SDL5_0/mobile_projection_2.txt
@@ -20,4 +20,4 @@
 ./test_scripts/MobileProjection/Phase2/020_different_types_apps_interactions.lua
 ./test_scripts/MobileProjection/Phase2/021_two_apps_and_deactivation.lua
 ./test_scripts/MobileProjection/Phase2/022_two_apps_proj_media_and_deactivation_streaming.lua
-./test_scripts/MobileProjection/Phase2/023_two_apps_navi_comm_and_deactivation_streaming.lua
+;./test_scripts/MobileProjection/Phase2/023_two_apps_navi_comm_and_deactivation_streaming.lua 2642

--- a/test_sets/SDL5_0/mobile_projection_2_smoke.txt
+++ b/test_sets/SDL5_0/mobile_projection_2_smoke.txt
@@ -19,4 +19,4 @@
 ./test_scripts/MobileProjection/Phase2/smoke/020_different_types_apps_interactions.lua
 ./test_scripts/MobileProjection/Phase2/smoke/021_two_apps_and_deactivation.lua
 ./test_scripts/MobileProjection/Phase2/smoke/022_two_apps_proj_media_and_deactivation_streaming.lua
-./test_scripts/MobileProjection/Phase2/smoke/023_two_apps_navi_comm_and_deactivation_streaming.lua
+;./test_scripts/MobileProjection/Phase2/smoke/023_two_apps_navi_comm_and_deactivation_streaming.lua 2642


### PR DESCRIPTION
By current PR failed test scripts from Mobile Projection are excluded from test sets (marked as skipped with link to appropriate issue)