### PR TITLE
Read Generic Network Signal data feature scripts update according new revision

### DIFF
--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/007_Applying_PTU_with_updated_VDitems.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/007_Applying_PTU_with_updated_VDitems.lua
@@ -297,7 +297,7 @@ runner.Step("PTU with updated VehicleDataItems", ptu)
 runner.Title("Test")
 for _, vehicleDataItem in pairs(anotherCustomDataType) do
   runner.Step("SubscribeVehicleData " .. vehicleDataItem.name, common.VDsubscription,
-    { appSessionId, vehicleDataItem.name, "SubscribeVehicleData" })
+    { appSessionId, vehicleDataItem.name, "SubscribeVehicleData", vehicleDataItem})
   runner.Step("OnVehicleData " .. vehicleDataItem.name, common.onVD,
     { appSessionId, vehicleDataItem.name })
   runner.Step("GetVehicleData " .. vehicleDataItem.name, common.GetVD,

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/008_SubscribeVehicleData_cache_with_VDitems_one_app.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/008_SubscribeVehicleData_cache_with_VDitems_one_app.lua
@@ -53,7 +53,7 @@ local function processingVD()
     [common.VehicleDataItemsWithData.custom_vd_item2_float.key] = true
   }
 
-  local VDItemResponse = { dataType = "OEM_SPECIFIC", resultCode = "SUCCESS" }
+  local VDItemResponse = { dataType = common.CUSTOM_DATA_TYPE, resultCode = "SUCCESS" }
   local gpsResponse = { dataType = common.VehicleDataItemsWithData.gps.APItype, resultCode = "SUCCESS" }
 
   local hmiResponseData = {
@@ -61,10 +61,13 @@ local function processingVD()
     gps = gpsResponse
   }
 
+  local floatItem = common.VehicleDataItemsWithData.custom_vd_item2_float
+  local integerItem = common.VehicleDataItemsWithData.custom_vd_item1_integer
   local MobResp = {
     gps = gpsResponse,
-    [common.VehicleDataItemsWithData.custom_vd_item2_float.name] = VDItemResponse,
-    [common.VehicleDataItemsWithData.custom_vd_item1_integer.name] = { dataType = "OEM_SPECIFIC", resultCode = "DATA_ALREADY_SUBSCRIBED" }
+    [floatItem.name] = common.buildSubscribeMobileResponseItem(VDItemResponse, floatItem.name),
+    [integerItem.name] = common.buildSubscribeMobileResponseItem(
+        { dataType = common.CUSTOM_DATA_TYPE, resultCode = "DATA_ALREADY_SUBSCRIBED" }, integerItem.name)
   }
 
   local cid = common.getMobileSession():SendRPC("SubscribeVehicleData", mobRequestData)

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/009_UnsubscribeVehicleData_cache_with_VDitems_one_app.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/009_UnsubscribeVehicleData_cache_with_VDitems_one_app.lua
@@ -54,7 +54,7 @@ local function processingVD()
     [common.VehicleDataItemsWithData.custom_vd_item2_float.key] = true
   }
 
-  local VDItemResponse = { dataType = "OEM_SPECIFIC", resultCode = "SUCCESS" }
+  local VDItemResponse = { dataType = common.CUSTOM_DATA_TYPE, resultCode = "SUCCESS" }
   local gpsResponse = { dataType = common.VehicleDataItemsWithData.gps.APItype, resultCode = "SUCCESS" }
 
   local hmiResponseData = {
@@ -62,10 +62,13 @@ local function processingVD()
     gps = gpsResponse
   }
 
+  local floatItem = common.VehicleDataItemsWithData.custom_vd_item2_float
+  local integerItem = common.VehicleDataItemsWithData.custom_vd_item1_integer
   local MobResp = {
     gps = gpsResponse,
-    [common.VehicleDataItemsWithData.custom_vd_item2_float.name] = VDItemResponse,
-    [common.VehicleDataItemsWithData.custom_vd_item1_integer.name] = { dataType = "OEM_SPECIFIC", resultCode = "DATA_NOT_SUBSCRIBED" }
+    [floatItem.name] = common.buildSubscribeMobileResponseItem(VDItemResponse, floatItem.name),
+    [integerItem.name] = common.buildSubscribeMobileResponseItem(
+        { dataType = common.CUSTOM_DATA_TYPE, resultCode = "DATA_NOT_SUBSCRIBED" }, integerItem.name)
   }
 
   local cid = common.getMobileSession():SendRPC("UnsubscribeVehicleData", mobRequestData)

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/010_Subscription_resumption_for_VDitems_unexpected_disconnect.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/010_Subscription_resumption_for_VDitems_unexpected_disconnect.lua
@@ -50,7 +50,7 @@ local function registerApp()
 
       local hmiResponseData = {
         [common.VehicleDataItemsWithData.custom_vd_item1_integer.key] = {
-          dataType = "OEM_SPECIFIC", resultCode = "SUCCESS"
+          dataType = common.CUSTOM_DATA_TYPE, resultCode = "SUCCESS"
         },
         gps = { dataType = common.VehicleDataItemsWithData.gps.APItype, resultCode = "SUCCESS" }
       }

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/011_Subscription_resumption_for_VDitems_ign_off.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/011_Subscription_resumption_for_VDitems_ign_off.lua
@@ -50,7 +50,7 @@ local function registerApp()
 
       local hmiResponseData = {
         [common.VehicleDataItemsWithData.custom_vd_item1_integer.key] = {
-          dataType = "OEM_SPECIFIC", resultCode = "SUCCESS"
+          dataType = common.CUSTOM_DATA_TYPE, resultCode = "SUCCESS"
         },
         gps = { dataType = common.VehicleDataItemsWithData.gps.APItype, resultCode = "SUCCESS" }
       }

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/029_SubscribeVehicleData_cache_with_VDitems_for_different_data_two_apps.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/029_SubscribeVehicleData_cache_with_VDitems_for_different_data_two_apps.lua
@@ -51,13 +51,16 @@ local function processingVDSubscription()
   }
   local hmiResponseData = {
     [common.VehicleDataItemsWithData.custom_vd_item2_float.key] = {
-      dataType = "OEM_SPECIFIC",
+      dataType = common.CUSTOM_DATA_TYPE,
       resultCode = "SUCCESS"
     }
   }
+
+  local floatItem = common.VehicleDataItemsWithData.custom_vd_item2_float
+  local integerItem = common.VehicleDataItemsWithData.custom_vd_item1_integer
   local mobileResponseData = {
-    [common.VehicleDataItemsWithData.custom_vd_item1_integer.name] = hmiResponseData[common.VehicleDataItemsWithData.custom_vd_item2_float.key],
-    [common.VehicleDataItemsWithData.custom_vd_item2_float.name] = hmiResponseData[common.VehicleDataItemsWithData.custom_vd_item2_float.key]
+    [integerItem.name] = common.buildSubscribeMobileResponseItem(hmiResponseData[floatItem.key], integerItem.name),
+    [floatItem.name] = common.buildSubscribeMobileResponseItem(hmiResponseData[floatItem.key], floatItem.name)
   }
 
   local cid = common.getMobileSession(appSessionIdForApp2):SendRPC("SubscribeVehicleData", mobRequestData)

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/031_UnsubscribeVehicleData_cache_with_VDitems_for_different_data_two_apps.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/031_UnsubscribeVehicleData_cache_with_VDitems_for_different_data_two_apps.lua
@@ -61,14 +61,16 @@ local function processingVDunsubscribeWithSeveralData()
 
   local hmiResponseData = {
     [common.VehicleDataItemsWithData.custom_vd_item2_float.key] = {
-      dataType = "OEM_SPECIFIC",
+      dataType = common.CUSTOM_DATA_TYPE,
       resultCode = "SUCCESS"
     }
   }
 
+  local floatItem = common.VehicleDataItemsWithData.custom_vd_item2_float
+  local integerItem = common.VehicleDataItemsWithData.custom_vd_item1_integer
   local mobileResponseData = {
-    [common.VehicleDataItemsWithData.custom_vd_item1_integer.name] = hmiResponseData[common.VehicleDataItemsWithData.custom_vd_item2_float.key],
-    [common.VehicleDataItemsWithData.custom_vd_item2_float.name] = hmiResponseData[common.VehicleDataItemsWithData.custom_vd_item2_float.key]
+    [integerItem.name] = common.buildSubscribeMobileResponseItem(hmiResponseData[floatItem.key], integerItem.name),
+    [floatItem.name] = common.buildSubscribeMobileResponseItem(hmiResponseData[floatItem.key], floatItem.name)
   }
 
   local cid = common.getMobileSession(appSessionIdForApp1):SendRPC("UnsubscribeVehicleData", mobRequestData)

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/032_Subscription_resumption_for_VDitems_2_apps_unexpected_disconnect.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/032_Subscription_resumption_for_VDitems_2_apps_unexpected_disconnect.lua
@@ -87,12 +87,14 @@ local function registerApps()
   }
 
   local hmiResponseDataApp1 = {
-    [common.VehicleDataItemsWithData.custom_vd_item1_integer.key] = { dataType = "OEM_SPECIFIC", resultCode = "SUCCESS" },
+    [common.VehicleDataItemsWithData.custom_vd_item1_integer.key] =
+        { dataType = common.CUSTOM_DATA_TYPE, resultCode = "SUCCESS" },
     gps = { dataType = common.VehicleDataItemsWithData.gps.APItype, resultCode = "SUCCESS" }
   }
 
   local hmiResponseDataApp2 = {
-    [common.VehicleDataItemsWithData.custom_vd_item2_float.key] = { dataType = "OEM_SPECIFIC", resultCode = "SUCCESS" },
+    [common.VehicleDataItemsWithData.custom_vd_item2_float.key] =
+        { dataType = common.CUSTOM_DATA_TYPE, resultCode = "SUCCESS" },
     rpm = { dataType = common.VehicleDataItemsWithData.rpm.APItype, resultCode = "SUCCESS" }
   }
 

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/033_Subscription_resumption_for_VDitems_2_apps_ign_off.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/033_Subscription_resumption_for_VDitems_2_apps_ign_off.lua
@@ -87,12 +87,14 @@ local function registerApps()
   }
 
   local hmiResponseDataApp1 = {
-    [common.VehicleDataItemsWithData.custom_vd_item1_integer.key] = { dataType = "OEM_SPECIFIC", resultCode = "SUCCESS" },
+    [common.VehicleDataItemsWithData.custom_vd_item1_integer.key] =
+        { dataType = common.CUSTOM_DATA_TYPE, resultCode = "SUCCESS" },
     gps = { dataType = common.VehicleDataItemsWithData.gps.APItype, resultCode = "SUCCESS" }
   }
 
   local hmiResponseDataApp2 = {
-    [common.VehicleDataItemsWithData.custom_vd_item2_float.key] = { dataType = "OEM_SPECIFIC", resultCode = "SUCCESS" },
+    [common.VehicleDataItemsWithData.custom_vd_item2_float.key] =
+        { dataType = common.CUSTOM_DATA_TYPE, resultCode = "SUCCESS" },
     rpm = { dataType = common.VehicleDataItemsWithData.rpm.APItype, resultCode = "SUCCESS" }
   }
 

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/040_Get_Subscribe_Unsubscribe_request_data_not_match_to_response_data.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/040_Get_Subscribe_Unsubscribe_request_data_not_match_to_response_data.lua
@@ -84,7 +84,7 @@ local function subscriptionVDNotMatch(pRPC, pData)
   end
   local hmiResponseData = {
     [common.VehicleDataItemsWithData.custom_vd_item2_float.key] = {
-      dataType = "OEM_SPECIFIC",
+      dataType = common.CUSTOM_DATA_TYPE,
       resultCode = "SUCCESS"
     }
   }
@@ -109,7 +109,7 @@ local function subscriptionVDWithRedundant(pRPC, pData)
     hmiRequestData = common.getHMIrequestData(pData)
   end
   local vdResponseStruct = {
-      dataType = "OEM_SPECIFIC",
+      dataType = common.CUSTOM_DATA_TYPE,
       resultCode = "SUCCESS"
     }
   local hmiResponseData = {
@@ -123,7 +123,8 @@ local function subscriptionVDWithRedundant(pRPC, pData)
     common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", hmiResponseData)
   end)
 
-  local mobileResponseData = { [pData] = vdResponseStruct }
+  local item = common.VehicleDataItemsWithData[pData]
+  local mobileResponseData = { [item.name] = common.buildSubscribeMobileResponseItem(vdResponseStruct, item.name) }
   mobileResponseData.success = true
   mobileResponseData.resultCode = "SUCCESS"
   common.getMobileSession():ExpectResponse(cid, mobileResponseData)

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/051_VD_request_with_false_value.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/051_VD_request_with_false_value.lua
@@ -53,14 +53,14 @@ local function VDsubscription(pRPC)
       resultCode = "SUCCESS"
     },
     [floatItem.key] = {
-      dataType = "OEM_SPECIFIC",
+      dataType = common.CUSTOM_DATA_TYPE,
       resultCode = "SUCCESS"
     }
   }
 
   local mobileResponseData = {
     [speedItem.name] = hmiResponseData[speedItem.name],
-    [floatItem.name] = hmiResponseData[floatItem.key]
+    [floatItem.name] = common.buildSubscribeMobileResponseItem(hmiResponseData[floatItem.key], floatItem.name)
   }
 
   local cid = common.getMobileSession():SendRPC(pRPC, mobRequestData)


### PR DESCRIPTION
### Summary
Update of scripts for feature "Read Generic Network Signal data" according new revision of proposal [Read Generic Network Signal Data Clarification](https://github.com/smartdevicelink/sdl_evolution/pull/802)

### Changelog
 - Scripts were updated with adding with non mandatory parameter `oemCustomDataType`  into `VehicleDataResult` structure

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
