### PR TITLE
add tests for using new menuLayout parameter

### DIFF
--- a/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
+++ b/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
@@ -29,33 +29,38 @@ local commonSmoke = require('test_scripts/Smoke/commonSmoke')
 local hmi_values = require('user_modules/hmi_values')
 
 --[[ Local Variables ]]
+local addSubMenuParams = { 
+  menuLayout = "TILES",
+  menuID = 44991234,
+  menuName = "sickMenu"
+}
+
+local setGlobalPropertiesParams = { 
+  menuLayout = "TILES"
+}
+
+local successResponse = {
+  success = true,
+  resultCode = "SUCCESS"
+}
+
+--[[ Local Functions ]]
 local function setMenuLayoutTiles(self)
-  local cid = self.mobileSession1:SendRPC("SetGlobalProperties", { menuLayout = "TILES" })
+  local cid = self.mobileSession1:SendRPC("SetGlobalProperties", setGlobalPropertiesParams)
   
   EXPECT_HMICALL("UI.SetGlobalProperties", {})
   :Do(function(_, data)
     --util.printTable(data)
     self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    self.mobileSession1:ExpectResponse(cid, {
-      success = true,
-      resultCode = "SUCCESS"
-    })
+    self.mobileSession1:ExpectResponse(cid, successResponse)
   end)
 
-  local _addSubMenuParams = { menuLayout = "TILES",
-                              menuID = 44991234,
-                              menuName = "sickMenu"
-                            }
-
-  local cid2 = self.mobileSession1:SendRPC("AddSubMenu", _addSubMenuParams)
+  local cid2 = self.mobileSession1:SendRPC("AddSubMenu", addSubMenuParams)
   
   EXPECT_HMICALL("UI.AddSubMenu", {})
   :Do(function(_, data)
     self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    self.mobileSession1:ExpectResponse(cid2, {
-      success = true,
-      resultCode = "SUCCESS"
-    })
+    self.mobileSession1:ExpectResponse(cid2, successResponse)
   end)
 end
 

--- a/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
+++ b/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
@@ -1,0 +1,79 @@
+---------------------------------------------------------------------------------------------------
+-- User story: Smoke
+-- Use case: Set Menu Layout
+-- Item: Happy path
+--
+-- Requirement summary:
+-- [ReadDID] SUCCESS: getting SUCCESS:VehicleInfo.GetSystemCapabilities()
+--
+-- Description:
+-- HMI Has capability to support a TILES menuLayout
+
+-- Pre-conditions:
+-- a. HMI and SDL are started
+-- b. appID is registered and activated on SDL
+-- c. appID is currently in Background, Full or Limited HMI level
+-- d. HMI display capabilities member menuLayoutsAvailable contains TILES
+
+-- Steps:
+-- Mobile App calls SetGlobalProperties with menuLayout = TILES
+-- Mobile App calls AddSubMenu with menuLayout = TILES
+
+-- Expected:
+-- SDL responds with (resultCode: SUCCESS, success:true) to mobile application for both requests
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSmoke = require('test_scripts/Smoke/commonSmoke')
+local hmi_values = require('user_modules/hmi_values')
+
+--[[ Local Variables ]]
+local function setMenuLayoutTiles(self)
+  local cid = self.mobileSession1:SendRPC("SetGlobalProperties", { menuLayout = "TILES" })
+  
+  EXPECT_HMICALL("UI.SetGlobalProperties", {})
+  :Do(function(_, data)
+    --util.printTable(data)
+    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+    self.mobileSession1:ExpectResponse(cid, {
+      success = true,
+      resultCode = "SUCCESS"
+    })
+  end)
+
+  local _addSubMenuParams = { menuLayout = "TILES",
+                              menuID = 44991234,
+                              menuName = "sickMenu"
+                            }
+
+  local cid2 = self.mobileSession1:SendRPC("AddSubMenu", _addSubMenuParams)
+  
+  EXPECT_HMICALL("UI.AddSubMenu", {})
+  :Do(function(_, data)
+    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+    self.mobileSession1:ExpectResponse(cid2, {
+      success = true,
+      resultCode = "SUCCESS"
+    })
+  end)
+end
+
+local function getHMIParams()
+  local params = hmi_values.getDefaultHMITable()
+  params.UI.GetCapabilities.params.displayCapabilities.menuLayoutsAvailable = { "LIST", "TILES" }
+  return params
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSmoke.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start, { getHMIParams() })
+runner.Step("RAI", commonSmoke.registerApp)
+runner.Step("Activate App", commonSmoke.activateApp)
+
+runner.Title("Test")
+runner.Step("Setting Menu Layout to supported TILES", setMenuLayoutTiles)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSmoke.postconditions)

--- a/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
+++ b/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
@@ -50,7 +50,6 @@ local function setMenuLayoutTiles(self)
   
   EXPECT_HMICALL("UI.SetGlobalProperties", {})
   :Do(function(_, data)
-    --util.printTable(data)
     self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
     self.mobileSession1:ExpectResponse(cid, successResponse)
   end)

--- a/test_scripts/Smoke/API/050_SetMenuLayout_unspported_WARNINGS.lua
+++ b/test_scripts/Smoke/API/050_SetMenuLayout_unspported_WARNINGS.lua
@@ -1,0 +1,79 @@
+---------------------------------------------------------------------------------------------------
+-- User story: Smoke
+-- Use case: Set Menu Layout
+-- Item: Happy path
+--
+-- Requirement summary:
+-- [ReadDID] SUCCESS: getting SUCCESS:VehicleInfo.GetSystemCapabilities()
+--
+-- Description:
+-- HMI Has capability to support a TILES menuLayout
+
+-- Pre-conditions:
+-- a. HMI and SDL are started
+-- b. appID is registered and activated on SDL
+-- c. appID is currently in Background, Full or Limited HMI level
+-- d. HMI display capabilities member menuLayoutsAvailable contains TILES
+
+-- Steps:
+-- Mobile App calls SetGlobalProperties with menuLayout = TILES
+-- Mobile App calls AddSubMenu with menuLayout = TILES
+
+-- Expected:
+-- SDL responds with (resultCode: SUCCESS, success:true) to mobile application for both requests
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local commonSmoke = require('test_scripts/Smoke/commonSmoke')
+local hmi_values = require('user_modules/hmi_values')
+
+--[[ Local Variables ]]
+local function setMenuLayoutTiles(self)
+  local cid = self.mobileSession1:SendRPC("SetGlobalProperties", { menuLayout = "TILES", menuTitle = "sickMenu" })
+  
+  EXPECT_HMICALL("UI.SetGlobalProperties", {})
+  :Do(function(_, data)
+    --util.printTable(data)
+    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+    self.mobileSession1:ExpectResponse(cid, {
+      success = true,
+      resultCode = "WARNINGS"
+    })
+  end)
+
+  local _addSubMenuParams = { menuLayout = "TILES",
+                              menuID = 44991234,
+                              menuName = "sickMenu"
+                            }
+
+  local cid2 = self.mobileSession1:SendRPC("AddSubMenu", _addSubMenuParams)
+  
+  EXPECT_HMICALL("UI.AddSubMenu", {})
+  :Do(function(_, data)
+    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+    self.mobileSession1:ExpectResponse(cid2, {
+      success = true,
+      resultCode = "WARNINGS"
+    })
+  end)
+end
+
+local function getHMIParams()
+  local params = hmi_values.getDefaultHMITable()
+  params.UI.GetCapabilities.params.displayCapabilities.menuLayoutsAvailable = { "LIST" }
+  return params
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", commonSmoke.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start, { getHMIParams() })
+runner.Step("RAI", commonSmoke.registerApp)
+runner.Step("Activate App", commonSmoke.activateApp)
+
+runner.Title("Test")
+runner.Step("Attempting to use unsupported menu layout TILES", setMenuLayoutTiles)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", commonSmoke.postconditions)

--- a/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
+++ b/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
@@ -29,33 +29,39 @@ local commonSmoke = require('test_scripts/Smoke/commonSmoke')
 local hmi_values = require('user_modules/hmi_values')
 
 --[[ Local Variables ]]
+local addSubMenuParams = { 
+  menuLayout = "TILES",
+  menuID = 44991234,
+  menuName = "sickMenu"
+}
+
+local setGlobalPropertiesParams = { 
+  menuLayout = "TILES", 
+  menuTitle = "sickMenu" 
+}
+
+local warningsResponse = {
+  success = true,
+  resultCode = "WARNINGS"
+}
+
+--[[ Local Functions ]]
 local function setMenuLayoutTiles(self)
-  local cid = self.mobileSession1:SendRPC("SetGlobalProperties", { menuLayout = "TILES", menuTitle = "sickMenu" })
+  local cid = self.mobileSession1:SendRPC("SetGlobalProperties", setGlobalPropertiesParams)
   
   EXPECT_HMICALL("UI.SetGlobalProperties", {})
   :Do(function(_, data)
     --util.printTable(data)
     self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    self.mobileSession1:ExpectResponse(cid, {
-      success = true,
-      resultCode = "WARNINGS"
-    })
+    self.mobileSession1:ExpectResponse(cid, warningsResponse)
   end)
 
-  local _addSubMenuParams = { menuLayout = "TILES",
-                              menuID = 44991234,
-                              menuName = "sickMenu"
-                            }
-
-  local cid2 = self.mobileSession1:SendRPC("AddSubMenu", _addSubMenuParams)
+  local cid2 = self.mobileSession1:SendRPC("AddSubMenu", addSubMenuParams)
   
   EXPECT_HMICALL("UI.AddSubMenu", {})
   :Do(function(_, data)
     self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    self.mobileSession1:ExpectResponse(cid2, {
-      success = true,
-      resultCode = "WARNINGS"
-    })
+    self.mobileSession1:ExpectResponse(cid2, warningsResponse)
   end)
 end
 

--- a/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
+++ b/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
@@ -51,7 +51,6 @@ local function setMenuLayoutTiles(self)
   
   EXPECT_HMICALL("UI.SetGlobalProperties", {})
   :Do(function(_, data)
-    --util.printTable(data)
     self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
     self.mobileSession1:ExpectResponse(cid, warningsResponse)
   end)

--- a/test_sets/smoke_tests.txt
+++ b/test_sets/smoke_tests.txt
@@ -46,6 +46,8 @@
 ./test_scripts/Smoke/API/046_NavApp_SubscribeButtonRequest_SUCCESS.lua
 ./test_scripts/Smoke/API/047_NonNavApp_SubscribeButtonRequest_REJECTED.lua
 ./test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
+./test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
+./test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
 ./test_scripts/API/CloseApplication/001_Success_flow.lua
 ./test_scripts/Smoke/HeartBeat/001_HeartBeat_App_does_not_send_HB_and_does_not_respond.lua
 ./test_scripts/Smoke/HeartBeat/002_HeartBeat_App_does_not_send_HB_but_respond.lua


### PR DESCRIPTION
ATF Test Scripts to check [#2925](https://github.com/smartdevicelink/sdl_core/issues/2925)

This PR is **ready** for review.

### Summary
Add the ability to request a tiled menu through SetGlobalProperties or AddSubMenu RPCs.

### ATF version
develop

### Changelog

##### Enhancements
* Adds new parameter menuLayout to SetGlobalProperties RPC.
* Adds new parameter menuLayout to AddSubMenu RPC.
* Adds new parameter menuLayoutsAvailable to HMI Capabilities

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
