### PR TITLE
Update existing policy scripts due to changes for issue 2463

### DIFF
--- a/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
+++ b/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
@@ -257,6 +257,7 @@ function testCasesForPolicyTableSnapshot:verify_PTS(is_created, app_IDs, device_
         --omitted_preloaded_original[#omitted_preloaded_original + 1] = { name = "device_data."..device_IDs[i]..".usb_transport_enabled", elem_required = "required"}
         omitted_preloaded_original[#omitted_preloaded_original + 1] = { name = "device_data."..device_IDs[i]..".user_consent_records.device.input", elem_required = "required"}
         omitted_preloaded_original[#omitted_preloaded_original + 1] = { name = "device_data."..device_IDs[i]..".user_consent_records.device.time_stamp", elem_required = "required"}
+        omitted_preloaded_original[#omitted_preloaded_original + 1] = { name = "device_data."..device_IDs[i]..".unpaired", elem_required = "optional"} -- fix for GH-2463
       end
 
       --TODO(istoimenova): Clarification for the section - exist only if application has consented groups?


### PR DESCRIPTION
ATF Test Scripts to check #[2463](https://github.com/smartdevicelink/sdl_core/issues/2463)

This PR is **ready** for review.

### Summary
Update existing scripts due to changes introduced by the fix

### ATF version
[develop](https://github.com/smartdevicelink/sdl_atf/commit/35ca987c2f4e18eb6e2ef09e53cbae4e6a339ce3)

### Changelog
* Added additional `unpaired` flag to the function that validate policy snapshot

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
