### PR TITLE
Stabilize test script on Mobile Projection 1 feature

### DIFF
--- a/test_scripts/MobileProjection/Phase1/015_Restore_video_streaming_from_NONE.lua
+++ b/test_scripts/MobileProjection/Phase1/015_Restore_video_streaming_from_NONE.lua
@@ -45,7 +45,7 @@ local function EndServiceByUserExit()
       and data.frameInfo == constants.FRAME_INFO.END_SERVICE
 	end
   common.getMobileSession():ExpectEvent(EndServiceEvent, "Expect EndServiceEvent")
-  :Do(function()
+  :DoOnce(function()
       common.getMobileSession():StopStreaming(FileForStreaming)
 	    common.getMobileSession():Send({
         frameType = constants.FRAME_TYPE.CONTROL_FRAME,

--- a/test_scripts/MobileProjection/Phase1/016_Restore_audio_streaming_from_NONE.lua
+++ b/test_scripts/MobileProjection/Phase1/016_Restore_audio_streaming_from_NONE.lua
@@ -45,7 +45,7 @@ local function EndServiceByUserExit()
        and data.frameInfo == constants.FRAME_INFO.END_SERVICE
   end
   common.getMobileSession():ExpectEvent(EndServiceEvent, "Expect EndServiceEvent")
-  :Do(function()
+  :DoOnce(function()
       common.getMobileSession():StopStreaming(FileForStreaming)
 	    common.getMobileSession():Send({
 	      frameType = constants.FRAME_TYPE.CONTROL_FRAME,


### PR DESCRIPTION
There is instability in test scripts for Mobile Projection 1 feature. 
Some scripts were aborted due to the fact that ATF tried to stop streaming twice.
Current PR allows to stop streaming only once.