### PR TITLE
Update test scripts to support HTTP and EXT SDL's policy modes

### DIFF
--- a/test_scripts/API/Expanded_proprietary_data_exchange/commonDataExchange.lua
+++ b/test_scripts/API/Expanded_proprietary_data_exchange/commonDataExchange.lua
@@ -7,6 +7,10 @@ local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
 local utils = require("user_modules/utils")
 local events = require("events")
 local json = require("modules/json")
+local runner = require('user_modules/script_runner')
+
+-- Set applicalbe SDL policy mode
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" } } }
 
 --[[ General configuration parameters ]]
 config.defaultProtocolVersion = 2

--- a/test_scripts/API/ServiceStatusUpdateToHMI/common.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/common.lua
@@ -104,7 +104,7 @@ function m.policyTableUpdateSuccess(pPTUpdateFunc)
     :Times(AtMost(1))
     m.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { odometer = true })
   end
-  m.getHMIConnection():ExpectRequest("BasicCommunication.PolicyUpdate")
+  m.isPTUStarted()
   :Do(function(e, data)
       if e.occurences == 1 then
         m.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
@@ -123,7 +123,7 @@ function m.policyTableUpdateUnsuccess()
     common.getHMIConnection():ExpectRequest("BasicCommunication.DecryptCertificate")
     :Times(0)
   end
-  common.getHMIConnection():ExpectRequest("BasicCommunication.PolicyUpdate")
+  m.isPTUStarted()
   :Do(function(e, data)
       if e.occurences == 1 then
         common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })

--- a/test_scripts/API/VehicleData/DOP/common.lua
+++ b/test_scripts/API/VehicleData/DOP/common.lua
@@ -59,4 +59,8 @@ function m.checkAbsenceOfParam(pParam, pData)
   return true
 end
 
+function m.ptUpdate(pTbl)
+  pTbl.policy_table.functional_groupings["Location-1"].user_consent_prompt = nil
+end
+
 return m

--- a/test_scripts/API/VehicleData/GpsShiftSupport/commonGpsShift.lua
+++ b/test_scripts/API/VehicleData/GpsShiftSupport/commonGpsShift.lua
@@ -42,6 +42,7 @@ m.gpsParams = {
 --[[ Functions ]]
 function m.pTUpdateFunc(tbl)
     tbl.policy_table.app_policies[config.application1.registerAppInterfaceParams.fullAppID].groups = {"Base-4", "Location-1"}
+    tbl.policy_table.functional_groupings["Location-1"].user_consent_prompt = nil
 end
 
 function m.checkShifted(data, pShiftValue)

--- a/test_scripts/AppServices/RPCPassThrough/008_PTU_allow_unknown_rpc_passthrough.lua
+++ b/test_scripts/AppServices/RPCPassThrough/008_PTU_allow_unknown_rpc_passthrough.lua
@@ -16,6 +16,7 @@ local common = require('test_scripts/AppServices/commonAppServices')
 
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" } } }
 
 --[[ Local Functions ]]
 local function PTUfunc(tbl)

--- a/test_scripts/AppServices/commonAppServices.lua
+++ b/test_scripts/AppServices/commonAppServices.lua
@@ -459,16 +459,9 @@ function commonAppServices.getRpcPassThroughTimeoutFromINI()
   return tonumber(RpcPassThroughTimeout)
 end
 
-function commonAppServices:Request_PTU()
-  local is_test_fail = false
-  local hmi_app1_id = config.application1.registerAppInterfaceParams.appName
+function commonAppServices:Request_PTU()  
   commonAppServices.getHMIConnection():SendNotification("SDL.OnPolicyUpdate", {} )
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"})
-
-  EXPECT_HMICALL("BasicCommunication.PolicyUpdate",{ file = "/tmp/fs/mp/images/ivsu_cache/sdl_snapshot.json" })
-  :Do(function(_,data)
-    commonAppServices.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
-    end)
+  commonAppServices.isPTUStarted()
 end
 
 function commonAppServices.GetPolicySnapshot()

--- a/test_scripts/CloudAppRPCs/005_SetCloudAppProperties_Success.lua
+++ b/test_scripts/CloudAppRPCs/005_SetCloudAppProperties_Success.lua
@@ -21,6 +21,7 @@ local commonFunctions = require ('user_modules/shared_testcases/commonFunctions'
 
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" } } }
 
 --[[ Local Variables ]]
 local rpc = {

--- a/test_scripts/CloudAppRPCs/007_SetCloudAppProperties_InitNewCloudApp.lua
+++ b/test_scripts/CloudAppRPCs/007_SetCloudAppProperties_InitNewCloudApp.lua
@@ -21,6 +21,7 @@ local commonFunctions = require ('user_modules/shared_testcases/commonFunctions'
 
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" } } }
 
 --[[ Local Variables ]]
 local rpc = {

--- a/test_scripts/CloudAppRPCs/010_get_icon_url.lua
+++ b/test_scripts/CloudAppRPCs/010_get_icon_url.lua
@@ -18,6 +18,7 @@ local common = require('test_scripts/CloudAppRPCs/commonCloudAppRPCs')
 
  --[[ Test Configuration ]]
  runner.testSettings.isSelfIncluded = false
+ runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" } } }
 
 --[[ Local Variables ]]
 local cloud_app_id = "cloudAppID123"

--- a/test_scripts/CloudAppRPCs/commonCloudAppRPCs.lua
+++ b/test_scripts/CloudAppRPCs/commonCloudAppRPCs.lua
@@ -39,16 +39,9 @@ function commonCloudAppRPCs.getCloudAppStoreConfig()
   }
 end
 
-function commonCloudAppRPCs:Request_PTU()
-  local is_test_fail = false
-  local hmi_app1_id = config.application1.registerAppInterfaceParams.appName
+function commonCloudAppRPCs:Request_PTU()  
   commonCloudAppRPCs.getHMIConnection():SendNotification("SDL.OnPolicyUpdate", {} )
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"})
-
-  EXPECT_HMICALL("BasicCommunication.PolicyUpdate",{ file = "/tmp/fs/mp/images/ivsu_cache/sdl_snapshot.json" })
-  :Do(function(_,data)
-    commonCloudAppRPCs.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
-    end)
+  commonCloudAppRPCs.isPTUStarted()
 end
 
 function commonCloudAppRPCs.test_assert(condition, msg)

--- a/test_scripts/SDL5_0/FullAppID/common.lua
+++ b/test_scripts/SDL5_0/FullAppID/common.lua
@@ -14,6 +14,9 @@ local sdl = require("SDL")
 local commonSteps = require("user_modules/shared_testcases/commonSteps")
 local commonSmoke = require('test_scripts/Smoke/commonSmoke')
 
+-- Set applicalbe SDL policy mode
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY" } } }
+
 --[[ Local Variables ]]
 
 local m = commonSteps

--- a/test_scripts/Security/SSLHandshakeFlow/common.lua
+++ b/test_scripts/Security/SSLHandshakeFlow/common.lua
@@ -203,7 +203,7 @@ function m.defaultExpNotificationFunc()
   m.getHMIConnection():ExpectRequest("BasicCommunication.DecryptCertificate")
   :Do(function(_, d)
       m.getHMIConnection():SendResponse(d.id, d.method, "SUCCESS", { })
-      utils.wait(1000) -- time for SDL to save certificates
+    utils.wait(1000) -- time for SDL to save certificates
     end)
   :Times(AnyNumber())
   m.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { odometer = true })
@@ -217,12 +217,9 @@ function m.policyTableUpdate(pPTUpdateFunc, pExpNotificationFunc)
 end
 
 function m.policyTableUpdateSuccess(pPTUpdateFunc)
-  m.getHMIConnection():ExpectRequest("BasicCommunication.PolicyUpdate")
-  :Do(function(e, d)
-      if e.occurences == 1 then
-        m.getHMIConnection():SendResponse(d.id, d.method, "SUCCESS", { })
-        m.policyTableUpdate(pPTUpdateFunc)
-      end
+  m.isPTUStarted()
+  :Do(function()
+      m.policyTableUpdate(pPTUpdateFunc)
     end)
 end
 

--- a/test_scripts/TheSameApp/Security/001_Send_RPC_or_encrypted_RPC_in_protected_unprotected_mode_apps_with_same_appName_appID_from_2_devices.lua
+++ b/test_scripts/TheSameApp/Security/001_Send_RPC_or_encrypted_RPC_in_protected_unprotected_mode_apps_with_same_appName_appID_from_2_devices.lua
@@ -68,7 +68,7 @@ runner.Step("Set DTLS protocol in SDL", common.setSDLIniParameter, { "Protocol",
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("Connect two mobile devices to SDL", common.connectMobDevices, {devices})
 runner.Step("Register App1 from device 1", common.registerAppEx, {1, appParams[1], 1})
-runner.Step("Register App2 from device 2", common.registerAppEx, {2, appParams[2], 2}, true)
+runner.Step("Register App2 from device 2", common.registerAppEx, {2, appParams[2], 2, true})
 runner.Step("Policy Table Update Certificate", common.policyTableUpdate, { common.ptUpdate })
 runner.Step("Activate App 1", common.activateApp, { 1 })
 

--- a/test_scripts/TheSameApp/Security/002_Send_RPC_or_encrypted_RPC_in_protected_unprotected_mode_apps_with_same_appName_diff_appID_from_2_devices.lua
+++ b/test_scripts/TheSameApp/Security/002_Send_RPC_or_encrypted_RPC_in_protected_unprotected_mode_apps_with_same_appName_diff_appID_from_2_devices.lua
@@ -68,7 +68,7 @@ runner.Step("Set DTLS protocol in SDL", common.setSDLIniParameter, { "Protocol",
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("Connect two mobile devices to SDL", common.connectMobDevices, {devices})
 runner.Step("Register App1 from device 1", common.registerAppEx, {1, appParams[1], 1})
-runner.Step("Register App2 from device 2", common.registerAppEx, {2, appParams[2], 2}, true)
+runner.Step("Register App2 from device 2", common.registerAppEx, {2, appParams[2], 2, true})
 runner.Step("Policy Table Update Certificate", common.policyTableUpdate, { common.ptUpdate })
 runner.Step("Activate App 1", common.activateApp, { 1 })
 

--- a/test_scripts/TheSameApp/Security/003_Send_RPC_or_encrypted_RPC_in_protected_unprotected_mode_apps_with_diff_appName_same_appID_from_2_devices.lua
+++ b/test_scripts/TheSameApp/Security/003_Send_RPC_or_encrypted_RPC_in_protected_unprotected_mode_apps_with_diff_appName_same_appID_from_2_devices.lua
@@ -68,7 +68,7 @@ runner.Step("Set DTLS protocol in SDL", common.setSDLIniParameter, { "Protocol",
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("Connect two mobile devices to SDL", common.connectMobDevices, {devices})
 runner.Step("Register App1 from device 1", common.registerAppEx, {1, appParams[1], 1})
-runner.Step("Register App2 from device 2", common.registerAppEx, {2, appParams[2], 2}, true)
+runner.Step("Register App2 from device 2", common.registerAppEx, {2, appParams[2], 2, true})
 runner.Step("Policy Table Update Certificate", common.policyTableUpdate, { common.ptUpdate })
 runner.Step("Activate App 1", common.activateApp, { 1 })
 

--- a/test_scripts/TheSameApp/commonTheSameApp.lua
+++ b/test_scripts/TheSameApp/commonTheSameApp.lua
@@ -104,10 +104,7 @@ function common.registerAppEx(pAppId, pAppParams, pMobConnId, pHasPTU)
       :Do(function(_, d1)
         common.app.setHMIId(d1.params.application.appID, pAppId)
           if pHasPTU then
-            common.hmi.getConnection():ExpectRequest("BasicCommunication.PolicyUpdate")
-              :Do(function(_, d2)
-                  common.hmi.getConnection():SendResponse(d2.id, d2.method, "SUCCESS", { })
-                end)
+            common.isPTUStarted()
           end
         end)
       session:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })


### PR DESCRIPTION
Fixed issue [#2229](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2229)

### Summary
Update various common modules in order to support SDL's `HTTP` and `EXTERNAL_PROPRIETARY` policy modes
The main idea is to make possible to run ATF test scripts on all existing SDL policy modes: `PROPRIETARY`, `EXTERNAL_PROPRIETARY` and `HTTP`

### ATF version
develop

### Changelog
- add support of `HTTP`mode to `actions.policyTableUpdate()`
- create new `actions.isPTUStarted()` function
- add policy mode configuration option to some scripts to prevent running of them on not applicable mode (test will be skipped)
- remove `user_consent_prompt` for some scripts related to VehicleData.
- add delay after `BC.DecryptCertificate` in order to SDL has time to store certificates on a file system (this fixed instability in security scripts for EXT mode)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
