### PR TITLE
Add GENERIC_ERROR tests to app services test set

### DIFF
--- a/test_sets/app_services.txt
+++ b/test_sets/app_services.txt
@@ -12,6 +12,9 @@
 ./test_scripts/AppServices/GetAppServiceData/008_M2M_Timeout.lua
 ./test_scripts/AppServices/GetAppServiceData/009_M2H_Timeout.lua
 ./test_scripts/AppServices/GetAppServiceData/010_H2M_Timeout.lua
+./test_scripts/AppServices/GetAppServiceData/011_M2M_GENERIC_ERROR.lua
+./test_scripts/AppServices/GetAppServiceData/012_M2H_GENERIC_ERROR.lua
+./test_scripts/AppServices/GetAppServiceData/013_H2M_GENERIC_ERROR.lua
 ./test_scripts/AppServices/GetAppServiceRecords/001_GetAppServiceRecords_MOBILE.lua
 ./test_scripts/AppServices/GetAppServiceRecords/002_GetAppServiceRecords_HMI.lua
 ./test_scripts/AppServices/GetAppServiceRecords/003_GetAppServiceRecords_Multiple.lua
@@ -37,6 +40,9 @@
 ./test_scripts/AppServices/PerformAppServiceInteraction/008_M2M_Timeout.lua
 ./test_scripts/AppServices/PerformAppServiceInteraction/009_M2H_Timeout.lua
 ./test_scripts/AppServices/PerformAppServiceInteraction/010_H2M_Timeout.lua
+./test_scripts/AppServices/PerformAppServiceInteraction/011_M2M_GENERIC_ERROR.lua
+./test_scripts/AppServices/PerformAppServiceInteraction/012_M2H_GENERIC_ERROR.lua
+./test_scripts/AppServices/PerformAppServiceInteraction/013_H2M_GENERIC_ERROR.lua
 ./test_scripts/AppServices/PublishAppService/001_Mobile_success_flow.lua
 ./test_scripts/AppServices/PublishAppService/002_HMI_success_flow.lua
 ./test_scripts/AppServices/PublishAppService/003_Nav_success_flow.lua


### PR DESCRIPTION

This PR is **ready** for review.

### Summary
Add missing App Services tests to test set

### ATF version
`develop` branch

### Changelog
##### Bug Fixes
* Add missing App Services tests to test set

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
