### PR TITLE
Add 'lock_screen_dismissal_enabled' to the list of available data in PTS

### DIFF
--- a/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
+++ b/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
@@ -138,6 +138,7 @@ function testCasesForPolicyTableSnapshot:verify_PTS(is_created, app_IDs, device_
     { name = "module_config.vehicle_year", elem_required = "optional"},
     { name = "module_config.display_order", elem_required = "optional"},
     { name = "module_config.full_app_id_supported", elem_required = "required"},
+    { name = "module_config.lock_screen_dismissal_enabled", elem_required = "optional"},
 
     { name = "consumer_friendly_messages.version", elem_required = "required"},
 
@@ -178,7 +179,6 @@ function testCasesForPolicyTableSnapshot:verify_PTS(is_created, app_IDs, device_
     { name = "app_policies.pre_consent_passengersRC.priority", elem_required = "optional"},
     { name = "app_policies.pre_consent_passengersRC.groups.1", elem_required = "optional"},
     { name = "app_policies.pre_consent_passengersRC.AppHMIType.1", elem_required = "optional"},
-    { name = "module_config.lock_screen_dismissal_enabled", elem_required = "optional"},
     -- custom vehicle_data
     { name = "module_config.endpoint_properties.custom_vehicle_data_mapping_url.version", elem_required = "optional"},
     { name = "vehicle_data.schema_version", elem_required = "optional"}

--- a/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
+++ b/user_modules/shared_testcases/testCasesForPolicyTableSnapshot.lua
@@ -178,6 +178,7 @@ function testCasesForPolicyTableSnapshot:verify_PTS(is_created, app_IDs, device_
     { name = "app_policies.pre_consent_passengersRC.priority", elem_required = "optional"},
     { name = "app_policies.pre_consent_passengersRC.groups.1", elem_required = "optional"},
     { name = "app_policies.pre_consent_passengersRC.AppHMIType.1", elem_required = "optional"},
+    { name = "module_config.lock_screen_dismissal_enabled", elem_required = "optional"},
     -- custom vehicle_data
     { name = "module_config.endpoint_properties.custom_vehicle_data_mapping_url.version", elem_required = "optional"},
     { name = "vehicle_data.schema_version", elem_required = "optional"}


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2215

This PR is **[ready]** for review.

### Summary
Update for Policies scripts which verifies Policy Table Snapshot data consistency.


### ATF version
https://github.com/smartdevicelink/sdl_atf/tree/develop

### Changelog
New `lock_screen_dismissal_enabled` is added to `verify_PTS()` function

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
