### PR TITLE
Test for onsystemRequest ICON_URL

### DIFF
--- a/test_scripts/CloudAppRPCs/010_get_icon_url.lua
+++ b/test_scripts/CloudAppRPCs/010_get_icon_url.lua
@@ -18,6 +18,8 @@ local common = require('test_scripts/CloudAppRPCs/commonCloudAppRPCs')
 
 --[[ Local Variables ]]
 local cloud_app_id = "cloudAppID123"
+config.application1.registerAppInterfaceParams.syncMsgVersion.majorVersion = 5
+config.application1.registerAppInterfaceParams.syncMsgVersion.minorVersion = 1
 
 --[[ Local Functions ]]
 local function PTUfunc(tbl)

--- a/test_scripts/CloudAppRPCs/010_get_icon_url.lua
+++ b/test_scripts/CloudAppRPCs/010_get_icon_url.lua
@@ -1,0 +1,75 @@
+---------------------------------------------------------------------------------------------------
+--  Precondition: 
+--  1) Application with <appID> is registered on SDL.
+--  2) Specific permissions are assigned for a cloud app with an icon_url
+--
+--  Steps:
+--  1) Core sends a systemRequest type = ICONURL
+--  2) Mobile responds with image data in a SystemRequest ICON_URL
+--
+--  Expected:
+--  1) SDL responds to mobile app with "ResultCode: SUCCESS,
+--        success: true
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/CloudAppRPCs/commonCloudAppRPCs')
+
+--[[ Local Variables ]]
+local cloud_app_id = "cloudAppID123"
+
+--[[ Local Functions ]]
+local function PTUfunc(tbl)
+    params = {
+        keep_context = false,
+        steal_focus = false,
+        priority = "NONE",
+        default_hmi = "NONE",
+        groups = {"Base-4"},
+        RequestType = {},
+        RequestSubType = {},
+        hybrid_app_preference = "CLOUD",
+        endpoint = "ws://192.168.1.1:3000/",
+        enabled = true,
+        cloud_transport_type = "WS",
+        icon_url = "https://fakeurl1234512345.com",
+        nicknames = {"CloudApp"}
+    }
+    
+    tbl.policy_table.app_policies[cloud_app_id] = params
+end
+
+local rpc = {
+    name = "SystemRequest",
+    params = {
+        requestType = "ICON_URL", fileName = "https://fakeurl1234512345.com"
+    }
+}
+
+local icon_image_path = "files/icon.png"
+
+local function processRPCSuccess(self)
+    local mobileSession = common.getMobileSession(self, 1)
+    local cid = mobileSession:SendRPC(rpc.name, rpc.params, icon_image_path)
+    EXPECT_HMICALL("BasicCommunication." .. "UpdateAppList")
+    :Do(function(_, data)
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS")
+      end)
+    local responseParams = {}
+    responseParams.success = true
+    responseParams.resultCode = "SUCCESS"
+    mobileSession:ExpectResponse(cid, responseParams)
+  end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+
+runner.Title("Test")
+runner.Step("OnSystemRequest ICON_URL Post PTU", common.registerAppWithPTUExpectIconURL, {nil, PTUfunc})
+runner.Step("Send App Icon SystemRequest", processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/CloudAppRPCs/010_get_icon_url.lua
+++ b/test_scripts/CloudAppRPCs/010_get_icon_url.lua
@@ -18,8 +18,17 @@ local common = require('test_scripts/CloudAppRPCs/commonCloudAppRPCs')
 
 --[[ Local Variables ]]
 local cloud_app_id = "cloudAppID123"
+local url = "https://fakeurl1234512345.com"
+local icon_image_path = "files/icon.png"
 config.application1.registerAppInterfaceParams.syncMsgVersion.majorVersion = 5
 config.application1.registerAppInterfaceParams.syncMsgVersion.minorVersion = 1
+
+local rpc = {
+  name = "SystemRequest",
+  params = {
+      requestType = "ICON_URL", fileName = url
+  }
+}
 
 --[[ Local Functions ]]
 local function PTUfunc(tbl)
@@ -35,12 +44,10 @@ local function PTUfunc(tbl)
         endpoint = "ws://192.168.1.1:3000/",
         enabled = true,
         cloud_transport_type = "WS",
-        icon_url = "https://fakeurl1234512345.com",
+        icon_url = url,
         nicknames = {"CloudApp"}
     }
-    
     tbl.policy_table.app_policies[cloud_app_id] = params
-
 end
 
 local function PostPtuExpectation(self)
@@ -48,19 +55,10 @@ local function PostPtuExpectation(self)
     print(data.payload.requestType)
     if data.payload == nil then return false end
     if data.payload.requestType == nil then return false end
-    if data.payload.requestType == "ICON_URL" then return true end
+    if data.payload.requestType == "ICON_URL" and data.payload.url == url then return true end
     return false
   end)
 end
-
-local rpc = {
-    name = "SystemRequest",
-    params = {
-        requestType = "ICON_URL", fileName = "https://fakeurl1234512345.com"
-    }
-}
-
-local icon_image_path = "files/icon.png"
 
 local function processRPCSuccess(self)
     local mobileSession = common.getMobileSession(self, 1)

--- a/test_scripts/CloudAppRPCs/commonCloudAppRPCs.lua
+++ b/test_scripts/CloudAppRPCs/commonCloudAppRPCs.lua
@@ -130,10 +130,23 @@ local function ptu(self, app_id, ptu_update_func)
   os.remove(ptu_file_name)
 end
 
+function commonCloudAppRPCs.DeleteStorageFolder()
+  local ExistDirectoryResult = commonSteps:Directory_exist( tostring(config.pathToSDL .. "storage"))
+  if ExistDirectoryResult == true then
+    local RmFolder  = assert( os.execute( "rm -rf " .. tostring(config.pathToSDL .. "storage" )))
+    if RmFolder ~= true then
+      commonFunctions:userPrint(31, "Folder 'storage' is not deleted")
+    end
+  else
+    commonFunctions:userPrint(33, "Folder 'storage' is absent")
+  end
+end
+
 function commonCloudAppRPCs.preconditions()
   commonFunctions:SDLForceStop()
   commonSteps:DeletePolicyTable()
   commonSteps:DeleteLogsFiles()
+  commonCloudAppRPCs.DeleteStorageFolder()
 end
 
 --[[Module functions]]
@@ -190,6 +203,7 @@ end
 
 function commonCloudAppRPCs.postconditions()
   StopSDL()
+  commonCloudAppRPCs.DeleteStorageFolder()
 end
 
 function commonCloudAppRPCs.test_assert(condition, msg)

--- a/test_scripts/CloudAppRPCs/commonCloudAppRPCs.lua
+++ b/test_scripts/CloudAppRPCs/commonCloudAppRPCs.lua
@@ -1,6 +1,10 @@
 local actions = require("user_modules/sequences/actions")
 local json = require("modules/json")
 local test = require("user_modules/dummy_connecttest")
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+local commonSteps = require("user_modules/shared_testcases/commonSteps")
+local utils = require("user_modules/utils")
+local events = require("events")
 
 local commonCloudAppRPCs = actions
 
@@ -80,6 +84,97 @@ function commonCloudAppRPCs.DeleteStorageFolder()
   else
     print("Folder 'storage' is absent")
   end
+end
+
+local function getPTUFromPTS()
+  local pTbl = {}
+  local ptsFileName = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath") .. "/"
+    .. commonFunctions:read_parameter_from_smart_device_link_ini("PathToSnapshot")
+  if utils.isFileExist(ptsFileName) then
+    pTbl = utils.jsonFileToTable(ptsFileName)
+  else
+    utils.cprint(35, "PTS file was not found, PreloadedPT is used instead")
+    local appConfigFolder = commonFunctions:read_parameter_from_smart_device_link_ini("AppConfigFolder")
+    if appConfigFolder == nil or appConfigFolder == "" then
+      appConfigFolder = commonPreconditions:GetPathToSDL()
+    end
+    local preloadedPT = commonFunctions:read_parameter_from_smart_device_link_ini("PreloadedPT")
+    local ptsFile = appConfigFolder .. preloadedPT
+    if utils.isFileExist(ptsFile) then
+      pTbl = utils.jsonFileToTable(ptsFile)
+    else
+      utils.cprint(35, "PreloadedPT was not found, PTS is not created")
+    end
+  end
+  if next(pTbl) ~= nil then
+    pTbl.policy_table.consumer_friendly_messages.messages = nil
+    pTbl.policy_table.device_data = nil
+    pTbl.policy_table.module_meta = nil
+    pTbl.policy_table.usage_and_error_counts = nil
+    pTbl.policy_table.functional_groupings["DataConsent-2"].rpcs = json.null
+    pTbl.policy_table.module_config.preloaded_pt = nil
+    pTbl.policy_table.module_config.preloaded_date = nil
+  end
+  return pTbl
+end
+
+function commonCloudAppRPCs.policyTableUpdateWithIconUrl(pPTUpdateFunc, pExpNotificationFunc, url)
+  if pExpNotificationFunc then
+    pExpNotificationFunc()
+  end
+  local ptsFileName = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath") .. "/"
+    .. commonFunctions:read_parameter_from_smart_device_link_ini("PathToSnapshot")
+  local ptuFileName = os.tmpname()
+  local requestId = commonCloudAppRPCs.getHMIConnection():SendRequest("SDL.GetURLS", { service = 7 })
+  commonCloudAppRPCs.getHMIConnection():ExpectResponse(requestId)
+  :Do(function()
+    commonCloudAppRPCs.getHMIConnection():SendNotification("BasicCommunication.OnSystemRequest",
+        { requestType = "PROPRIETARY", fileName = ptsFileName })
+      local ptuTable = getPTUFromPTS()
+      for i = 1, commonCloudAppRPCs.getAppsCount() do
+        ptuTable.policy_table.app_policies[commonCloudAppRPCs.getConfigAppParams(i).fullAppID] = commonCloudAppRPCs.getAppDataForPTU(i)
+      end
+      if pPTUpdateFunc then
+        pPTUpdateFunc(ptuTable)
+      end
+      utils.tableToJsonFile(ptuTable, ptuFileName)
+      local event = events.Event()
+      event.matches = function(e1, e2) return e1 == e2 end
+      commonCloudAppRPCs.getHMIConnection():ExpectEvent(event, "PTU event")
+      for id = 1, commonCloudAppRPCs.getAppsCount() do
+        commonCloudAppRPCs.getMobileSession(id):ExpectNotification("OnSystemRequest", { requestType = "PROPRIETARY"}, {requestType = "ICON_URL"  })
+        :ValidIf(function(self, data)
+          if data.payload.requestType == "PROPRIETARY" then
+            return true
+          end
+          if data.payload.requestType == "ICON_URL" and data.payload.url == url then 
+            return true 
+          end
+          return false
+        end)
+        :Do(function(_, data)
+            if data.payload.requestType == "PROPRIETARY" then
+              if not pExpNotificationFunc then
+                commonCloudAppRPCs.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { odometer = true })
+                commonCloudAppRPCs.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", { status = "UP_TO_DATE" })
+              end
+              utils.cprint(35, "App ".. id .. " was used for PTU")
+              commonCloudAppRPCs.getHMIConnection():RaiseEvent(event, "PTU event")
+              local corIdSystemRequest = commonCloudAppRPCs.getMobileSession(id):SendRPC("SystemRequest", {
+                requestType = "PROPRIETARY" }, ptuFileName)
+              commonCloudAppRPCs.getHMIConnection():ExpectRequest("BasicCommunication.SystemRequest")
+              :Do(function(_, d3)
+                  commonCloudAppRPCs.getHMIConnection():SendResponse(d3.id, "BasicCommunication.SystemRequest", "SUCCESS", { })
+                  commonCloudAppRPCs.getHMIConnection():SendNotification("SDL.OnReceivedPolicyUpdate", { policyfile = d3.params.fileName })
+                end)
+              commonCloudAppRPCs.getMobileSession(id):ExpectResponse(corIdSystemRequest, { success = true, resultCode = "SUCCESS" })
+              :Do(function() 
+                os.remove(ptuFileName) end)
+            end
+          end)
+        :Times(AtMost(2))
+      end
+    end)
 end
 
 return commonCloudAppRPCs


### PR DESCRIPTION
### Summary

Add success case for onSystemRequest ICON Url. Tests that the request is created when a icon url is added to the PT. Also tests the SystemRequest from mobile that the image is received and a new onHMIStatus is updated.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
