### PR TITLE
Add GENERIC_ERROR timeout tests for app service RPCs

### DIFF
--- a/test_scripts/AppServices/GetAppServiceData/011_M2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/011_M2M_GENERIC_ERROR.lua
@@ -1,0 +1,79 @@
+---------------------------------------------------------------------------------------------------
+--  Precondition: 
+--  1) Application 1 with <appID> is registered on SDL.
+--  2) Application 2 with <appID2> is registered on SDL.
+--  3) Specific permissions are assigned for <appID> with PublishAppService
+--  4) Specific permissions are assigned for <appID2> with GetAppServiceData
+--  5) Application 1 has published a MEDIA service
+--
+--  Steps:
+--  1) Application 2 sends a GetAppServiceData RPC request with serviceType MEDIA
+--
+--  Expected:
+--  1) SDL forwards the GetAppServiceData request to Application 1
+--  2) Application 1 sends a GetAppServiceData response (SUCCESS) to Core with its own serviceData
+--  3) SDL forwards the response to Application 2
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/AppServices/commonAppServices')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local manifest = {
+  serviceName = config.application1.registerAppInterfaceParams.appName,
+  serviceType = "MEDIA",
+  allowAppConsumers = true,
+  rpcSpecVersion = config.application1.registerAppInterfaceParams.syncMsgVersion,
+  mediaServiceManifest = {}
+}
+
+local rpc = {
+  name = "GetAppServiceData",
+  params = {
+    serviceType = manifest.serviceType
+  }
+}
+
+local expectedResponse = {
+  success = false,
+  resultCode = "GENERIC_ERROR"
+}
+
+local function PTUfunc(tbl)
+  tbl.policy_table.app_policies[common.getConfigAppParams(1).fullAppID] = common.getAppServiceProducerConfig(1);
+  tbl.policy_table.app_policies[common.getConfigAppParams(2).fullAppID] = common.getAppServiceConsumerConfig(2);
+end
+
+--[[ Local Functions ]]
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession(1)
+  local mobileSession2 = common.getMobileSession(2)
+  local cid = mobileSession2:SendRPC(rpc.name, rpc.params)
+  local service_id = common.getAppServiceID()
+  -- Do not respond
+  mobileSession:ExpectRequest(rpc.name, rpc.params)
+
+  mobileSession2:ExpectResponse(cid, expectedResponse)
+  :Timeout(runner.testSettings.defaultTimeout + common.getRpcPassThroughTimeoutFromINI() + 1000)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerApp)
+runner.Step("PTU", common.policyTableUpdate, { PTUfunc })
+runner.Step("RAI w/o PTU", common.registerAppWOPTU, { 2 })
+runner.Step("Activate App", common.activateApp)
+runner.Step("Publish App Service", common.publishMobileAppService, { manifest })
+
+runner.Title("Test")
+runner.Step("RPC " .. rpc.name .. "_resultCode_GENERIC_ERROR", processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)
+

--- a/test_scripts/AppServices/GetAppServiceData/011_M2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/011_M2M_GENERIC_ERROR.lua
@@ -11,8 +11,8 @@
 --
 --  Expected:
 --  1) SDL forwards the GetAppServiceData request to Application 1
---  2) Application 1 sends a GetAppServiceData response (SUCCESS) to Core with its own serviceData
---  3) SDL forwards the response to Application 2
+--  2) Application 1 does not respond to SDL
+--  3) SDL sends a GENERIC_ERROR response to Application 2 when the request times out
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]

--- a/test_scripts/AppServices/GetAppServiceData/011_M2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/011_M2M_GENERIC_ERROR.lua
@@ -54,7 +54,7 @@ local function processRPCSuccess(self)
   local mobileSession2 = common.getMobileSession(2)
   local cid = mobileSession2:SendRPC(rpc.name, rpc.params)
   local service_id = common.getAppServiceID()
-  -- Do not respond
+  -- Do not respond to request
   mobileSession:ExpectRequest(rpc.name, rpc.params)
 
   mobileSession2:ExpectResponse(cid, expectedResponse)

--- a/test_scripts/AppServices/GetAppServiceData/012_M2H_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/012_M2H_GENERIC_ERROR.lua
@@ -29,24 +29,6 @@ local manifest = {
   mediaServiceManifest = {}
 }
 
-local appServiceData = {
-  serviceType = manifest.serviceType,
-  mediaServiceData = {
-    mediaType = "MUSIC",
-    mediaTitle = "Song name",
-    mediaArtist = "Band name",
-    mediaAlbum = "Album name",
-    playlistName = "Good music",
-    isExplicit = false,
-    trackPlaybackProgress = 200,
-    trackPlaybackDuration = 300,
-    queuePlaybackProgress = 2200,
-    queuePlaybackDuration = 4000,
-    queueCurrentTrackNumber = 12,
-    queueTotalTrackCount = 20
-  }
-}
-
 local rpc = {
   name = "GetAppServiceData",
   hmiName = "AppService.GetAppServiceData",
@@ -69,7 +51,7 @@ local function processRPCSuccess(self)
   local mobileSession = common.getMobileSession()
   local cid = mobileSession:SendRPC(rpc.name, rpc.params)
   local service_id = common.getAppServiceID(0)
-  -- Do not respond
+  -- Do not respond to request
   EXPECT_HMICALL(rpc.hmiName, rpc.params)
 
   mobileSession:ExpectResponse(cid, expectedResponse)

--- a/test_scripts/AppServices/GetAppServiceData/012_M2H_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/012_M2H_GENERIC_ERROR.lua
@@ -9,8 +9,8 @@
 --
 --  Expected:
 --  1) SDL forwards the GetAppServiceData request to the HMI as AppService.GetAppServiceData
---  2) HMI sends a AppService.GetAppServiceData response (SUCCESS) to Core with its own serviceData
---  3) SDL forwards the response to Application as GetAppServiceData
+--  2) HMI does not respond to SDL
+--  3) SDL sends a GENERIC_ERROR response to the Application when the request times out
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]

--- a/test_scripts/AppServices/GetAppServiceData/012_M2H_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/012_M2H_GENERIC_ERROR.lua
@@ -1,0 +1,92 @@
+---------------------------------------------------------------------------------------------------
+--  Precondition: 
+--  1) Application with <appID> is registered on SDL.
+--  2) Specific permissions are assigned for <appID> with GetAppServiceData
+--  3) HMI has published a MEDIA service
+--
+--  Steps:
+--  1) Application sends a GetAppServiceData RPC request with serviceType MEDIA
+--
+--  Expected:
+--  1) SDL forwards the GetAppServiceData request to the HMI as AppService.GetAppServiceData
+--  2) HMI sends a AppService.GetAppServiceData response (SUCCESS) to Core with its own serviceData
+--  3) SDL forwards the response to Application as GetAppServiceData
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/AppServices/commonAppServices')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local manifest = {
+  serviceName = "HMI_MEDIA_SERVICE",
+  serviceType = "MEDIA",
+  allowAppConsumers = true,
+  rpcSpecVersion = config.application1.registerAppInterfaceParams.syncMsgVersion,
+  mediaServiceManifest = {}
+}
+
+local appServiceData = {
+  serviceType = manifest.serviceType,
+  mediaServiceData = {
+    mediaType = "MUSIC",
+    mediaTitle = "Song name",
+    mediaArtist = "Band name",
+    mediaAlbum = "Album name",
+    playlistName = "Good music",
+    isExplicit = false,
+    trackPlaybackProgress = 200,
+    trackPlaybackDuration = 300,
+    queuePlaybackProgress = 2200,
+    queuePlaybackDuration = 4000,
+    queueCurrentTrackNumber = 12,
+    queueTotalTrackCount = 20
+  }
+}
+
+local rpc = {
+  name = "GetAppServiceData",
+  hmiName = "AppService.GetAppServiceData",
+  params = {
+    serviceType = manifest.serviceType
+  }
+}
+
+local expectedResponse = {
+  success = false,
+  resultCode = "GENERIC_ERROR"
+}
+
+local function PTUfunc(tbl)
+  tbl.policy_table.app_policies[common.getConfigAppParams(1).fullAppID] = common.getAppServiceConsumerConfig(1);
+end
+
+--[[ Local Functions ]]
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession()
+  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
+  local service_id = common.getAppServiceID(0)
+  -- Do not respond
+  EXPECT_HMICALL(rpc.hmiName, rpc.params)
+
+  mobileSession:ExpectResponse(cid, expectedResponse)
+  :Timeout(runner.testSettings.defaultTimeout + common.getRpcPassThroughTimeoutFromINI() + 1000)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerApp)
+runner.Step("PTU", common.policyTableUpdate, { PTUfunc })
+runner.Step("Activate App", common.activateApp)
+runner.Step("Publish App Service", common.publishEmbeddedAppService, { manifest })
+
+runner.Title("Test")
+runner.Step("RPC " .. rpc.name .. "_resultCode_GENERIC_ERROR", processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/AppServices/GetAppServiceData/013_H2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/013_H2M_GENERIC_ERROR.lua
@@ -29,24 +29,6 @@ local manifest = {
   mediaServiceManifest = {}
 }
 
-local appServiceData = {
-  serviceType = manifest.serviceType,
-  mediaServiceData = {
-    mediaType = "MUSIC",
-    mediaTitle = "Song name",
-    mediaArtist = "Band name",
-    mediaAlbum = "Album name",
-    playlistName = "Good music",
-    isExplicit = false,
-    trackPlaybackProgress = 200,
-    trackPlaybackDuration = 300,
-    queuePlaybackProgress = 2200,
-    queuePlaybackDuration = 4000,
-    queueCurrentTrackNumber = 12,
-    queueTotalTrackCount = 20
-  }
-}
-
 local rpc = {
   name = "GetAppServiceData",
   hmiName = "AppService.GetAppServiceData",

--- a/test_scripts/AppServices/GetAppServiceData/013_H2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/013_H2M_GENERIC_ERROR.lua
@@ -1,0 +1,95 @@
+---------------------------------------------------------------------------------------------------
+--  Precondition: 
+--  1) Application with <appID> is registered on SDL.
+--  2) Specific permissions are assigned for <appID> with GetAppServiceData
+--  3) Application has published a MEDIA service
+--
+--  Steps:
+--  1) HMI sends a AppService.GetAppServiceData RPC request with serviceType MEDIA
+--
+--  Expected:
+--  1) SDL forwards the GetAppServiceData request to Application as GetAppServiceData
+--  2) Application sends a GetAppServiceData response (SUCCESS) to Core with its own serviceData
+--  3) SDL forwards the response to HMI as AppService.GetAppServiceData
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/AppServices/commonAppServices')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local manifest = {
+  serviceName = config.application1.registerAppInterfaceParams.appName,
+  serviceType = "MEDIA",
+  allowAppConsumers = true,
+  rpcSpecVersion = config.application1.registerAppInterfaceParams.syncMsgVersion,
+  mediaServiceManifest = {}
+}
+
+local appServiceData = {
+  serviceType = manifest.serviceType,
+  mediaServiceData = {
+    mediaType = "MUSIC",
+    mediaTitle = "Song name",
+    mediaArtist = "Band name",
+    mediaAlbum = "Album name",
+    playlistName = "Good music",
+    isExplicit = false,
+    trackPlaybackProgress = 200,
+    trackPlaybackDuration = 300,
+    queuePlaybackProgress = 2200,
+    queuePlaybackDuration = 4000,
+    queueCurrentTrackNumber = 12,
+    queueTotalTrackCount = 20
+  }
+}
+
+local rpc = {
+  name = "GetAppServiceData",
+  hmiName = "AppService.GetAppServiceData",
+  params = {
+    serviceType = manifest.serviceType
+  }
+}
+
+local expectedResponse = {
+  code = 22,
+  data = {
+    method = rpc.hmiName
+  }
+}
+
+local function PTUfunc(tbl)
+  tbl.policy_table.app_policies[common.getConfigAppParams(1).fullAppID] = common.getAppServiceProducerConfig(1);
+end
+
+--[[ Local Functions ]]
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession()
+  local cid = common.getHMIConnection():SendRequest(rpc.hmiName, rpc.params)
+  local service_id = common.getAppServiceID()
+  -- Do not respond to request
+  mobileSession:ExpectRequest(rpc.name, rpc.params)
+
+  EXPECT_HMIRESPONSE(cid, {
+    error = expectedResponse
+  }):Timeout(runner.testSettings.defaultTimeout + common.getRpcPassThroughTimeoutFromINI() + 1000)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerApp)
+runner.Step("PTU", common.policyTableUpdate, { PTUfunc })
+runner.Step("Activate App", common.activateApp)
+runner.Step("Publish App Service", common.publishMobileAppService, { manifest })
+
+runner.Title("Test")
+runner.Step("RPC " .. rpc.name .. "_resultCode_GENERIC_ERROR", processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/AppServices/GetAppServiceData/013_H2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/GetAppServiceData/013_H2M_GENERIC_ERROR.lua
@@ -9,8 +9,8 @@
 --
 --  Expected:
 --  1) SDL forwards the GetAppServiceData request to Application as GetAppServiceData
---  2) Application sends a GetAppServiceData response (SUCCESS) to Core with its own serviceData
---  3) SDL forwards the response to HMI as AppService.GetAppServiceData
+--  2) Application does not respond to SDL
+--  3) SDL sends a GENERIC_ERROR response to the HMI when the request times out
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
@@ -56,7 +56,7 @@ local rpc = {
 }
 
 local expectedResponse = {
-  code = 22,
+  code = 22, --GENERIC_ERROR
   data = {
     method = rpc.hmiName
   }

--- a/test_scripts/AppServices/PerformAppServiceInteraction/003_H2M_success_flow.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/003_H2M_success_flow.lua
@@ -1,7 +1,7 @@
 ---------------------------------------------------------------------------------------------------
 --  Precondition: 
 --  1) Application with <appID> is registered on SDL.
---  2) Specific permissions are assigned for <appID> with PerformAppServiceInteraction
+--  2) Specific permissions are assigned for <appID> with PublishAppService
 --  3) Application 1 has published a MEDIA service
 --
 --  Steps:

--- a/test_scripts/AppServices/PerformAppServiceInteraction/010_H2M_Timeout.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/010_H2M_Timeout.lua
@@ -1,8 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 --  Precondition: 
 --  1) Application with <appID> is registered on SDL.
---  2) Specific permissions are assigned for <appID> with PerformAppServiceInteraction
---  3) Application 1 has published a MEDIA service
+--  2) Specific permissions are assigned for <appID> with PublishAppService
+--  3) Application has published a MEDIA service
 --
 --  Steps:
 --  1) HMI sends a AppService.PerformAppServiceInteraction RPC request with Application's serviceID

--- a/test_scripts/AppServices/PerformAppServiceInteraction/011_M2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/011_M2M_GENERIC_ERROR.lua
@@ -11,8 +11,8 @@
 --
 --  Expected:
 --  1) SDL forwards the PerformAppServiceInteraction request to Application 1
---  2) Application 1 sends a PerformAppServiceInteraction response (SUCCESS) to Core with a serviceSpecificResult
---  3) SDL forwards the response to Application 2
+--  2) Application 1 does not respond to SDL
+--  3) SDL sends a GENERIC_ERROR response to Application 2 when the request times out
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]

--- a/test_scripts/AppServices/PerformAppServiceInteraction/011_M2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/011_M2M_GENERIC_ERROR.lua
@@ -57,7 +57,7 @@ local function processRPCSuccess(self)
   local requestParams = rpc.params
   requestParams.serviceID = service_id
   local cid = mobileSession2:SendRPC(rpc.name, requestParams)
-  -- Do not respond
+  -- Do not respond to request
   mobileSession:ExpectRequest(rpc.name, requestParams)
 
   mobileSession2:ExpectResponse(cid, expectedResponse)

--- a/test_scripts/AppServices/PerformAppServiceInteraction/011_M2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/011_M2M_GENERIC_ERROR.lua
@@ -1,0 +1,82 @@
+---------------------------------------------------------------------------------------------------
+--  Precondition: 
+--  1) Application 1 with <appID> is registered on SDL.
+--  2) Application 2 with <appID2> is registered on SDL.
+--  3) Specific permissions are assigned for <appID> with PublishAppService
+--  4) Specific permissions are assigned for <appID2> with PerformAppServiceInteraction
+--  5) Application 1 has published a MEDIA service
+--
+--  Steps:
+--  1) Application 2 sends a PerformAppServiceInteraction RPC request with Application 1's serviceID
+--
+--  Expected:
+--  1) SDL forwards the PerformAppServiceInteraction request to Application 1
+--  2) Application 1 sends a PerformAppServiceInteraction response (SUCCESS) to Core with a serviceSpecificResult
+--  3) SDL forwards the response to Application 2
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/AppServices/commonAppServices')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local manifest = {
+  serviceName = config.application1.registerAppInterfaceParams.appName,
+  serviceType = "MEDIA",
+  allowAppConsumers = true,
+  rpcSpecVersion = config.application1.registerAppInterfaceParams.syncMsgVersion,
+  mediaServiceManifest = {}
+}
+
+local rpc = {
+  name = "PerformAppServiceInteraction",
+  params = {
+    originApp = config.application2.registerAppInterfaceParams.fullAppID,
+    serviceUri = "mobile:sample.service.uri"
+  }
+}
+
+local expectedResponse = {
+  success = false,
+  resultCode = "GENERIC_ERROR"
+}
+
+local function PTUfunc(tbl)
+  tbl.policy_table.app_policies[common.getConfigAppParams(1).fullAppID] = common.getAppServiceProducerConfig(1);
+  tbl.policy_table.app_policies[common.getConfigAppParams(2).fullAppID] = common.getAppServiceConsumerConfig(2);
+end
+
+--[[ Local Functions ]]
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession(1)
+  local mobileSession2 = common.getMobileSession(2)
+  local service_id = common.getAppServiceID()
+  local requestParams = rpc.params
+  requestParams.serviceID = service_id
+  local cid = mobileSession2:SendRPC(rpc.name, requestParams)
+  -- Do not respond
+  mobileSession:ExpectRequest(rpc.name, requestParams)
+
+  mobileSession2:ExpectResponse(cid, expectedResponse)
+  :Timeout(runner.testSettings.defaultTimeout + common.getRpcPassThroughTimeoutFromINI() + 1000)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerApp)
+runner.Step("PTU", common.policyTableUpdate, { PTUfunc })
+runner.Step("RAI w/o PTU", common.registerAppWOPTU, { 2 })
+runner.Step("Activate App", common.activateApp)
+runner.Step("Publish App Service", common.publishMobileAppService, { manifest })
+
+runner.Title("Test")
+runner.Step("RPC " .. rpc.name .. "_resultCode_GENERIC_ERROR", processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)
+

--- a/test_scripts/AppServices/PerformAppServiceInteraction/012_M2H_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/012_M2H_GENERIC_ERROR.lua
@@ -9,8 +9,8 @@
 --
 --  Expected:
 --  1) SDL forwards the PerformAppServiceInteraction request to the HMI as AppService.PerformAppServiceInteraction
---  2) HMI sends a AppService.PerformAppServiceInteraction response (SUCCESS) to Core with a serviceSpecificResult
---  3) SDL forwards the response to Application as PerformAppServiceInteraction
+--  2) HMI does not respond to SDL
+--  3) SDL sends a GENERIC_ERROR response to the Application when the request times out
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
@@ -54,6 +54,7 @@ local function processRPCSuccess(self)
   local requestParams = rpc.params
   requestParams.serviceID = service_id
   local cid = mobileSession:SendRPC(rpc.name, requestParams)
+  -- Do not respond to request
   EXPECT_HMICALL(rpc.hmiName, requestParams)
 
   mobileSession:ExpectResponse(cid, expectedResponse)

--- a/test_scripts/AppServices/PerformAppServiceInteraction/012_M2H_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/012_M2H_GENERIC_ERROR.lua
@@ -1,0 +1,76 @@
+---------------------------------------------------------------------------------------------------
+--  Precondition: 
+--  1) Application with <appID> is registered on SDL.
+--  2) Specific permissions are assigned for <appID> with PerformAppServiceInteraction
+--  3) HMI has published a MEDIA service
+--
+--  Steps:
+--  1) Application sends a PerformAppServiceInteraction RPC request with HMI's serviceID
+--
+--  Expected:
+--  1) SDL forwards the PerformAppServiceInteraction request to the HMI as AppService.PerformAppServiceInteraction
+--  2) HMI sends a AppService.PerformAppServiceInteraction response (SUCCESS) to Core with a serviceSpecificResult
+--  3) SDL forwards the response to Application as PerformAppServiceInteraction
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/AppServices/commonAppServices')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local manifest = {
+  serviceName = "HMI_MEDIA_SERVICE",
+  serviceType = "MEDIA",
+  allowAppConsumers = true,
+  rpcSpecVersion = config.application1.registerAppInterfaceParams.syncMsgVersion,
+  mediaServiceManifest = {}
+}
+
+local rpc = {
+  name = "PerformAppServiceInteraction",
+  hmiName = "AppService.PerformAppServiceInteraction",
+  params = {
+    originApp = config.application1.registerAppInterfaceParams.fullAppID,
+    serviceUri = "hmi:sample.service.uri"
+  }
+}
+
+local expectedResponse = {
+  success = false,
+  resultCode = "GENERIC_ERROR"
+}
+
+local function PTUfunc(tbl)
+  tbl.policy_table.app_policies[common.getConfigAppParams(1).fullAppID] = common.getAppServiceConsumerConfig(1);
+end
+
+--[[ Local Functions ]]
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession()
+  local service_id = common.getAppServiceID(0)
+  local requestParams = rpc.params
+  requestParams.serviceID = service_id
+  local cid = mobileSession:SendRPC(rpc.name, requestParams)
+  EXPECT_HMICALL(rpc.hmiName, requestParams)
+
+  mobileSession:ExpectResponse(cid, expectedResponse)
+  :Timeout(runner.testSettings.defaultTimeout + common.getRpcPassThroughTimeoutFromINI() + 1000)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerApp)
+runner.Step("PTU", common.policyTableUpdate, { PTUfunc })
+runner.Step("Activate App", common.activateApp)
+runner.Step("Publish App Service", common.publishEmbeddedAppService, { manifest })
+
+runner.Title("Test")
+runner.Step("RPC " .. rpc.name .. "_resultCode_GENERIC_ERROR", processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/AppServices/PerformAppServiceInteraction/013_H2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/013_H2M_GENERIC_ERROR.lua
@@ -1,0 +1,85 @@
+---------------------------------------------------------------------------------------------------
+--  Precondition: 
+--  1) Application with <appID> is registered on SDL.
+--  2) Specific permissions are assigned for <appID> with PerformAppServiceInteraction
+--  3) Application 1 has published a MEDIA service
+--
+--  Steps:
+--  1) HMI sends a AppService.PerformAppServiceInteraction RPC request with Application's serviceID
+--
+--  Expected:
+--  1) SDL forwards the PerformAppServiceInteraction request to Application as PerformAppServiceInteraction
+--  2) Application sends a PerformAppServiceInteraction response (SUCCESS) to Core with a serviceSpecificResult
+--  3) SDL forwards the response to HMI as AppService.PerformAppServiceInteraction
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/AppServices/commonAppServices')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local manifest = {
+  serviceName = config.application1.registerAppInterfaceParams.appName,
+  serviceType = "MEDIA",
+  allowAppConsumers = true,
+  rpcSpecVersion = config.application1.registerAppInterfaceParams.syncMsgVersion,
+  mediaServiceManifest = {}
+}
+
+local hmiOriginID = "HMI_ORIGIN_ID"
+
+local rpc = {
+  name = "PerformAppServiceInteraction",
+  hmiName = "AppService.PerformAppServiceInteraction",
+  params = {
+    serviceUri = "mobile:sample.service.uri"
+  }
+}
+
+local expectedResponse = {
+  code = 22,
+  data = {
+    method = rpc.hmiName
+  }
+}
+
+local function PTUfunc(tbl)
+  tbl.policy_table.app_policies[common.getConfigAppParams(1).fullAppID] = common.getAppServiceProducerConfig(1);
+end
+
+--[[ Local Functions ]]
+local function processRPCSuccess(self)
+  local mobileSession = common.getMobileSession()
+  local service_id = common.getAppServiceID()
+  local requestParams = rpc.params
+  requestParams.serviceID = service_id
+  local cid = common.getHMIConnection():SendRequest(rpc.hmiName, requestParams)
+  local passedRequestParams = requestParams
+  -- Core manually sets the originApp parameter when passing an HMI message through
+  passedRequestParams.originApp = hmiOriginID
+  -- Do not respond
+  mobileSession:ExpectRequest(rpc.name, passedRequestParams)
+
+  EXPECT_HMIRESPONSE(cid, {
+    error = expectedResponse
+  }):Timeout(runner.testSettings.defaultTimeout + common.getRpcPassThroughTimeoutFromINI() + 1000)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Set HMI Origin ID", common.setSDLIniParameter, { "HMIOriginID", hmiOriginID })
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerApp)
+runner.Step("PTU", common.policyTableUpdate, { PTUfunc })
+runner.Step("Activate App", common.activateApp)
+runner.Step("Publish App Service", common.publishMobileAppService, { manifest })
+
+runner.Title("Test")
+runner.Step("RPC " .. rpc.name .. "_resultCode_GENERIC_ERROR", processRPCSuccess)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/AppServices/PerformAppServiceInteraction/013_H2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/013_H2M_GENERIC_ERROR.lua
@@ -1,8 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 --  Precondition: 
 --  1) Application with <appID> is registered on SDL.
---  2) Specific permissions are assigned for <appID> with PerformAppServiceInteraction
---  3) Application 1 has published a MEDIA service
+--  2) Specific permissions are assigned for <appID> with PublishAppService
+--  3) Application has published a MEDIA service
 --
 --  Steps:
 --  1) HMI sends a AppService.PerformAppServiceInteraction RPC request with Application's serviceID
@@ -60,7 +60,7 @@ local function processRPCSuccess(self)
   local passedRequestParams = requestParams
   -- Core manually sets the originApp parameter when passing an HMI message through
   passedRequestParams.originApp = hmiOriginID
-  -- Do not respond
+  -- Do not respond to request
   mobileSession:ExpectRequest(rpc.name, passedRequestParams)
 
   EXPECT_HMIRESPONSE(cid, {

--- a/test_scripts/AppServices/PerformAppServiceInteraction/013_H2M_GENERIC_ERROR.lua
+++ b/test_scripts/AppServices/PerformAppServiceInteraction/013_H2M_GENERIC_ERROR.lua
@@ -9,8 +9,8 @@
 --
 --  Expected:
 --  1) SDL forwards the PerformAppServiceInteraction request to Application as PerformAppServiceInteraction
---  2) Application sends a PerformAppServiceInteraction response (SUCCESS) to Core with a serviceSpecificResult
---  3) SDL forwards the response to HMI as AppService.PerformAppServiceInteraction
+--  2) Application does not respond to SDL
+--  3) SDL sends a GENERIC_ERROR response to the HMI when the request times out
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
@@ -40,7 +40,7 @@ local rpc = {
 }
 
 local expectedResponse = {
-  code = 22,
+  code = 22, --GENERIC_ERROR
   data = {
     method = rpc.hmiName
   }


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/sdl_core/issues/2866
This PR is **ready** for review.

### Summary
Adds tests for GENERIC_ERROR timeout when app service provider doesn't respond

### ATF version
`develop` branch

### Changelog

##### Enhancements
* Adds tests for GENERIC_ERROR timeout when app service provider doesn't respond

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
