### PR TITLE
Update min rpc patch version

### DIFF
--- a/test_scripts/SDL5_0/MobileVersioning/PlayPauseButton/002_play_pause_v4_invalid_data.lua
+++ b/test_scripts/SDL5_0/MobileVersioning/PlayPauseButton/002_play_pause_v4_invalid_data.lua
@@ -32,7 +32,8 @@ local commonSmoke = require('test_scripts/Smoke/commonSmoke')
 
 config.application1.registerAppInterfaceParams.syncMsgVersion = {
   majorVersion = 4,
-  minorVersion = 5
+  minorVersion = 5,
+  patchVersion = 1
 }
 
 --[[ Local Functions ]]

--- a/test_scripts/SDL5_0/MobileVersioning/VersionNegotiation/001_register_legacy_app.lua
+++ b/test_scripts/SDL5_0/MobileVersioning/VersionNegotiation/001_register_legacy_app.lua
@@ -100,6 +100,7 @@ local function RegisterAppInterface(self)
 	self.mobileSession1:ExpectResponse(CorIdRAI, { success = true, resultCode = "SUCCESS", syncMsgVersion = {
 		majorVersion = 4,
 		minorVersion = 5,
+		patchVersion = 1
 	}})
 	self.mobileSession1:ExpectNotification("OnHMIStatus",
 		{ hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })


### PR DESCRIPTION
Update min negotiated rpc version to 4.5.1.

[Associated core pr](https://github.com/smartdevicelink/sdl_core/pull/2673)