### PR TITLE
Make scripts for proprietary data exchange stable

### DIFF
--- a/test_scripts/API/Expanded_proprietary_data_exchange/commonDataExchange.lua
+++ b/test_scripts/API/Expanded_proprietary_data_exchange/commonDataExchange.lua
@@ -95,7 +95,6 @@ function m.policyTableUpdate(pPTUpdateFunc, pExpNotificationFunc, pRequestSubTyp
     pExpNotificationFunc()
   else
     m.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { odometer = true })
-    m.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", { status = "UP_TO_DATE" })
   end
   local ptsFileName = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath") .. "/"
     .. commonFunctions:read_parameter_from_smart_device_link_ini("PathToSnapshot")


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
There is some instability in scripts for Proprietary data exchange feature
Current PR fix this 

### ATF version
develop

### Changelog
Remove expectation on `OnStatusUpdate` notification. 
In `develop` branch such expectation doesn't exist
So current PR is just use develop version of `policyTableUpdate()` function

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
