### PR TITLE
use new parameter audioPassThruCapabilitiesList in hmi_values

### DIFF
--- a/user_modules/hmi_values.lua
+++ b/user_modules/hmi_values.lua
@@ -236,10 +236,12 @@ function module.getDefaultHMITable()
         },
         numCustomPresetsAvailable = 10
       },
-      audioPassThruCapabilities = {
-        samplingRate = "44KHZ",
-        bitsPerSample = "8_BIT",
-        audioType = "PCM"
+      audioPassThruCapabilitiesList = {
+        {
+          samplingRate = "44KHZ",
+          bitsPerSample = "8_BIT",
+          audioType = "PCM"
+        }
       },
       hmiZoneCapabilities = "FRONT",
       softButtonCapabilities = {


### PR DESCRIPTION
ATF Test Scripts to check #[2024](https://github.com/smartdevicelink/sdl_core/issues/2024)

This PR is **ready** for review.

### Summary
Change the hmi_values.lua file to use the new parameter audioPassThruCapabilitiesList

### ATF version
develop

### Changelog

##### Enhancements
* use the new parameter audioPassThruCapabilitiesList

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
