### PR TITLE
[Read generic network signal data] Extension of test coverage

### DIFF
--- a/test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua
+++ b/test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua
@@ -1,0 +1,121 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal:
+--  https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0173-Read-Generic-Network-Signal-data.md
+--
+-- Description: GetPolicyConfigurationData processing with all correct parameters
+
+-- Precondition:
+-- 1. SDL and HMI started
+
+-- Sequence:
+-- 1. HMI requests valid SDL.GetPolicyConfigurationData
+--  a. SDL responds to SDL.GetPolicyConfigurationData with appropriate data
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('/test_scripts/API/GetPolicyConfigurationData/commonGetPolicyConfigurationData')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local CHECK_TYPES = { PRIMITIVE = 1, OBJECT = 2, ARRAY_OF_PRIMITIVES = 3, ARRAY_OF_OBJECTS = 4 }
+
+local function validation(pActualData, pPolicyType, pProperty, pCheckType)
+  local msg = tostring(pPolicyType) .. "." .. tostring(pProperty) .. " from GetPolicyConfigurationData response"
+  local policyTable = common.getPreloadedTable()
+  local expectedData = policyTable.policy_table[pPolicyType][pProperty]
+  local actualData = pActualData.result.value
+
+  if pCheckType == CHECK_TYPES.PRIMITIVE then
+    expectedData = { tostring(expectedData) }
+  elseif pCheckType == CHECK_TYPES.OBJECT then
+    actualData = common.decode(actualData[1])
+  elseif pCheckType == CHECK_TYPES.ARRAY_OF_PRIMITIVES then
+    local array = {}
+    for _, item in pairs(expectedData) do
+      table.insert(array, tostring(item))
+    end
+    expectedData = array
+  elseif pCheckType == CHECK_TYPES.ARRAY_OF_OBJECTS then
+    local array = {}
+    for _, jsonStr in pairs(actualData) do
+      local jsonTbl = common.decode(jsonStr)
+      table.insert(array, jsonTbl)
+    end
+    actualData = array
+  end
+
+  if true ~= common:is_table_equal(actualData, expectedData) then
+      return false, msg .. " contains unexpected parameters.\n" ..
+      "Expected table: " .. common.tableToString(expectedData) .. "\n" ..
+      "Actual table: " .. common.tableToString(actualData) .. "\n"
+  end
+  return true
+end
+
+local dataReqRes = {
+  number = {
+    request = { policyType = "module_config", property = "timeout_after_x_seconds" },
+    response = { result = { code = 0 } },
+    validIf = function(data)
+      return validation(data, "module_config", "timeout_after_x_seconds", CHECK_TYPES.PRIMITIVE)
+    end
+  },
+  string = {
+    request = { policyType = "consumer_friendly_messages", property = "version" },
+    response = { result = { code = 0 } },
+    validIf = function(data)
+    return validation(data, "consumer_friendly_messages", "version", CHECK_TYPES.PRIMITIVE)
+    end
+  },
+  boolean = {
+    request = { policyType = "module_config", property = "lock_screen_dismissal_enabled" },
+    response = { result = { code = 0 } },
+    validIf = function(data)
+    return validation(data, "module_config", "lock_screen_dismissal_enabled", CHECK_TYPES.PRIMITIVE)
+    end
+  },
+  object = {
+    request = { policyType = "module_config", property = "endpoints" },
+    response = { result = { code = 0 } },
+    validIf = function(data)
+    return validation(data, "module_config", "endpoints", CHECK_TYPES.OBJECT)
+    end
+  },
+  hugeJson = {
+    request = { policyType = "consumer_friendly_messages", property = "messages" },
+    response = { result = { code = 0 } },
+    validIf = function(data)
+    return validation(data, "consumer_friendly_messages", "messages", CHECK_TYPES.OBJECT)
+    end
+  },
+  arrayOfNumbers = {
+    request = { policyType = "module_config", property = "seconds_between_retries" },
+    response = { result = { code = 0 } },
+    validIf = function(data)
+      return validation(data, "module_config", "seconds_between_retries", CHECK_TYPES.ARRAY_OF_PRIMITIVES)
+    end
+  },
+  arrayOfObjects = {
+    request = { policyType = "vehicle_data", property = "schema_items" },
+    response = { result = { code = 0 } },
+    validIf = function(data)
+      return validation(data, "vehicle_data", "schema_items", CHECK_TYPES.ARRAY_OF_OBJECTS)
+    end
+  }
+}
+
+
+-- [[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+
+runner.Title("Test")
+for caseName, testData in pairs(dataReqRes) do
+  runner.Step("GetPolicyConfigurationData " .. caseName, common.GetPolicyConfigurationData, { testData })
+end
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/GetPolicyConfigurationData/002_GetPolicyConfigurationData_incorrect_params.lua
+++ b/test_scripts/API/GetPolicyConfigurationData/002_GetPolicyConfigurationData_incorrect_params.lua
@@ -1,0 +1,54 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal:
+--  https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0173-Read-Generic-Network-Signal-data.md
+--
+-- Description: GetPolicyConfigurationData processing with incorrect parameters
+
+-- Precondition:
+-- 1. SDL and HMI started
+
+-- Sequence:
+-- 1. HMI requests valid SDL.GetPolicyConfigurationData with undefined value in policyType or property
+--  a. SDL responds to SDL.GetPolicyConfigurationData with resultCode DATA_NOT_AVAILABLE
+-- 2. HMI requests invalid SDL.GetPolicyConfigurationData with incorrect value in policyType or property
+--  a. SDL responds to SDL.GetPolicyConfigurationData with resultCode INVALID_DATA
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('/test_scripts/API/GetPolicyConfigurationData/commonGetPolicyConfigurationData')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local dataReqRes = {
+  undefinedPolicyType =  {
+    request = { policyType = "undefinedKey", property = "endpoints" },
+    response = { error = { code = 9 } } -- DATA_NOT_AVAILABLE
+  },
+  undefinedProperty =  {
+    request = { policyType = "module_config", property = "undefinedKey" },
+    response = { error = { code = 9 } } -- DATA_NOT_AVAILABLE
+  },
+  incorrectTypePolicyType =  {
+    request = { policyType = true, property = "endpoints" },
+    response = { error = { code = 11 } } -- INVALID_DATA
+  },
+  incorrectTypeProperty =  {
+    request = { policyType = "module_config", property = 5 },
+    response = { error = { code = 11 } } -- INVALID_DATA
+  }
+}
+
+-- [[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+
+runner.Title("Test")
+for caseName, testData in pairs(dataReqRes) do
+  runner.Step("GetPolicyConfigurationData " .. caseName, common.GetPolicyConfigurationData, { testData })
+end
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/GetPolicyConfigurationData/commonGetPolicyConfigurationData.lua
+++ b/test_scripts/API/GetPolicyConfigurationData/commonGetPolicyConfigurationData.lua
@@ -1,0 +1,50 @@
+---------------------------------------------------------------------------------------------------
+-- GetPolicyConfigurationData common module
+---------------------------------------------------------------------------------------------------
+--[[ General configuration parameters ]]
+config.defaultProtocolVersion = 2
+config.ValidateSchema = false
+
+--[[ Required Shared libraries ]]
+local actions = require("user_modules/sequences/actions")
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
+local json = require("modules/json")
+local utils = require('user_modules/utils')
+
+--[[ Local Variables ]]
+local common = {}
+common.start = actions.start
+common.getHMIConnection = actions.getHMIConnection
+common.preconditions = actions.preconditions
+common.postconditions = actions.postconditions
+common.decode = json.decode
+common.is_table_equal = commonFunctions.is_table_equal
+common.GetPathToSDL = commonPreconditions.GetPathToSDL
+common.read_parameter_from_smart_device_link_ini = commonFunctions.read_parameter_from_smart_device_link_ini
+common.jsonFileToTable = utils.jsonFileToTable
+common.tableToString = utils.tableToString
+
+local preloadedTable = nil
+
+function common.getPreloadedTable()
+  if not preloadedTable then
+    local preloadedFile = common:GetPathToSDL()
+      .. common:read_parameter_from_smart_device_link_ini("PreloadedPT")
+    preloadedTable = common.jsonFileToTable(preloadedFile)
+  end
+  return preloadedTable
+end
+
+function common.GetPolicyConfigurationData(pData)
+  local requestId = common.getHMIConnection():SendRequest("SDL.GetPolicyConfigurationData",pData.request)
+  common.getHMIConnection():ExpectResponse(requestId, pData.response)
+  :ValidIf(function(_, data)
+    if pData.validIf then
+      return pData.validIf(data)
+    end
+    return true
+    end)
+end
+
+return common

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/054_GetPolicyConfigurationData_processing.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/054_GetPolicyConfigurationData_processing.lua
@@ -36,7 +36,11 @@ local dataReqRes = {
     request = { policyType = "module_config", property = "seconds_between_retries" },
     response = { result = { code = 0 } },
     validIf = function(data)
-      return common.validation(data.result.value, preloadedTable.policy_table.module_config.seconds_between_retries,
+      local expectedData = {}
+      for _, item in ipairs(preloadedTable.policy_table.module_config.seconds_between_retries) do
+        table.insert(expectedData, tostring(item))
+      end
+      return common.validation(data.result.value, expectedData,
         "seconds_between_retries from GetPolicyConfigurationData response ")
     end
 },
@@ -56,7 +60,7 @@ local function GetPolicyConfigurationData(pData)
   common.getHMIConnection():ExpectResponse(requestId, pData.response)
   :ValidIf(function(_, data)
     if pData.validIf then
-      pData.validIf(data)
+      return pData.validIf(data)
     end
     return true
     end)

--- a/test_sets/get_policy_configuration_data.txt
+++ b/test_sets/get_policy_configuration_data.txt
@@ -1,0 +1,2 @@
+./test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua
+;./test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua 2983

--- a/test_sets/smoke_tests.txt
+++ b/test_sets/smoke_tests.txt
@@ -47,6 +47,7 @@
 ./test_scripts/Smoke/API/047_NonNavApp_SubscribeButtonRequest_REJECTED.lua
 ./test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
 ./test_scripts/Smoke/API/049_GetPolicyConfigurationData_SUCCESS.lua
+./test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua
 ./test_scripts/API/CloseApplication/001_Success_flow.lua
 ./test_scripts/Smoke/HeartBeat/001_HeartBeat_App_does_not_send_HB_and_does_not_respond.lua
 ./test_scripts/Smoke/HeartBeat/002_HeartBeat_App_does_not_send_HB_but_respond.lua


### PR DESCRIPTION
### Summary
Extension of test coverage for feature "Read Generic Network Signal data" 

### Changelog
 - There is fixed test script "054_GetPolicyConfigurationData_processing.lua"
 - There are created test scripts to check new GetPolicyConfigurationData RPC 

### CLA
- [X ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)

