### PR TITLE
Improve app activation speed

### DIFF
--- a/user_modules/sequences/actions.lua
+++ b/user_modules/sequences/actions.lua
@@ -571,16 +571,8 @@ function m.app.activate(pAppId)
   if not pAppId then pAppId = 1 end
   local requestId = m.hmi.getConnection():SendRequest("SDL.ActivateApp", { appID = m.app.getHMIId(pAppId) })
   m.hmi.getConnection():ExpectResponse(requestId)
-  local params = m.app.getParams(pAppId)
-  local audioStreamingState = "NOT_AUDIBLE"
-  if params.isMediaApplication or
-      utils.isTableContains(params.appHMIType, "NAVIGATION") or
-      utils.isTableContains(params.appHMIType, "COMMUNICATION") then
-    audioStreamingState = "AUDIBLE"
-  end
-  m.mobile.getSession(pAppId):ExpectNotification("OnHMIStatus",
-    { hmiLevel = "FULL", audioStreamingState = audioStreamingState, systemContext = "MAIN" })
-  m.run.wait()
+  m.mobile.getSession(pAppId):ExpectNotification("OnHMIStatus", { hmiLevel = "FULL", systemContext = "MAIN" })
+  if m.mobile.getAppsCount() > 1 then m.run.wait(500) end
 end
 
 --[[ @app.unRegister: perform unregistration of application sequence


### PR DESCRIPTION
Fixed issue [#2231](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2231)

This PR is **[ready]** for review.

### Summary
Improve app activation speed

### ATF version
develop

### Changelog

##### Enhancements
* Activation speed is improved significantly in case of single app
In case of a few apps delay is reduced to 500ms

##### Bug Fixes
* Removed expectation on `audioStreamingState`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
