### PR TITLE
Rework VehicleData scripts

### DIFF
--- a/test_scripts/API/VehicleData/GetVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/001_Success_flow.lua
@@ -16,23 +16,20 @@
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
-local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
-local actions = require("user_modules/sequences/actions")
 
 --[[ Local Functions ]]
-local function processGetVehicleDataSuccess(pData, self)
-  local mobileSession = common.getMobileSession(self, 1)
+local function processRPCSuccess(pData)
   local reqParams = {
     [pData] = true
   }
   local hmiResParams = {
     [pData] = common.allVehicleData[pData].value
   }
-  local cid = mobileSession:SendRPC("GetVehicleData", reqParams)
-  EXPECT_HMICALL("VehicleInfo.GetVehicleData", reqParams)
+  local cid = common.getMobileSession():SendRPC("GetVehicleData", reqParams)
+  common.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", reqParams)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", hmiResParams )
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", hmiResParams)
     end)
   local mobResParams = common.cloneTable(hmiResParams)
   if mobResParams.emergencyEvent then
@@ -40,23 +37,23 @@ local function processGetVehicleDataSuccess(pData, self)
   end
   mobResParams.success = true
   mobResParams.resultCode = "SUCCESS"
-  mobileSession:ExpectResponse(cid, mobResParams)
+  common.getMobileSession():ExpectResponse(cid, mobResParams)
 end
 
 --[[ Scenario ]]
-runner.Title("Preconditions")
-runner.Step("Clean environment", common.preconditions)
-runner.Step("`100, 1` in GetVehicleDataRequest in ini file", actions.setSDLIniParameter,
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("`100, 1` in GetVehicleDataRequest in ini file", common.setSDLIniParameter,
   { "GetVehicleDataRequest", "100, 1" })
-runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
-runner.Step("Activate App", common.activateApp)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App", common.activateApp)
 
-runner.Title("Test")
+common.Title("Test")
 for vehicleDataName in pairs(common.allVehicleData) do
-  runner.Step("RPC GetVehicleData " .. vehicleDataName, processGetVehicleDataSuccess,{ vehicleDataName })
+  common.Step("RPC GetVehicleData " .. vehicleDataName, processRPCSuccess, { vehicleDataName })
 end
 
-runner.Title("Postconditions")
-runner.Step("restore ini file", actions.restoreSDLIniParameters)
-runner.Step("Stop SDL", common.postconditions)
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
@@ -16,9 +16,7 @@
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
-local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
-local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 
 --[[ Local Variables ]]
 local rpc = {
@@ -32,76 +30,23 @@ local rpc = {
   }
 }
 
-local vehicleDataValues = {
-  engineOilLife = 52.3,
-  fuelRange = {
-    {
-      type = "GASOLINE",
-      range = 400.00
-    }
-  },
-  tirePressure = {
-    leftFront = {
-      status = "NORMAL",
-      tpms = "SYSTEM_ACTIVE",
-      pressure = 35.00
-    },
-    rightFront = {
-      status = "NORMAL",
-      tpms = "SYSTEM_ACTIVE",
-      pressure = 35.00
-    }
-  },
-  electronicParkBrakeStatus = "CLOSED",
-  turnSignal = "OFF"
-}
-
 --[[ Local Functions ]]
-local function ptu_update_func(tbl)
-  local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["GetVehicleData"].parameters
-  local newParams = {}
-  for index, value in pairs(params) do
-    if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
-  end
-  tbl.policy_table.functional_groupings["Emergency-1"].rpcs["GetVehicleData"].parameters = newParams
-
-  params = tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["GetVehicleData"].parameters
-  newParams = {}
-  for index, value in pairs(params) do
-    if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
-  end
-  tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["GetVehicleData"].parameters = newParams
-end
-
-local function processRPCSuccess(self)
-  local mobileSession = common.getMobileSession(self, 1)
-  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
-  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params)
-  :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", vehicleDataValues)
-    end)
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
-end
-
-local function processRPCFailure(self)
-  local mobileSession = common.getMobileSession(self, 1)
-  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
-  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
-  commonTestCases:DelayedExp(common.timeout)
-  mobileSession:ExpectResponse(cid, { success = false, resultCode = "DISALLOWED" })
+local function processRPCFailure()
+  local cid = common.getMobileSession():SendRPC(rpc.name, rpc.params)
+  common.getHMIConnection():ExpectRequest("VehicleInfo." .. rpc.name, rpc.params):Times(0)
+  common.getMobileSession():ExpectResponse(cid, { success = false, resultCode = "DISALLOWED" })
 end
 
 --[[ Scenario ]]
-runner.Title("Preconditions")
-runner.Step("Clean environment", common.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
-runner.Step("Activate App", common.activateApp)
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdateMin })
+common.Step("Activate App", common.activateApp)
 
-runner.Title("Test")
-runner.Step("RPC " .. rpc.name .. " 1st time" , processRPCSuccess)
-runner.Step("RAI 2nd app with PTU", common.registerAppWithPTU, {2, ptu_update_func})
-runner.Step("RPC " .. rpc.name .. " 2nd time", processRPCFailure)
+common.Title("Test")
+common.Step("RPC " .. rpc.name .. " DISALLOWED", processRPCFailure)
 
-runner.Title("Postconditions")
-runner.Step("Stop SDL", common.postconditions)
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/OnVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/001_Success_flow.lua
@@ -28,7 +28,8 @@ common.allVehicleData.vin = nil
 runner.Title("Preconditions")
 runner.Step("Clean environment", common.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdate })
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/API/VehicleData/OnVehicleData/002_NotificationForUnsubsribedParameter_Ignored_flow.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/002_NotificationForUnsubsribedParameter_Ignored_flow.lua
@@ -30,7 +30,8 @@ common.allVehicleData.vin = nil
 runner.Title("Preconditions")
 runner.Step("Clean environment", common.preconditions)
 runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdate })
 runner.Step("Activate App", common.activateApp)
 
 runner.Title("Test")

--- a/test_scripts/API/VehicleData/OnVehicleData/004_OnVD_gps_mandatory_parameters.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/004_OnVD_gps_mandatory_parameters.lua
@@ -18,7 +18,6 @@
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
-local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
 
 --[[ Local Variables ]]
@@ -70,46 +69,45 @@ local vehicleDataValuesMissedMandatory = {
 }
 
 --[[ Local Functions ]]
-local function processRPCSubscribeSuccess(self)
-  local mobileSession = common.getMobileSession(self, 1)
-  local cid = mobileSession:SendRPC(rpc1.name, rpc1.params)
-  EXPECT_HMICALL("VehicleInfo." .. rpc1.name, rpc1.params)
+local function processRPCSubscribeSuccess()
+  local cid = common.getMobileSession():SendRPC(rpc1.name, rpc1.params)
+  common.getHMIConnection():ExpectRequest("VehicleInfo." .. rpc1.name, rpc1.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", vehicleDataResults)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", vehicleDataResults)
     end)
 
-  local responseParams = common.cloneTable(vehicleDataResults)
+  local responseParams = vehicleDataResults
   responseParams.success = true
   responseParams.resultCode = "SUCCESS"
-  mobileSession:ExpectResponse(cid, responseParams)
+  common.getMobileSession():ExpectResponse(cid, responseParams)
 end
 
-local function checkNotification(pParams, isNotificationExpect, self)
-  local mobileSession = common.getMobileSession(self, 1)
-  self.hmiConnection:SendNotification("VehicleInfo.OnVehicleData", { gps = pParams })
+local function checkNotification(pParams, isNotificationExpect)
+  common.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", { gps = pParams })
   if isNotificationExpect == true then
-    mobileSession:ExpectNotification("OnVehicleData", { gps = pParams })
+    common.getMobileSession():ExpectNotification("OnVehicleData", { gps = pParams })
   else
-    mobileSession:ExpectNotification("OnVehicleData")
+    common.getMobileSession():ExpectNotification("OnVehicleData")
     :Times(0)
   end
 end
 
 --[[ Scenario ]]
-runner.Title("Preconditions")
-runner.Step("Clean environment", common.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
-runner.Step("Activate App", common.activateApp)
-runner.Step("SubscribeVehicleData gps", processRPCSubscribeSuccess)
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App", common.activateApp)
+common.Step("SubscribeVehicleData gps", processRPCSubscribeSuccess)
 
-runner.Title("Test")
+common.Title("Test")
 for key, value in pairs(vehicleDataValues) do
-  runner.Step("RPC OnVehicleData gps " .. key, checkNotification, { value, true })
+  common.Step("RPC OnVehicleData gps " .. key, checkNotification, { value, true })
 end
 for key, value in pairs(vehicleDataValuesMissedMandatory) do
-  runner.Step("RPC OnVehicleData gps " .. key, checkNotification, { value, false })
+  common.Step("RPC OnVehicleData gps " .. key, checkNotification, { value, false })
 end
 
-runner.Title("Postconditions")
-runner.Step("Stop SDL", common.postconditions)
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/OnVehicleData/005_Success_flow_deviceStatus_primaryAudioSource.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/005_Success_flow_deviceStatus_primaryAudioSource.lua
@@ -14,9 +14,7 @@
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
-local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
-local utils = require('user_modules/utils')
 
 --[[ Local Variables ]]
 local audioSources = {
@@ -58,39 +56,38 @@ local rpc2 = {
 }
 
 --[[ Local Functions ]]
-local function processRPCSubscribeSuccess(self)
-  local mobileSession = common.getMobileSession(self, 1)
-  local cid = mobileSession:SendRPC(rpc1.name, rpc1.params)
-  EXPECT_HMICALL("VehicleInfo." .. rpc1.name, rpc1.params)
+local function processRPCSubscribeSuccess()
+  local cid = common.getMobileSession():SendRPC(rpc1.name, rpc1.params)
+  common.getHMIConnection():ExpectRequest("VehicleInfo." .. rpc1.name, rpc1.params)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", vehicleDataResults)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", vehicleDataResults)
     end)
 
-  local responseParams = utils.cloneTable(vehicleDataResults)
+  local responseParams = vehicleDataResults
   responseParams.success = true
   responseParams.resultCode = "SUCCESS"
-  mobileSession:ExpectResponse(cid, responseParams)
+  common.getMobileSession():ExpectResponse(cid, responseParams)
 end
 
-local function checkNotificationSuccess(pAudioSource, self)
+local function checkNotificationSuccess(pAudioSource)
   rpc2.params.deviceStatus.primaryAudioSource = pAudioSource
-  local mobileSession = common.getMobileSession(self, 1)
-  self.hmiConnection:SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
-  mobileSession:ExpectNotification("OnVehicleData", rpc2.params)
+  common.getHMIConnection():SendNotification("VehicleInfo." .. rpc2.name, rpc2.params)
+  common.getMobileSession():ExpectNotification("OnVehicleData", rpc2.params)
 end
 
 --[[ Scenario ]]
-runner.Title("Preconditions")
-runner.Step("Clean environment", common.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
-runner.Step("Activate App", common.activateApp)
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App", common.activateApp)
 
-runner.Title("Test")
-runner.Step("RPC " .. rpc1.name, processRPCSubscribeSuccess)
+common.Title("Test")
+common.Step("RPC " .. rpc1.name, processRPCSubscribeSuccess)
 for _, source in pairs(audioSources) do
-  runner.Step("RPC " .. rpc2.name .. " source " .. source, checkNotificationSuccess, { source })
+  common.Step("RPC " .. rpc2.name .. " source " .. source, checkNotificationSuccess, { source })
 end
 
-runner.Title("Postconditions")
-runner.Step("Stop SDL", common.postconditions)
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/SubscribeVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/001_Success_flow.lua
@@ -24,17 +24,18 @@ local rpc = "SubscribeVehicleData"
 common.allVehicleData.vin = nil
 
 --[[ Scenario ]]
-runner.Title("Preconditions")
-runner.Step("Clean environment", common.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
-runner.Step("Activate App", common.activateApp)
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App", common.activateApp)
 
-runner.Title("Test")
+common.Title("Test")
 for vehicleDataName in pairs(common.allVehicleData) do
   runner.Step("RPC " .. rpc .. " " .. vehicleDataName, common.processRPCSubscriptionSuccess,
     {rpc, vehicleDataName })
 end
 
-runner.Title("Postconditions")
-runner.Step("Stop SDL", common.postconditions)
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/001_Success_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/001_Success_flow.lua
@@ -26,19 +26,19 @@ local rpc_unsubscribe = "UnsubscribeVehicleData"
 common.allVehicleData.vin = nil
 
 --[[ Scenario ]]
-runner.Title("Preconditions")
-runner.Step("Clean environment", common.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
-runner.Step("Activate App", common.activateApp)
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App", common.activateApp)
 
-runner.Title("Test")
+common.Title("Test")
 for vehicleDataName in pairs(common.allVehicleData) do
   runner.Step("RPC " .. rpc_subscribe .. " " .. vehicleDataName, common.processRPCSubscriptionSuccess,
     {rpc_subscribe, vehicleDataName })
   runner.Step("RPC " .. rpc_unsubscribe .. " " .. vehicleDataName, common.processRPCSubscriptionSuccess,
     {rpc_unsubscribe, vehicleDataName })
 end
-
-runner.Title("Postconditions")
-runner.Step("Stop SDL", common.postconditions)
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/002_RPC_parameter_not_yet_subscribed_IGNORED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/002_RPC_parameter_not_yet_subscribed_IGNORED_flow.lua
@@ -16,9 +16,7 @@
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
-local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
-local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 
 --[[ Local Variables ]]
 local rpc = {
@@ -34,15 +32,15 @@ local rpc = {
 
 local vehicleDataResults = {
   engineOilLife = {
-    dataType = "VEHICLEDATA_ENGINEOILLIFE", 
+    dataType = "VEHICLEDATA_ENGINEOILLIFE",
     resultCode = "DATA_NOT_SUBSCRIBED"
   },
   fuelRange = {
-    dataType = "VEHICLEDATA_FUELRANGE", 
+    dataType = "VEHICLEDATA_FUELRANGE",
     resultCode = "DATA_NOT_SUBSCRIBED"
   },
   tirePressure = {
-    dataType = "VEHICLEDATA_TIREPRESSURE", 
+    dataType = "VEHICLEDATA_TIREPRESSURE",
     resultCode = "DATA_NOT_SUBSCRIBED"
   },
   electronicParkBrakeStatus = {
@@ -50,32 +48,31 @@ local vehicleDataResults = {
     resultCode = "DATA_NOT_SUBSCRIBED"
   },
   turnSignal = {
-    dataType = "VEHICLEDATA_TURNSIGNAL", 
+    dataType = "VEHICLEDATA_TURNSIGNAL",
     resultCode = "DATA_NOT_SUBSCRIBED"
   }
 }
 
 --[[ Local Functions ]]
-local function processRPCFailure(self)
-  local mobileSession = common.getMobileSession(self, 1)
-  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
-  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
-  commonTestCases:DelayedExp(common.timeout)
+local function processRPCFailure()
+  local cid = common.getMobileSession():SendRPC(rpc.name, rpc.params)
+  common.getHMIConnection():ExpectRequest("VehicleInfo." .. rpc.name, rpc.params):Times(0)
   local responseParams = vehicleDataResults
   responseParams.success = false
   responseParams.resultCode = "IGNORED"
-  mobileSession:ExpectResponse(cid, responseParams)
+  common.getMobileSession():ExpectResponse(cid, responseParams)
 end
 
 --[[ Scenario ]]
-runner.Title("Preconditions")
-runner.Step("Clean environment", common.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU)
-runner.Step("Activate App", common.activateApp)
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App", common.activateApp)
 
-runner.Title("Test")
-runner.Step("RPC " .. rpc.name , processRPCFailure)
+common.Title("Test")
+common.Step("RPC " .. rpc.name , processRPCFailure)
 
-runner.Title("Postconditions")
-runner.Step("Stop SDL", common.postconditions)
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/004_RPC_parameter_disallowed_by_policies_Result_DISALLOWED_flow.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/004_RPC_parameter_disallowed_by_policies_Result_DISALLOWED_flow.lua
@@ -15,9 +15,7 @@
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
-local runner = require('user_modules/script_runner')
 local common = require('test_scripts/API/VehicleData/commonVehicleData')
-local commonTestCases = require('user_modules/shared_testcases/commonTestCases')
 
 --[[ Local Variables ]]
 local rpc = {
@@ -33,64 +31,47 @@ local rpc = {
 
 local vehicleDataResults = {
   engineOilLife = {
-    dataType = "VEHICLEDATA_ENGINEOILLIFE", 
+    dataType = "VEHICLEDATA_ENGINEOILLIFE",
     resultCode = "DISALLOWED"
   },
   fuelRange = {
-    dataType = "VEHICLEDATA_FUELRANGE", 
+    dataType = "VEHICLEDATA_FUELRANGE",
     resultCode = "DISALLOWED"
   },
   tirePressure = {
-    dataType = "VEHICLEDATA_TIREPRESSURE", 
+    dataType = "VEHICLEDATA_TIREPRESSURE",
     resultCode = "DISALLOWED"
   },
   electronicParkBrakeStatus = {
-    dataType = "VEHICLEDATA_ELECTRONICPARKBRAKESTATUS", 
+    dataType = "VEHICLEDATA_ELECTRONICPARKBRAKESTATUS",
     resultCode = "DISALLOWED"
   },
   turnSignal = {
-    dataType = "VEHICLEDATA_TURNSIGNAL", 
+    dataType = "VEHICLEDATA_TURNSIGNAL",
     resultCode = "DISALLOWED"
   }
 }
 
 --[[ Local Functions ]]
-local function ptu_update_func(tbl)
-  local params = tbl.policy_table.functional_groupings["Emergency-1"].rpcs["UnsubscribeVehicleData"].parameters
-  local newParams = {}
-  for index, value in pairs(params) do
-    if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
-  end
-  tbl.policy_table.functional_groupings["Emergency-1"].rpcs["UnsubscribeVehicleData"].parameters = newParams
-
-  params = tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["UnsubscribeVehicleData"].parameters
-  newParams = {}
-  for index, value in pairs(params) do
-    if not (("engineOilLife" == value) or ("fuelRange" == value) or ("tirePressure" == value) or ("turnSignal" == value) or ("electronicParkBrakeStatus" == value)) then table.insert(newParams, value) end
-  end
-  tbl.policy_table.functional_groupings["VehicleInfo-3"].rpcs["UnsubscribeVehicleData"].parameters = newParams
-end
-
-local function processRPCFailure(self)
-  local mobileSession = common.getMobileSession(self, 1)
-  local cid = mobileSession:SendRPC(rpc.name, rpc.params)
-  EXPECT_HMICALL("VehicleInfo." .. rpc.name, rpc.params):Times(0)
-  commonTestCases:DelayedExp(common.timeout)
+local function processRPCFailure()
+  local cid = common.getMobileSession():SendRPC(rpc.name, rpc.params)
+  common.getHMIConnection():ExpectRequest("VehicleInfo." .. rpc.name, rpc.params):Times(0)
   local responseParams = vehicleDataResults
   responseParams.success = false
   responseParams.resultCode = "DISALLOWED"
-  mobileSession:ExpectResponse(cid, responseParams)
+  common.getMobileSession():ExpectResponse(cid, responseParams)
 end
 
 --[[ Scenario ]]
-runner.Title("Preconditions")
-runner.Step("Clean environment", common.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
-runner.Step("RAI with PTU", common.registerAppWithPTU, {1, ptu_update_func})
-runner.Step("Activate App", common.activateApp)
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("RAI", common.registerApp)
+common.Step("PTU", common.policyTableUpdate, { common.ptUpdateMin })
+common.Step("Activate App", common.activateApp)
 
-runner.Title("Test")
-runner.Step("RPC " .. rpc.name , processRPCFailure)
+common.Title("Test")
+common.Step("RPC " .. rpc.name , processRPCFailure)
 
-runner.Title("Postconditions")
-runner.Step("Stop SDL", common.postconditions)
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/commonVehicleData.lua
+++ b/test_scripts/API/VehicleData/commonVehicleData.lua
@@ -1,31 +1,20 @@
 ---------------------------------------------------------------------------------------------------
 -- VehicleData common module
 ---------------------------------------------------------------------------------------------------
---[[ General configuration parameters ]]
-config.mobileHost = "127.0.0.1"
+--[[ Required Shared libraries ]]
+local actions = require("user_modules/sequences/actions")
+local runner = require('user_modules/script_runner')
+local utils = require("user_modules/utils")
+local sdl = require("SDL")
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
 config.defaultProtocolVersion = 2
 
---[[ Required Shared libraries ]]
-local mobile_session = require("mobile_session")
-local json = require("modules/json")
-local events = require("events")
-local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
-local commonSteps = require("user_modules/shared_testcases/commonSteps")
-local commonTestCases = require("user_modules/shared_testcases/commonTestCases")
-local utils = require('user_modules/utils')
-
 --[[ Local Variables ]]
-local ptu_table = {}
-local hmiAppIds = {}
+local m = {}
 
-local commonVehicleData = {}
-
-commonVehicleData.EMPTY_ARRAY = json.EMPTY_ARRAY
-commonVehicleData.timeout = 2000
-commonVehicleData.minTimeout = 500
-commonVehicleData.DEFAULT = "Default"
-commonVehicleData.cloneTable =  utils.cloneTable
-commonVehicleData.allVehicleData = {
+m.allVehicleData = {
   gps = {
     value = {
       longitudeDegrees = 100,
@@ -263,286 +252,56 @@ commonVehicleData.allVehicleData = {
   }
 }
 
-local function checkIfPTSIsSentAsBinary(bin_data)
-  if not (bin_data ~= nil and string.len(bin_data) > 0) then
-    commonFunctions:userPrint(31, "PTS was not sent to Mobile in payload of OnSystemRequest")
+m.EMPTY_ARRAY = actions.json.EMPTY_ARRAY
+
+--[[ Shared Functions ]]
+m.Title = runner.Title
+m.Step = runner.Step
+m.preconditions = actions.preconditions
+m.postconditions = actions.postconditions
+m.start = actions.start
+m.activateApp = actions.activateApp
+m.getMobileSession = actions.getMobileSession
+m.getHMIConnection = actions.getHMIConnection
+m.registerApp = actions.registerApp
+m.registerAppWOPTU = actions.registerAppWOPTU
+m.policyTableUpdate = actions.policyTableUpdate
+m.getConfigAppParams = actions.getConfigAppParams
+m.wait = utils.wait
+m.extendedPolicy = sdl.buildOptions.extendedPolicy
+m.setSDLIniParameter = actions.setSDLIniParameter
+m.cloneTable = utils.cloneTable
+
+--[[ Common Functions ]]
+local function getVDParams()
+  local out = {}
+  for k in pairs(m.allVehicleData) do
+    table.insert(out, k)
   end
+  return out
 end
 
-function commonVehicleData.getGetVehicleDataConfig()
-  return {
-    keep_context = false,
-    steal_focus = false,
-    priority = "NONE",
-    default_hmi = "NONE",
-    groups = { "Base-4", "Emergency-1", "VehicleInfo-3" }
-  }
-end
-
-local function getPTUFromPTS(tbl)
-  tbl.policy_table.consumer_friendly_messages.messages = nil
-  tbl.policy_table.device_data = nil
-  tbl.policy_table.module_meta = nil
-  tbl.policy_table.usage_and_error_counts = nil
-  tbl.policy_table.functional_groupings["DataConsent-2"].rpcs = json.null
-  tbl.policy_table.module_config.preloaded_pt = nil
-  tbl.policy_table.module_config.preloaded_date = nil
-  tbl.policy_table.vehicle_data = nil
-end
-
-local function jsonFileToTable(file_name)
-  local f = io.open(file_name, "r")
-  local content = f:read("*all")
-  f:close()
-  return json.decode(content)
-end
-
-local function addParamToRPC(tbl, functional_grouping, rpc, param)
-  local is_found = false
-  local params = tbl.policy_table.functional_groupings[functional_grouping].rpcs[rpc].parameters
-  for _, value in pairs(params) do
-    if (value == param) then is_found = true end
+function m.ptUpdate(pTbl)
+  pTbl.policy_table.app_policies[m.getConfigAppParams().fullAppID].groups = { "Base-4", "Emergency-1" }
+  local grp = pTbl.policy_table.functional_groupings["Emergency-1"]
+  for _, v in pairs(grp.rpcs) do
+    v.parameters = getVDParams()
   end
-  if not is_found then
-    table.insert(tbl.policy_table.functional_groupings[functional_grouping].rpcs[rpc].parameters, param)
+  pTbl.policy_table.vehicle_data = nil
+end
+
+function m.ptUpdateMin(pTbl)
+  pTbl.policy_table.app_policies[m.getConfigAppParams().fullAppID].groups = { "Base-4", "Emergency-1" }
+  local grp = pTbl.policy_table.functional_groupings["Emergency-1"]
+  for _, v in pairs(grp.rpcs) do
+    v.parameters = {
+      "gps"
+    }
   end
+  pTbl.policy_table.vehicle_data = nil
 end
 
-local function ptu(self, app_id, ptu_update_func)
-  local function getAppsCount()
-    local count = 0
-    for _ in pairs(hmiAppIds) do
-      count = count + 1
-    end
-    return count
-  end
-
-  local policy_file_name = "PolicyTableUpdate"
-  local policy_file_path = commonFunctions:read_parameter_from_smart_device_link_ini("SystemFilesPath")
-  local pts_file_name = commonFunctions:read_parameter_from_smart_device_link_ini("PathToSnapshot")
-  local ptu_file_name = os.tmpname()
-  local requestId = self.hmiConnection:SendRequest("SDL.GetPolicyConfigurationData",
-      { policyType = "module_config", property = "endpoints" })
-  EXPECT_HMIRESPONSE(requestId)
-  :Do(function()
-      self.hmiConnection:SendNotification("BasicCommunication.OnSystemRequest",
-        { requestType = "PROPRIETARY", fileName = pts_file_name })
-      getPTUFromPTS(ptu_table)
-      local function updatePTU(tbl)
-        for rpc in pairs(tbl.policy_table.functional_groupings["Emergency-1"].rpcs) do
-          for vehicleDataName in pairs(commonVehicleData.allVehicleData) do
-            addParamToRPC(tbl, "Emergency-1", rpc, vehicleDataName)
-          end
-        end
-        tbl.policy_table.app_policies[commonVehicleData.getMobileAppId(app_id)] = commonVehicleData.getGetVehicleDataConfig()
-      end
-      updatePTU(ptu_table)
-      if ptu_update_func then
-        ptu_update_func(ptu_table)
-      end
-      local function tableToJsonFile(tbl, file_name)
-        local f = io.open(file_name, "w")
-        f:write(json.encode(tbl))
-        f:close()
-      end
-      tableToJsonFile(ptu_table, ptu_file_name)
-
-      local event = events.Event()
-      event.matches = function(self, e) return self == e end
-      EXPECT_EVENT(event, "PTU event")
-      :Timeout(11000)
-
-      for id = 1, getAppsCount() do
-        local mobileSession = commonVehicleData.getMobileSession(self, id)
-        mobileSession:ExpectNotification("OnSystemRequest", { requestType = "PROPRIETARY" })
-        :Do(function(_, d2)
-            print("App ".. id .. " was used for PTU")
-            RAISE_EVENT(event, event, "PTU event")
-            checkIfPTSIsSentAsBinary(d2.binaryData)
-            local corIdSystemRequest = mobileSession:SendRPC("SystemRequest",
-              { requestType = "PROPRIETARY", fileName = policy_file_name }, ptu_file_name)
-            EXPECT_HMICALL("BasicCommunication.SystemRequest")
-            :Do(function(_, d3)
-                self.hmiConnection:SendResponse(d3.id, "BasicCommunication.SystemRequest", "SUCCESS", { })
-                self.hmiConnection:SendNotification("SDL.OnReceivedPolicyUpdate",
-                  { policyfile = policy_file_path .. "/" .. policy_file_name })
-              end)
-            mobileSession:ExpectResponse(corIdSystemRequest, { success = true, resultCode = "SUCCESS" })
-          end)
-        :Times(AtMost(1))
-      end
-    end)
-  os.remove(ptu_file_name)
-end
-
-function commonVehicleData.preconditions()
-  commonFunctions:SDLForceStop()
-  commonSteps:DeletePolicyTable()
-  commonSteps:DeleteLogsFiles()
-end
-
---[[Module functions]]
-function commonVehicleData.activateApp(pAppId, self)
-  self, pAppId = commonVehicleData.getSelfAndParams(pAppId, self)
-  if not pAppId then pAppId = 1 end
-  local pHMIAppId = hmiAppIds[config["application" .. pAppId].registerAppInterfaceParams.fullAppID]
-  local mobSession = commonVehicleData.getMobileSession(self, pAppId)
-  local requestId = self.hmiConnection:SendRequest("SDL.ActivateApp", { appID = pHMIAppId })
-  EXPECT_HMIRESPONSE(requestId)
-  mobSession:ExpectNotification("OnHMIStatus",
-    { hmiLevel = "FULL", audioStreamingState = "AUDIBLE", systemContext = "MAIN" })
-  commonTestCases:DelayedExp(commonVehicleData.minTimeout)
-end
-
-function commonVehicleData.getSelfAndParams(...)
-  local out = { }
-  local selfIdx = nil
-  for i,v in pairs({...}) do
-    if type(v) == "table" and v.isTest then
-      table.insert(out, v)
-      selfIdx = i
-      break
-    end
-  end
-  local idx = 2
-  for i = 1, table.maxn({...}) do
-    if i ~= selfIdx then
-      out[idx] = ({...})[i]
-      idx = idx + 1
-    end
-  end
-  return table.unpack(out, 1, table.maxn(out))
-end
-
-function commonVehicleData.getHMIAppId(pAppId)
-  if not pAppId then pAppId = 1 end
-  return hmiAppIds[config["application" .. pAppId].registerAppInterfaceParams.fullAppID]
-end
-
-function commonVehicleData.getMobileSession(self, pAppId)
-  if not pAppId then pAppId = 1 end
-  return self["mobileSession" .. pAppId]
-end
-
-function commonVehicleData.getMobileAppId(pAppId)
-  if not pAppId then pAppId = 1 end
-  return config["application" .. pAppId].registerAppInterfaceParams.fullAppID
-end
-
-function commonVehicleData.getPathToSDL()
-  return config.pathToSDL
-end
-
-function commonVehicleData.postconditions()
-  StopSDL()
-end
-
-function commonVehicleData.registerAppWithPTU(id, ptu_update_func, self)
-  self, id, ptu_update_func = commonVehicleData.getSelfAndParams(id, ptu_update_func, self)
-  if not id then id = 1 end
-  self["mobileSession" .. id] = mobile_session.MobileSession(self, self.mobileConnection)
-  self["mobileSession" .. id]:StartService(7)
-  :Do(function()
-      local corId = self["mobileSession" .. id]:SendRPC("RegisterAppInterface",
-        config["application" .. id].registerAppInterfaceParams)
-      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered",
-        { application = { appName = config["application" .. id].registerAppInterfaceParams.appName } })
-      :Do(function(_, d1)
-          hmiAppIds[config["application" .. id].registerAppInterfaceParams.fullAppID] = d1.params.application.appID
-          EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate",
-            { status = "UPDATE_NEEDED" }, { status = "UPDATING" }, { status = "UP_TO_DATE" })
-          :Times(3)
-          EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
-          :Do(function(e, d2)
-              if e.occurences == 1 then
-                self.hmiConnection:SendResponse(d2.id, d2.method, "SUCCESS", { })
-                ptu_table = jsonFileToTable(d2.params.file)
-                ptu(self, id, ptu_update_func)
-              else
-                self:FailTestCase("BC.PolicyUpdate was sent more than once (PTU update was incorrect)")
-              end
-            end)
-        end)
-      self["mobileSession" .. id]:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
-      :Do(function()
-          self["mobileSession" .. id]:ExpectNotification("OnHMIStatus",
-            { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
-          :Times(1)
-          self["mobileSession" .. id]:ExpectNotification("OnPermissionsChange"):Times(2)
-          EXPECT_HMICALL("VehicleInfo.GetVehicleData", { odometer = true})
-        end)
-    end)
-end
-
-function commonVehicleData.raiN(id, self)
-  self, id = commonVehicleData.getSelfAndParams(id, self)
-  if not id then id = 1 end
-  self["mobileSession" .. id] = mobile_session.MobileSession(self, self.mobileConnection)
-  self["mobileSession" .. id]:StartService(7)
-  :Do(function()
-      local corId = self["mobileSession" .. id]:SendRPC("RegisterAppInterface",
-        config["application" .. id].registerAppInterfaceParams)
-      EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered",
-        { application = { appName = config["application" .. id].registerAppInterfaceParams.appName } })
-      :Do(function(_, d1)
-          hmiAppIds[config["application" .. id].registerAppInterfaceParams.fullAppID] = d1.params.application.appID
-        end)
-      self["mobileSession" .. id]:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
-      :Do(function()
-          self["mobileSession" .. id]:ExpectNotification("OnHMIStatus",
-            { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
-          :Times(1)
-          self["mobileSession" .. id]:ExpectNotification("OnPermissionsChange")
-        end)
-    end)
-end
-
-local function allowSDL(self)
-  self.hmiConnection:SendNotification("SDL.OnAllowSDLFunctionality", {
-      allowed = true,
-      source = "GUI",
-      device = {
-        id = commonVehicleData.getDeviceMAC(),
-        name = commonVehicleData.getDeviceName()
-      }
-    })
-end
-
-function commonVehicleData.start(pHMIParams, self)
-  self, pHMIParams = commonVehicleData.getSelfAndParams(pHMIParams, self)
-  self:runSDL()
-  commonFunctions:waitForSDLStart(self)
-  :Do(function()
-      self:initHMI(self)
-      :Do(function()
-          commonFunctions:userPrint(35, "HMI initialized")
-          self:initHMI_onReady(pHMIParams)
-          :Do(function()
-              commonFunctions:userPrint(35, "HMI is ready")
-              self:connectMobile()
-              :Do(function()
-                  commonFunctions:userPrint(35, "Mobile connected")
-                  allowSDL(self)
-                end)
-            end)
-        end)
-    end)
-end
-
-function commonVehicleData.getDeviceName()
-  return config.mobileHost .. ":" .. config.mobilePort
-end
-
-function commonVehicleData.getDeviceMAC()
-  local cmd = "echo -n " .. commonVehicleData.getDeviceName() .. " | sha256sum | awk '{printf $1}'"
-  local handle = io.popen(cmd)
-  local result = handle:read("*a")
-  handle:close()
-  return result
-end
-
-function commonVehicleData.processRPCSubscriptionSuccess(pRpcName, pData, self)
-  local mobileSession = commonVehicleData.getMobileSession(self, 1)
+function m.processRPCSubscriptionSuccess(pRpcName, pData)
   local reqParams = {
     [pData] = true
   }
@@ -555,38 +314,35 @@ function commonVehicleData.processRPCSubscriptionSuccess(pRpcName, pData, self)
   local hmiResParams = {
     [respData] = {
       resultCode = "SUCCESS",
-      dataType = commonVehicleData.allVehicleData[pData].type
+      dataType = m.allVehicleData[pData].type
     }
   }
-  local cid = mobileSession:SendRPC(pRpcName, reqParams)
-  EXPECT_HMICALL("VehicleInfo." .. pRpcName, reqParams)
+  local cid = m.getMobileSession():SendRPC(pRpcName, reqParams)
+  m.getHMIConnection():ExpectRequest("VehicleInfo." .. pRpcName, reqParams)
   :Do(function(_, data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", hmiResParams)
+      m.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", hmiResParams)
     end)
-
-  local mobResParams = commonVehicleData.cloneTable(hmiResParams)
+  local mobResParams = m.cloneTable(hmiResParams)
   mobResParams.success = true
   mobResParams.resultCode = "SUCCESS"
-  mobileSession:ExpectResponse(cid, mobResParams)
+  m.getMobileSession():ExpectResponse(cid, mobResParams)
 end
 
-function commonVehicleData.checkNotificationSuccess(pData, self)
-  local mobileSession = commonVehicleData.getMobileSession(self, 1)
-  local hmiNotParams = { [pData] = commonVehicleData.allVehicleData[pData].value }
-  local mobNotParams = commonVehicleData.cloneTable(hmiNotParams)
+function m.checkNotificationSuccess(pData)
+  local hmiNotParams = { [pData] = m.allVehicleData[pData].value }
+  local mobNotParams = m.cloneTable(hmiNotParams)
   if mobNotParams.emergencyEvent then
     mobNotParams.emergencyEvent.maximumChangeVelocity = 0
   end
-  self.hmiConnection:SendNotification("VehicleInfo.OnVehicleData", hmiNotParams)
-  mobileSession:ExpectNotification("OnVehicleData", mobNotParams)
+  m.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", hmiNotParams)
+  m.getMobileSession():ExpectNotification("OnVehicleData", mobNotParams)
 end
 
-function commonVehicleData.checkNotificationIgnored(pData, self)
-  local mobileSession = commonVehicleData.getMobileSession(self, 1)
-  local hmiNotParams = { [pData] = commonVehicleData.allVehicleData[pData].value }
-  self.hmiConnection:SendNotification("VehicleInfo.OnVehicleData", hmiNotParams)
-  mobileSession:ExpectNotification("OnVehicleData")
+function m.checkNotificationIgnored(pData)
+  local hmiNotParams = { [pData] = m.allVehicleData[pData].value }
+  m.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", hmiNotParams)
+  m.getMobileSession():ExpectNotification("OnVehicleData")
   :Times(0)
 end
 
-return commonVehicleData
+return m

--- a/test_sets/SDL5_0/vehicle_data.txt
+++ b/test_sets/SDL5_0/vehicle_data.txt
@@ -4,12 +4,12 @@
 ./test_scripts/API/VehicleData/GetVehicleData/004_Success_deviceStatus_primaryAudioSource.lua
 ./test_scripts/API/VehicleData/OnVehicleData/001_Success_flow.lua
 ./test_scripts/API/VehicleData/OnVehicleData/002_NotificationForUnsubsribedParameter_Ignored_flow.lua
-;./test_scripts/API/VehicleData/OnVehicleData/003_NotificationParameterDisallowedByPolicies_Ignored_flow.lua
+./test_scripts/API/VehicleData/OnVehicleData/003_NotificationParameterDisallowedByPolicies_Ignored_flow.lua
 ./test_scripts/API/VehicleData/OnVehicleData/004_OnVD_gps_mandatory_parameters.lua
 ./test_scripts/API/VehicleData/OnVehicleData/005_Success_flow_deviceStatus_primaryAudioSource.lua
 ./test_scripts/API/VehicleData/SubscribeVehicleData/001_Success_flow.lua
-;./test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
-;./test_scripts/API/VehicleData/SubscribeVehicleData/003_RPC_parameter_already_subscribed_Result_IGNORED_flow.lua
+./test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+./test_scripts/API/VehicleData/SubscribeVehicleData/003_RPC_parameter_already_subscribed_Result_IGNORED_flow.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/001_Success_flow.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/002_RPC_parameter_not_yet_subscribed_IGNORED_flow.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/003_RPC_parameter_already_unsubscribed_Result_IGNORED_flow.lua

--- a/test_sets/vehicle_data.txt
+++ b/test_sets/vehicle_data.txt
@@ -4,12 +4,12 @@
 ./test_scripts/API/VehicleData/GetVehicleData/004_Success_deviceStatus_primaryAudioSource.lua
 ./test_scripts/API/VehicleData/OnVehicleData/001_Success_flow.lua
 ./test_scripts/API/VehicleData/OnVehicleData/002_NotificationForUnsubsribedParameter_Ignored_flow.lua
-;./test_scripts/API/VehicleData/OnVehicleData/003_NotificationParameterDisallowedByPolicies_Ignored_flow.lua
+./test_scripts/API/VehicleData/OnVehicleData/003_NotificationParameterDisallowedByPolicies_Ignored_flow.lua
 ./test_scripts/API/VehicleData/OnVehicleData/004_OnVD_gps_mandatory_parameters.lua
 ./test_scripts/API/VehicleData/OnVehicleData/005_Success_flow_deviceStatus_primaryAudioSource.lua
 ./test_scripts/API/VehicleData/SubscribeVehicleData/001_Success_flow.lua
-;./test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
-;./test_scripts/API/VehicleData/SubscribeVehicleData/003_RPC_parameter_already_subscribed_Result_IGNORED_flow.lua
+./test_scripts/API/VehicleData/SubscribeVehicleData/002_RPC_parameter_DISALLOWED_by_policies_flow.lua
+./test_scripts/API/VehicleData/SubscribeVehicleData/003_RPC_parameter_already_subscribed_Result_IGNORED_flow.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/001_Success_flow.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/002_RPC_parameter_not_yet_subscribed_IGNORED_flow.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/003_RPC_parameter_already_unsubscribed_Result_IGNORED_flow.lua


### PR DESCRIPTION
Fixed issue [#2243](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2243)

This PR is **[ready]** for review.

### Summary
Rework VehicleData scripts

### ATF version
develop

### Changelog
 - utilized functions from `actions` module
 - added possibility to run scripts on all SDL policy flows
 - included in test set previously disabled tests since such functionality is implemented in scope of `Read Generic Network Signal Data` proposal
 - fixed expected result in [SubscribeVehicleData/003_RPC_parameter_already_subscribed_Result_IGNORED_flow](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/API/VehicleData/SubscribeVehicleData/003_RPC_parameter_already_subscribed_Result_IGNORED_flow.lua)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
