### PR TITLE
Added cleanup steps for test scripts which corrupt the PT/INI file

### DIFF
--- a/test_scripts/Policies/Validation_of_PolicyTables/310_ATF_Check_count_of_removals_for_bad_behavior_REQUEST_WHILE_IN_NONE_HMI_LEVEL.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/310_ATF_Check_count_of_removals_for_bad_behavior_REQUEST_WHILE_IN_NONE_HMI_LEVEL.lua
@@ -130,7 +130,7 @@ function Test.Postcondition_Stop_SDL()
   StopSDL()
 end
 function Test.RestoreIniFile()
-  -- Preconditions:RestoreFile("smartDeviceLink.ini")
+  Preconditions:RestoreFile("smartDeviceLink.ini")
 end
 
 return Test

--- a/test_scripts/Policies/user_consent_of_Policies/200_ATF_Data_consent_prompt.lua
+++ b/test_scripts/Policies/user_consent_of_Policies/200_ATF_Data_consent_prompt.lua
@@ -55,6 +55,7 @@ end
 
 --[[ Postconditions ]]
 commonFunctions:newTestCasesGroup("Postconditions")
+testCasesForPolicyTable:Restore_preloaded_pt()
 function Test.Postcondition_StopSDL()
   StopSDL()
 end


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Adds cleanup steps to the  EXTERNAL_PROPRIETARY test scripts which were corrupting the Preloaded policy table and SmartDeviceLink.ini file

### ATF version
[develop](https://github.com/smartdevicelink/sdl_atf/tree/develop)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
