### PR TITLE
fixup! Add remote_control module as new core module of user_modules

### DIFF
--- a/user_modules/sequences/remote_control.lua
+++ b/user_modules/sequences/remote_control.lua
@@ -2,7 +2,6 @@
 -- Common RC related actions module
 ---------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
-local commonRC = require('test_scripts/RC/commonRC')
 local actions = require("user_modules/sequences/actions")
 local hmi_values = require("user_modules/hmi_values")
 local utils = require('user_modules/utils')
@@ -850,7 +849,7 @@ local rcRPCs = {
     end,
     hmiRequestParams = function(pModuleType, pModuleId, pAppId)
       return {
-        appID = commonRC.getHMIAppId(pAppId),
+        appID = actions.app.getHMIId(pAppId),
         moduleType = pModuleType,
         moduleId = pModuleId,
         buttonName = m.predefined.getButtonName(pModuleType),
@@ -878,7 +877,7 @@ local rcRPCs = {
     end,
     hmiRequestParams = function(pModuleType, pModuleId, pAppId, pModuleIdArray)
       return {
-        appID = commonRC.getHMIAppId(pAppId),
+        appID = actions.app.getHMIId(pAppId),
         moduleType = pModuleType,
         moduleIds = pModuleIdArray
       }


### PR DESCRIPTION
Updates for ATF Test Scripts that checks RC related functionality that have been merged in scope of **[SDL 0204- Support running the same app from multiple devices at the same time feature](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2202 )** - 
And need to be updated in scope of **[SDL 0221-Remote Control - Allow Multiple Modules per Module Type feature](https://github.com/smartdevicelink/sdl_core/issues/2919)** 

This PR is **[ready]** for review.

**[these changes will be merged to [#2226](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2226)]**

### Summary
Update existing scripts according multiple modules feature changes

### ATF version
https://github.com/smartdevicelink/sdl_atf/tree/develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
