### PR TITLE
Remove undefined info param from response validation

### DIFF
--- a/test_scripts/SDL5_0/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
+++ b/test_scripts/SDL5_0/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
@@ -8,7 +8,7 @@
 -- 1. Mobile app requests PerfromInteraction with image that is absent on file system
 -- SDL must:
 -- 1. transfer this RPC to HMI for processing
--- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found”) to mobile app
+-- 2. transfer the received from HMI response (WARNINGS, message: “Requested image(s) not found.”) to mobile app
 ---------------------------------------------------------------------------------------------------
 
 --[[ Required Shared libraries ]]
@@ -294,14 +294,14 @@ local function PI_PerformViaBOTH(paramsSend)
       RUN_AFTER(choiceIconDisplayed, 25)
       local function uiResponse()
         common.getHMIConnection():SendNotification("TTS.Stopped")
-        common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
+        common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found.")
         SendOnSystemContext("MAIN")
       end
       RUN_AFTER(uiResponse, 30)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI("BOTH")
   common.getMobileSession():ExpectResponse(cid, { success = false, resultCode = "WARNINGS",
-    info = "Requested image(s) not found, Perform Interaction error response." })
+    info = "Requested image(s) not found., Perform Interaction error response." })
 end
 
 --[[ Scenario ]]

--- a/test_scripts/SDL5_0/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
+++ b/test_scripts/SDL5_0/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
@@ -200,13 +200,12 @@ local function PI_PerformViaVR_ONLY(paramsSend)
       vrHelpTitle = paramsSend.initialText,
     })
   :Do(function(_,data)
-      common.getHMIConnection():SendResponse( data.id, data.method, "WARNINGS",
-        { info = "Requested image(s) not found." } )
+      common.getHMIConnection():SendError( data.id, data.method, "WARNINGS","Requested image(s) not found.")
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI("VR")
   common.getMobileSession():ExpectResponse(cid,
     { success = true, resultCode = "WARNINGS", choiceID = paramsSend.interactionChoiceSetIDList[1],
-    info = "Requested image(s) not found" })
+    info = "Requested image(s) not found." })
 end
 
 --! @PI_PerformViaMANUAL_ONLY: Processing PI with interaction mode MANUAL_ONLY with performing selection
@@ -246,8 +245,7 @@ local function PI_PerformViaMANUAL_ONLY(paramsSend)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI("MANUAL")
   common.getMobileSession():ExpectResponse(cid,
-    { success = true, resultCode = "WARNINGS", choiceID = paramsSend.interactionChoiceSetIDList[1],
-    info = "Requested image(s) not found." })
+    { success = true, resultCode = "WARNINGS", choiceID = paramsSend.interactionChoiceSetIDList[1]})
 end
 
 --! @PI_PerformViaBOTH: Processing PI with interaction mode BOTH with timeout on VR and IU
@@ -295,8 +293,7 @@ local function PI_PerformViaBOTH(paramsSend)
       RUN_AFTER(choiceIconDisplayed, 25)
       local function uiResponse()
         common.getHMIConnection():SendNotification("TTS.Stopped")
-        common.getHMIConnection():SendResponse(data.id, data.method, "WARNINGS",
-          { info = "Requested image(s) not found." })
+        common.getHMIConnection():SendError(data.id, data.method, "WARNINGS", "Requested image(s) not found")
         SendOnSystemContext("MAIN")
       end
       RUN_AFTER(uiResponse, 30)

--- a/test_scripts/SDL5_0/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
+++ b/test_scripts/SDL5_0/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
@@ -237,7 +237,7 @@ local function PI_PerformViaMANUAL_ONLY(paramsSend)
       SendOnSystemContext("HMI_OBSCURED")
       local function uiResponse()
         common.getHMIConnection():SendResponse(data.id, data.method, "WARNINGS",
-          { choiceID = paramsSend.interactionChoiceSetIDList[1], info = "Requested image(s) not found." } )
+          { choiceID = paramsSend.interactionChoiceSetIDList[1] } )
         common.getHMIConnection():SendNotification("TTS.Stopped")
         SendOnSystemContext("MAIN")
       end
@@ -245,7 +245,8 @@ local function PI_PerformViaMANUAL_ONLY(paramsSend)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI("MANUAL")
   common.getMobileSession():ExpectResponse(cid,
-    { success = true, resultCode = "WARNINGS", choiceID = paramsSend.interactionChoiceSetIDList[1]})
+    { success = true, resultCode = "WARNINGS", choiceID = paramsSend.interactionChoiceSetIDList[1] })
+  -- this is the only case when 'info' won't be populated since HMI couldn't provide it within success response
 end
 
 --! @PI_PerformViaBOTH: Processing PI with interaction mode BOTH with timeout on VR and IU


### PR DESCRIPTION
ATF Test Scripts to check #[2974]( https://github.com/smartdevicelink/sdl_core/issues/2974)

This PR is **[ready]** for review.

### Summary
According to HMI specification, result structure has no any messages and SDL doesn't resent any 'info' messages to the mobile, this is why I removed 'info' validation 

### ATF version
 https://github.com/smartdevicelink/sdl_atf/tree/develop(d6c2138)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
