### PR TITLE
Fix the response struct in smoke scripts for SubscribeVD, UnsubscribeVD, GetVD

### DIFF
--- a/test_scripts/Smoke/API/024_SubscribeVehicleData_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/024_SubscribeVehicleData_PositiveCase_SUCCESS.lua
@@ -101,7 +101,7 @@ local function subscribeVD(pParams, self)
   :Do(function(_, data)
     self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", pParams.responseUiParams)
   end)
-  local MobResp = pParams.responseUiParams
+  local MobResp = commonSmoke.cloneTable(pParams.responseUiParams)
   MobResp.success = true
   MobResp.resultCode = "SUCCESS"
   self.mobileSession1:ExpectResponse(cid, MobResp)

--- a/test_scripts/Smoke/API/025_UnsubscribeVehicleData_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/025_UnsubscribeVehicleData_PositiveCase_SUCCESS.lua
@@ -111,7 +111,7 @@ local function unsubscribeVD(pParams, self)
   :Do(function(_, data)
     self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", pParams.responseUiParams)
   end)
-  local MobResp = pParams.responseUiParams
+  local MobResp = commonSmoke.cloneTable(pParams.responseUiParams)
   MobResp.success = true
   MobResp.resultCode = "SUCCESS"
   self.mobileSession1:ExpectResponse(cid, MobResp)

--- a/test_scripts/Smoke/API/026_GetVehicleData_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/026_GetVehicleData_PositiveCase_SUCCESS.lua
@@ -179,7 +179,7 @@ local function getVD(pParams, self)
   :Do(function(_,data)
       self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", pParams.responseUiParams)
     end)
-  local MobResp = pParams.responseUiParams
+  local MobResp = commonSmoke.cloneTable(pParams.responseUiParams)
   MobResp.success = true
   MobResp.resultCode = "SUCCESS"
   self.mobileSession1:ExpectResponse(cid, MobResp)

--- a/test_scripts/Smoke/commonSmoke.lua
+++ b/test_scripts/Smoke/commonSmoke.lua
@@ -22,6 +22,8 @@ local preloadedPT = commonFunctions:read_parameter_from_smart_device_link_ini("P
 
 local commonSmoke = {}
 
+commonSmoke.cloneTable = utils.cloneTable
+
 commonSmoke.HMITypeStatus = {
   NAVIGATION = false,
   COMMUNICATION = false


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary

Update for existing Smoke API scripts with cutting of redundant parameters ( "success":true, "resultCode":"SUCCESS" ) according to requirements within [HMI_API.xml](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/interfaces/HMI_API.xml#L5469)

### ATF version
https://github.com/smartdevicelink/sdl_atf/tree/develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
