### PR TITLE
Add getSystemCapability test to smoke test set

### DIFF
--- a/test_scripts/API/ATF_GetSystemCapability.lua
+++ b/test_scripts/API/ATF_GetSystemCapability.lua
@@ -75,7 +75,7 @@ function Test:TestStep_GetPhoneCapability()
   :Timeout(12000)   
 end
 
-function Test:TestStep_GetPhoneCapability()
+function Test:TestStep_GetVideoCapability()
   local CorIdGetSystemCapability = self.mobileSession:SendRPC(
     "GetSystemCapability",
     {

--- a/test_scripts/API/ATF_GetSystemCapability.lua
+++ b/test_scripts/API/ATF_GetSystemCapability.lua
@@ -49,7 +49,7 @@ function Test:TestStep_GetNavCapability()
   local CorIdGetSystemCapability = self.mobileSession:SendRPC(
     "GetSystemCapability",
     {
-      systemCapabilityType = 0
+      systemCapabilityType = "NAVIGATION"
     })
 
   --mobile response
@@ -64,7 +64,7 @@ function Test:TestStep_GetPhoneCapability()
   local CorIdGetSystemCapability = self.mobileSession:SendRPC(
     "GetSystemCapability",
     {
-      systemCapabilityType = 1
+      systemCapabilityType = "PHONE_CALL"
     })
 
   --mobile response
@@ -79,7 +79,7 @@ function Test:TestStep_GetVideoCapability()
   local CorIdGetSystemCapability = self.mobileSession:SendRPC(
     "GetSystemCapability",
     {
-      systemCapabilityType = 2
+      systemCapabilityType = "VIDEO_STREAMING"
     })
 
   --mobile response

--- a/test_scripts/API/ATF_GetSystemCapability.lua
+++ b/test_scripts/API/ATF_GetSystemCapability.lua
@@ -75,6 +75,36 @@ function Test:TestStep_GetPhoneCapability()
   :Timeout(12000)   
 end
 
+function Test:TestStep_GetPhoneCapability()
+  local CorIdGetSystemCapability = self.mobileSession:SendRPC(
+    "GetSystemCapability",
+    {
+      systemCapabilityType = 2
+    })
+
+  --mobile response
+  EXPECT_RESPONSE(CorIdGetSystemCapability, { 
+    success = true, 
+    resultCode = "SUCCESS",
+    systemCapability={
+      videoStreamingCapability={
+        preferredResolution={
+          resolutionWidth=800,
+          resolutionHeight=350
+        },
+        maxBitrate=10000,
+        supportedFormats={{
+          protocol="RAW",
+          codec="H264"
+        }},
+        hapticSpatialDataSupported= false
+      },
+      systemCapabilityType="VIDEO_STREAMING"
+    }
+  })
+  :Timeout(12000)   
+end
+
 --[[ Postconditions ]]
 -- if not applicable remove this section
 commonFunctions:newTestCasesGroup("Postconditions")

--- a/test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
+++ b/test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
@@ -1,0 +1,100 @@
+---------------------------------------------------------------------------------------------------
+-- User story: Smoke
+-- Use case: GetSystemCapabilities
+-- Item: Happy path
+--
+-- Requirement summary:
+-- [ReadDID] SUCCESS: getting SUCCESS:VehicleInfo.GetSystemCapabilities()
+--
+-- Description:
+-- Mobile application sends valid GetSystemCapabilities request for Nav, Phone, and Video.
+-- Capabilities related to app services and remote control are in seperate tests.
+
+-- Pre-conditions:
+-- a. HMI and SDL are started
+-- b. appID is registered and activated on SDL
+-- c. appID is currently in Background, Full or Limited HMI level
+
+-- Steps:
+-- appID requests GetSystemCapabilities with valid parameters
+
+-- Expected:
+-- SDL responds with (resultCode: SUCCESS, success:true) to mobile application for all Nav, Phone, and Video capability types
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSmoke = require('test_scripts/Smoke/commonSmoke')
+
+--[[ Local Variables ]]
+local navCapabilities = {
+  navigationCapability={
+    getWayPointsEnabled=true,
+    sendLocationEnabled=true
+  },
+  systemCapabilityType="NAVIGATION"
+}
+local phoneCapabilities = {
+  phoneCapability={
+    dialNumberEnabled=true
+  },
+  systemCapabilityType="PHONE_CALL"
+
+}
+local videoCapabilities = {
+  videoStreamingCapability={
+    preferredResolution={
+      resolutionWidth=800,
+      resolutionHeight=350
+    },
+    maxBitrate=10000,
+    supportedFormats={{
+      protocol="RAW",
+      codec="H264"
+    }},
+    hapticSpatialDataSupported= false
+  },
+  systemCapabilityType="VIDEO_STREAMING"
+}
+
+--[[ Local Functions ]]
+local function getSystemCapabilityRequest(type)
+  local temp = {
+    systemCapabilityType = type
+  }
+  return temp
+end
+
+local function getSystemCapabilityResponse(capabilities)
+  local temp = {
+    systemCapability = capabilities
+  }
+  return temp
+end
+
+local function getSystemCapability(type, capabilities, self)
+  local paramsSend = getSystemCapabilityRequest(type)
+  local response = getSystemCapabilityResponse(capabilities)
+  local cid = self.mobileSession1:SendRPC("GetSystemCapability", paramsSend)
+
+  local expectedResult = response
+  expectedResult.success = true
+  expectedResult.resultCode = "SUCCESS"
+  self.mobileSession1:ExpectResponse(cid, expectedResult)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSmoke.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
+runner.Step("RAI", commonSmoke.registerApp)
+runner.Step("Activate App", commonSmoke.activateApp)
+
+runner.Title("Test")
+runner.Step("GetSystemCapability NAVIGATION Positive Case", getSystemCapability, {"NAVIGATION", navCapabilities})
+runner.Step("GetSystemCapability PHONE_CALL Positive Case", getSystemCapability, {"PHONE_CALL", phoneCapabilities})
+runner.Step("GetSystemCapability VIDEO_STREAMING Positive Case", getSystemCapability, {"VIDEO_STREAMING", videoCapabilities})
+
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSmoke.postconditions)

--- a/test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
+++ b/test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
@@ -39,7 +39,6 @@ local phoneCapabilities = {
     dialNumberEnabled=true
   },
   systemCapabilityType="PHONE_CALL"
-
 }
 local videoCapabilities = {
   videoStreamingCapability={
@@ -72,7 +71,8 @@ local function getSystemCapabilityResponse(capabilities)
   return temp
 end
 
-local function getSystemCapability(type, capabilities, self)
+local function getSystemCapability(capabilities, self)
+  local type = capabilities.systemCapabilityType
   local paramsSend = getSystemCapabilityRequest(type)
   local response = getSystemCapabilityResponse(capabilities)
   local cid = self.mobileSession1:SendRPC("GetSystemCapability", paramsSend)
@@ -91,9 +91,9 @@ runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 
 runner.Title("Test")
-runner.Step("GetSystemCapability NAVIGATION Positive Case", getSystemCapability, {"NAVIGATION", navCapabilities})
-runner.Step("GetSystemCapability PHONE_CALL Positive Case", getSystemCapability, {"PHONE_CALL", phoneCapabilities})
-runner.Step("GetSystemCapability VIDEO_STREAMING Positive Case", getSystemCapability, {"VIDEO_STREAMING", videoCapabilities})
+runner.Step("GetSystemCapability NAVIGATION Positive Case", getSystemCapability, {navCapabilities})
+runner.Step("GetSystemCapability PHONE_CALL Positive Case", getSystemCapability, {phoneCapabilities})
+runner.Step("GetSystemCapability VIDEO_STREAMING Positive Case", getSystemCapability, {videoCapabilities})
 
 
 runner.Title("Postconditions")

--- a/test_sets/smoke_tests.txt
+++ b/test_sets/smoke_tests.txt
@@ -67,3 +67,4 @@
 ./test_scripts/Smoke/Resumption/011_Resumption_unexpected_disconnect.lua
 ./test_scripts/Smoke/ShutDown/001_ShutDown_IGNITION_OFF.lua
 ./test_scripts/Smoke/ShutDown/002_ShutDown_MASTER_RESET.lua
+./test_scripts/API/ATF_GetSystemCapability.lua

--- a/test_sets/smoke_tests.txt
+++ b/test_sets/smoke_tests.txt
@@ -67,4 +67,4 @@
 ./test_scripts/Smoke/Resumption/011_Resumption_unexpected_disconnect.lua
 ./test_scripts/Smoke/ShutDown/001_ShutDown_IGNITION_OFF.lua
 ./test_scripts/Smoke/ShutDown/002_ShutDown_MASTER_RESET.lua
-./test_scripts/API/ATF_GetSystemCapability.lua
+./test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua

--- a/test_sets/smoke_tests.txt
+++ b/test_sets/smoke_tests.txt
@@ -43,6 +43,7 @@
 ./test_scripts/Smoke/API/043_UnsubscribeButton_Non_Media_PositiveCase_SUCCESS.lua
 ./test_scripts/Smoke/API/044_AlertManeuver_Non_Media_PositiveCase_SUCCESS.lua
 ./test_scripts/Smoke/API/045_PerformAudioPassThru_Non_Media_PositiveCase_SUCCESS.lua
+./test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
 ./test_scripts/Smoke/HeartBeat/001_HeartBeat_App_does_not_send_HB_and_does_not_respond.lua
 ./test_scripts/Smoke/HeartBeat/002_HeartBeat_App_does_not_send_HB_but_respond.lua
 ./test_scripts/Smoke/HeartBeat/003_HeartBeat_App_send_HB.lua
@@ -67,4 +68,3 @@
 ./test_scripts/Smoke/Resumption/011_Resumption_unexpected_disconnect.lua
 ./test_scripts/Smoke/ShutDown/001_ShutDown_IGNITION_OFF.lua
 ./test_scripts/Smoke/ShutDown/002_ShutDown_MASTER_RESET.lua
-./test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua


### PR DESCRIPTION
This PR is **ready** for review.

### Summary

- Add getSystemCapability test to smoke test set.
- Add video streaming capabilities to the getSystemCapability test.

### ATF version
Develop/Master

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)