### PR TITLE
Script for reproducing 1878 issue

### DIFF
--- a/test_scripts/Defects/5_0/1878_AddCommand_resumption_order.lua
+++ b/test_scripts/Defects/5_0/1878_AddCommand_resumption_order.lua
@@ -1,0 +1,128 @@
+---------------------------------------------------------------------------------------------------
+-- User story: https://github.com/SmartDeviceLink/sdl_core/issues/1878
+--
+-- Description:
+-- SDL does not restore AddCommands in the same order as they were created by mobile app
+--
+-- Steps:
+-- 1) App is registered and activated.
+-- 2) App successfully added some AddCommands
+-- 3) Ign off – ign on
+-- 4) App registers -> SDL successfully performs HMILevel resumption and data resumption
+--
+-- Expected result:
+-- 1) SDL must generate <internal_consecutiveNumber> and assign this <internal_consecutiveNumber> to each AddCommand requested by app
+-- 2) Restore AddCommand by this <internal_consecutiveNumber> during data resumption
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('user_modules/sequences/actions')
+local test = require("user_modules/dummy_connecttest")
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local hashID
+
+local addCommands = {
+  {
+    cmdID = 1,
+    menuParams = {
+      position = 0,
+      menuName ="Command1"
+    },
+    vrCommands = {
+      "VRCommand1"
+    }
+  },
+  {
+    cmdID = 22,
+    menuParams = {
+      position = 0,
+      menuName ="Command2"
+    },
+    vrCommands = {
+      "VRCommand2"
+    }
+  },
+  {
+    cmdID = 3,
+    menuParams = {
+      position = 0,
+      menuName ="Command3"
+    },
+    vrCommands = {
+      "VRCommand3"
+    }
+  }
+}
+
+--[[ Local Functions ]]
+local function addCommand(pParams)
+  local cid = common.getMobileSession():SendRPC("AddCommand", pParams)
+  EXPECT_HMICALL("UI.AddCommand")
+  :Do(function(_,data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+
+  EXPECT_HMICALL("VR.AddCommand")
+  :Do(function(_,data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "SUCCESS"})
+  common.getMobileSession():ExpectNotification("OnHashChange")
+  :Do(function(_, data)
+      hashID = data.payload.hashID
+    end)
+end
+
+local function registerWithResumption()
+  config.application1.registerAppInterfaceParams.hashID = hashID
+
+  common.registerAppWOPTU()
+
+  EXPECT_HMICALL("VR.AddCommand",
+    { vrCommands = addCommands[1].vrCommands },
+    { vrCommands = addCommands[2].vrCommands },
+    { vrCommands = addCommands[3].vrCommands })
+  :Do(function(_,data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+  :Times(3)
+end
+
+function common.ignitionOff()
+  common.getHMIConnection():SendNotification("BasicCommunication.OnExitAllApplications", { reason = "SUSPEND" })
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLPersistenceComplete")
+  :Do(function()
+      common.getHMIConnection():SendNotification("BasicCommunication.OnExitAllApplications",{ reason = "IGNITION_OFF" })
+      common.getMobileSession():ExpectNotification("OnAppInterfaceUnregistered", { reason = "IGNITION_OFF" })
+    end)
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
+  :Do(function()
+      test.mobileSession[1] = nil
+      StopSDL()
+    end)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("App registration", common.registerApp)
+runner.Step("Activate App", common.activateApp)
+for key,value in pairs  (addCommands) do
+  runner.Step("AddCommand " .. key, addCommand, { value })
+end
+runner.Step("Ignition Off", common.ignitionOff)
+runner.Step("Ignition On", common.start)
+
+runner.Title("Test")
+runner.Step("Registration with resumption", registerWithResumption)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)


### PR DESCRIPTION
ATF Test Scripts to check [1878](https://github.com/smartdevicelink/sdl_core/issues/1878)

This PR is **not ready** for review.
This is **draft** of the script.

### Summary
Covered sequence from 1878 issue: Checked the order of the command resumption.
Covered only command with VR portion, because UI commands restore internally and in script there is no ability to check the order of the command resumption with UI commands.

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
