### PR TITLE
Stabilize test scripts on Policies

### DIFF
--- a/test_scripts/Policies/App_Permissions/002_ATF_HP_OnPermissionsChange_With_Assigned_Policy_After_App_Registration.lua
+++ b/test_scripts/Policies/App_Permissions/002_ATF_HP_OnPermissionsChange_With_Assigned_Policy_After_App_Registration.lua
@@ -190,22 +190,8 @@ function Test:Step2_Check_Disallowed_RPC()
 end
 
 function Test:Step3_Check_RPC_From_OnPermissionsChange_Allowance()
-  for i = 1, #RPC_BaseBeforeDataConsent do
-    if ( string.sub(RPC_BaseBeforeDataConsent[i],1,string.len("On")) ~= "On" ) then
-      local CorIdRAI = self.mobileSession:SendRPC(RPC_BaseBeforeDataConsent[i],{})
-      EXPECT_RESPONSE(CorIdRAI, {})
-      :ValidIf(function(_,data)
-          if data.payload.resultCode == "DISALLOWED" then
-            commonFunctions:printError("RPC: "..RPC_BaseBeforeDataConsent[i].." should be allowed by policy. Real: "..data.payload.resultCode)
-            return false
-          else
-            return true
-          end
-        end)
-
-      break
-    end
-  end
+  local CorIdRAI = self.mobileSession:SendRPC("ListFiles", {})
+  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS" })
 end
 
 --[[ Postconditions ]]

--- a/test_scripts/Policies/Policy_Table_Update/144_ATF_PTU_validation_failure.lua
+++ b/test_scripts/Policies/Policy_Table_Update/144_ATF_PTU_validation_failure.lua
@@ -34,6 +34,7 @@ local testCasesForPolicyTable = require('user_modules/shared_testcases/testCases
 local testCasesForPolicyTableSnapshot = require('user_modules/shared_testcases/testCasesForPolicyTableSnapshot')
 local testCasesForPolicySDLErrorsStops = require('user_modules/shared_testcases/testCasesForPolicySDLErrorsStops')
 local utils = require ('user_modules/utils')
+local commonTestCases = require ('user_modules/shared_testcases/commonTestCases')
 
 --[[ General Precondition before ATF start ]]
 commonSteps:DeleteLogsFileAndPolicyTable()
@@ -107,6 +108,10 @@ function Test:TestStep_PTU_validation_failure()
   if(is_test_fail == true) then
     self:FailTestCase("Test is FAILED. See prints.")
   end
+end
+
+function Test:Wait_3s()
+  commonTestCases:DelayedExp(3000)
 end
 
 function Test:TestStep_CheckSDLLogError()

--- a/test_scripts/Policies/Validation_of_PolicyTables/265_ATF_pt_snapshot_storage_on_file_system.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/265_ATF_pt_snapshot_storage_on_file_system.lua
@@ -58,10 +58,7 @@ local TestData = {
     end
   end,
   delete = function(self)
-    if self.isExist then
-      os.execute("rm -r -f " .. self.path)
-      self.isExist = false
-    end
+    os.execute("rm -r -f " .. self.path)
   end,
   info = function(self)
     if self.isExist then
@@ -139,6 +136,7 @@ end
 commonFunctions:newTestCasesGroup("Preconditions")
 
 function Test:StopSDL_precondition()
+  TestData:delete()
   TestData:init()
   StopSDL(self)
 end
@@ -151,9 +149,15 @@ function Test:Precondition_StartSDL()
   StartSDL(config.pathToSDL, true)
 end
 
-function Test:Precondition_InitHMIandMobileApp()
+function Test:InitHMI()
   self:initHMI()
+end
+
+function Test:InitHMI_onReady()
   self:initHMI_onReady()
+end
+
+function Test:Precondition_InitHMIandMobileApp()
   self:connectMobile()
   self.mobileSession = mobile_session.MobileSession(self, self.mobileConnection)
   self.mobileSession:StartService(7)

--- a/test_scripts/Policies/Validation_of_PolicyTables/282_ATF_PT_Exchanged_X_Days_After_Epoch_In_PTS.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/282_ATF_PT_Exchanged_X_Days_After_Epoch_In_PTS.lua
@@ -49,7 +49,15 @@ local function getDaysAfterEpochFromPTS(pathToFile)
 end
 
 local function getSystemDaysAfterEpoch()
-  return math.floor(os.time()/86400)
+  local function getTimezoneOffset(ts)
+    local utcdate = os.date("!*t", ts)
+    local localdate = os.date("*t", ts)
+    localdate.isdst = false
+    return os.difftime(os.time(localdate), os.time(utcdate))
+  end
+  local t = os.time()
+  local ofs = getTimezoneOffset(t)
+  return math.floor((t+ofs)/(60*60*24))
 end
 
 --[[ Preconditions ]]

--- a/test_scripts/Policies/user_consent_of_Policies/188_ATF_HP_Device_Data_Section_Validation.lua
+++ b/test_scripts/Policies/user_consent_of_Policies/188_ATF_HP_Device_Data_Section_Validation.lua
@@ -44,6 +44,7 @@ require('cardinalities')
 --[[ Required Shared libraries ]]
 local commonSteps = require ('user_modules/shared_testcases/commonSteps')
 local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
+local commonTestCases = require ('user_modules/shared_testcases/commonTestCases')
 local utils = require ('user_modules/utils')
 require('user_modules/AppTypes')
 
@@ -172,9 +173,12 @@ function Test:Precondition_Activate_App_Consent_Device_Make_PTU_Consent_Group()
                               EXPECT_HMIRESPONSE(RequestIdGetUserFriendlyMessage,{result = {code = 0, method = "SDL.GetUserFriendlyMessage"}})
                               :Do(function(_,_)
                                   local functionalGroupID = data1.result.allowedFunctions[1].id
-                                  self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent",
-                                    { appID = self.applications["Test Application"], source = "GUI", consentedFunctions = {{name = "Location", allowed = true, id = functionalGroupID} }})
-                                  GetCurrentTimeStampGroupConsent()
+                                  local function sendConsent()
+                                    self.hmiConnection:SendNotification("SDL.OnAppPermissionConsent",
+                                      { appID = self.applications["Test Application"], source = "GUI", consentedFunctions = {{name = "Location", allowed = true, id = functionalGroupID} }})
+                                    GetCurrentTimeStampGroupConsent()
+                                  end
+                                  RUN_AFTER(sendConsent, 2000)
                                 end)
                             end)
                         end)
@@ -186,7 +190,7 @@ function Test:Precondition_Activate_App_Consent_Device_Make_PTU_Consent_Group()
             end)
         end)
     end)
-
+  commonTestCases:DelayedExp(4000)
 end
 
 --[[ Test ]]


### PR DESCRIPTION
Some existing tests scripts on Policies were failed randomly.
Current PR fixes instability in these tests.