### PR TITLE
Fixed serviceType parameter in GetAppServiceRecords request to HMI

### DIFF
--- a/test_scripts/AppServices/GetAppServiceRecords/001_GetAppServiceRecords_MOBILE.lua
+++ b/test_scripts/AppServices/GetAppServiceRecords/001_GetAppServiceRecords_MOBILE.lua
@@ -50,10 +50,12 @@ local function PTUfunc(tbl)
   tbl.policy_table.app_policies[common.getConfigAppParams(1).fullAppID] = pt_entry
 end
 
-local function getAppServiceRecords(serviceType)
+local function getAppServiceRecords(service_type)
   expectedResponse = getExpectedResponse()
   table.sort(expectedResponse.serviceRecords, function(r1, r2) return r1.serviceID < r2.serviceID end)
-  local rid = common.getHMIConnection():SendRequest(expectedResponse.method, serivceType)
+  local rid = common.getHMIConnection():SendRequest(expectedResponse.method, {
+    serviceType = service_type
+  })
   EXPECT_HMIRESPONSE(rid, expectedResponse)
 end
 

--- a/test_scripts/AppServices/GetAppServiceRecords/002_GetAppServiceRecords_HMI.lua
+++ b/test_scripts/AppServices/GetAppServiceRecords/002_GetAppServiceRecords_HMI.lua
@@ -42,10 +42,12 @@ local function getExpectedResponse()
 end
 
 --[[ Local functions ]]
-local function getAppServiceRecords(serviceType)
+local function getAppServiceRecords(service_type)
   expectedResponse = getExpectedResponse()
   table.sort(expectedResponse.serviceRecords, function(r1, r2) return r1.serviceID < r2.serviceID end)
-  local rid = common.getHMIConnection():SendRequest(expectedResponse.method, serivceType)
+  local rid = common.getHMIConnection():SendRequest(expectedResponse.method, {
+    serviceType =  service_type
+  })
   EXPECT_HMIRESPONSE(rid, expectedResponse)
 end
 

--- a/test_scripts/AppServices/GetAppServiceRecords/003_GetAppServiceRecords_Multiple.lua
+++ b/test_scripts/AppServices/GetAppServiceRecords/003_GetAppServiceRecords_Multiple.lua
@@ -67,10 +67,12 @@ local function PTUfunc(tbl)
   tbl.policy_table.app_policies[common.getConfigAppParams(1).fullAppID] = pt_entry
 end
 
-local function getAppServiceRecords(serviceType)
+local function getAppServiceRecords(service_type)
   expectedResponse = getExpectedResponse()
   table.sort(expectedResponse.serviceRecords, function(r1, r2) return r1.serviceID < r2.serviceID end)
-  local rid = common.getHMIConnection():SendRequest(expectedResponse.method, serivceType)
+  local rid = common.getHMIConnection():SendRequest(expectedResponse.method, {
+    serviceType = service_type
+  })
   EXPECT_HMIRESPONSE(rid, expectedResponse)
 end
 


### PR DESCRIPTION
ATF Test Scripts to check #2176 

This PR is **ready** for review.

### Summary
Fixes the `serivceType` parameter typo in the `GetAppServiceRecords` ATF Tests

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
