### PR TITLE
Update for RC script with cutting of redundant gpsData from stationLocation

### DIFF
--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/016_RADIO_GPSdata_in_HMI_response.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/016_RADIO_GPSdata_in_HMI_response.lua
@@ -87,7 +87,14 @@ local function getRadioParams(pStationLocationParams)
 end
 
 local function getDataForModule(pStationLocationParams, isSuccess)
-  local radioParams = getRadioParams(pStationLocationParams)
+  local radioParamsHMIRes = getRadioParams(pStationLocationParams)
+  local dataForMobileRes = common.cloneTable(pStationLocationParams)
+  for key in pairs (dataForMobileRes) do
+    if key ~= "longitudeDegrees" and key ~= "latitudeDegrees" and key ~= "altitude" then
+      dataForMobileRes[key] = nil
+    end
+  end
+  local radioParamsMobileRes = getRadioParams(dataForMobileRes)
   local mobileSession = common.getMobileSession()
   local cid = mobileSession:SendRPC("GetInteriorVehicleData", {
       moduleType = moduleName
@@ -97,10 +104,10 @@ local function getDataForModule(pStationLocationParams, isSuccess)
       moduleType = moduleName
     })
   :Do(function(_, data)
-      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { moduleData = radioParams })
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { moduleData = radioParamsHMIRes })
     end)
   if isSuccess == true then
-    mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", moduleData = radioParams })
+    mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", moduleData = radioParamsMobileRes })
   else
     mobileSession:ExpectResponse(cid, { success = false, resultCode = "GENERIC_ERROR", info = "Invalid message received from vehicle" })
   end


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2216

This PR is **[ready]** for review.

### Summary
Update for existing RC script with cutting of redundant `gpsData` from `stationLocation` according to changes in requirements within [[SDL 0199]-Adding-GPS-Shift-support](https://github.com/smartdevicelink/sdl_core/issues/2639) feature

### ATF version
https://github.com/smartdevicelink/sdl_atf/tree/develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
