### PR TITLE
Improve stability of policy scripts - additional updates

### DIFF
--- a/test_scripts/Policies/App_Permissions/002_ATF_HP_OnPermissionsChange_With_Assigned_Policy_After_App_Registration.lua
+++ b/test_scripts/Policies/App_Permissions/002_ATF_HP_OnPermissionsChange_With_Assigned_Policy_After_App_Registration.lua
@@ -107,17 +107,12 @@ function Test:Step1_Register_App_And_Check_Its_Permissions_In_OnPermissionsChang
           isSDLAllowed = false
     } } })
   :Do(function(_,data)
-      if(order_communication ~= 1 and order_communication ~= 2 and order_communication ~= 3) then
-        commonFunctions:printError("BasicCommunication.OnAppRegistered is not received 1 or 2 in message order. Real: received number: "..order_communication)
-        is_test_fail = true
-      end
-      order_communication = order_communication + 1
       self.applications["SPT"] = data.params.application.appID
     end)
 
   EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
   :Do(function(_,_)
-      if(order_communication ~= 1 and order_communication ~= 2) then
+      if(order_communication ~= 1) then
         commonFunctions:printError("RegisterAppInterface response is not received 1 or 2 in message order. Real: received number: "..order_communication)
         is_test_fail = true
       end
@@ -126,7 +121,7 @@ function Test:Step1_Register_App_And_Check_Its_Permissions_In_OnPermissionsChang
 
   EXPECT_NOTIFICATION("OnHMIStatus", {hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN"})
   :Do(function(_,_)
-      if( order_communication ~= 2 and order_communication ~= 3) then
+      if( order_communication ~= 2) then
         commonFunctions:printError("OnHMIStatus is not received 3 in message order. Real: received number: "..order_communication)
         is_test_fail = true
       end
@@ -135,7 +130,7 @@ function Test:Step1_Register_App_And_Check_Its_Permissions_In_OnPermissionsChang
 
   EXPECT_NOTIFICATION("OnPermissionsChange")
   :Do(function(_,_data2)
-      if(order_communication ~= 4) then
+      if(order_communication ~= 3) then
         commonFunctions:printError("OnPermissionsChange is not received 4 in message order. Real: received number: "..order_communication)
         is_test_fail = true
       end

--- a/test_scripts/Policies/Related_HMI_API/186_ATF_OnPolicyUpdate_initiation_of_PTU.lua
+++ b/test_scripts/Policies/Related_HMI_API/186_ATF_OnPolicyUpdate_initiation_of_PTU.lua
@@ -126,6 +126,7 @@ function Test:TestStep_Send_OnPolicyUpdate_from_HMI()
   self.hmiConnection:SendNotification("SDL.OnPolicyUpdate")
   EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UPDATE_NEEDED"})
   EXPECT_HMICALL("BasicCommunication.PolicyUpdate", {file = "/tmp/fs/mp/images/ivsu_cache/sdl_snapshot.json"})
+  utils.wait(2000)
 end
 
 --[[ Postconditions ]]

--- a/test_scripts/Policies/Validation_of_PolicyTables/227_ATF_usage_and_error_counts_update_count_sync_out_of_memory.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/227_ATF_usage_and_error_counts_update_count_sync_out_of_memory.lua
@@ -194,10 +194,10 @@ end
 --[[ Test ]]
 commonFunctions:newTestCasesGroup("Test")
 function Test:HMIsendOnSystemError()
-  for _ = 1, 5 do
-    os.execute("sleep 2")
-    self:onSystemError("SYNC_OUT_OF_MEMMORY")
+  for i = 1, 5 do
+    RUN_AFTER(function() self:onSystemError("SYNC_OUT_OF_MEMMORY") end, 100 * i)
   end
+  commonTestCases:DelayedExp(1000)
 end
 
 function Test:StopSDL()
@@ -217,10 +217,10 @@ function Test:InitHMI_OnReady2()
   commonTestCases:DelayedExp(10000)
 end
 function Test:HMIsendOnSystemError2()
-  for _ = 1, 4 do
-    commonTestCases:DelayedExp(2000)
-    self:onSystemError("SYNC_OUT_OF_MEMMORY")
+  for i = 1, 4 do
+    RUN_AFTER(function() self:onSystemError("SYNC_OUT_OF_MEMMORY") end, 100 * i)
   end
+  commonTestCases:DelayedExp(1000)
 end
 
 function Test:StopSDL2()
@@ -228,6 +228,7 @@ function Test:StopSDL2()
 end
 
 function Test:CheckPTUinLocalPT()
+  os.execute("sleep 5")
   --TestData:store("Store LocalPT after SDL.onSystemError", constructPathToDatabase(), "policy.sqlite" )
   local checks = {
     {

--- a/test_scripts/Policies/Validation_of_PolicyTables/228_ATF_usage_and_error_counts_update_count_of_sync_reboots.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/228_ATF_usage_and_error_counts_update_count_of_sync_reboots.lua
@@ -257,6 +257,7 @@ function Test:StopSDL2()
 end
 
 function Test:CheckPTUinLocalPT()
+  os.execute("sleep 5")
   TestData:store("Store LocalPT after SDL.onSystemError", constructPathToDatabase(), "policy.sqlite" )
   local checks = {
     {

--- a/test_scripts/Policies/Validation_of_PolicyTables/229_ATF_usage_and_error_counts_update_count_of_iap_buffer_full.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/229_ATF_usage_and_error_counts_update_count_of_iap_buffer_full.lua
@@ -194,10 +194,10 @@ end
 commonFunctions:newTestCasesGroup("Test")
 
 function Test:HMIsendAddStatisticsInfo()
-  for _ = 1, 2 do
-    os.execute("sleep 2")
-    self:addStatisticsInfo("iAPP_BUFFER_FULL")
+  for i = 1, 2 do
+    RUN_AFTER(function() self:addStatisticsInfo("iAPP_BUFFER_FULL") end, 100 * i)
   end
+  commonTestCases:DelayedExp(1000)
 end
 
 function Test:StopSDL()
@@ -218,10 +218,10 @@ function Test:InitHMI_onReady()
 end
 
 function Test:HMIsendAddStatisticsInfo2()
-  for _ = 1, 3 do
-    os.execute("sleep 2")
-    self:addStatisticsInfo("iAPP_BUFFER_FULL")
+  for i = 1, 3 do
+    RUN_AFTER(function() self:addStatisticsInfo("iAPP_BUFFER_FULL") end, 100 * i)
   end
+  commonTestCases:DelayedExp(1000)
 end
 
 function Test:StopSDL2()
@@ -229,6 +229,7 @@ function Test:StopSDL2()
 end
 
 function Test:CheckPTUinLocalPT()
+  os.execute("sleep 5")
   --TestData:store("Store LocalPT after SDL.AddStatisticsInfo", constructPathToDatabase(), "policy.sqlite" )
   local checks = {
     {

--- a/test_scripts/Policies/Validation_of_PolicyTables/230_ATF_usage_and_error_counts_update_minutes_in_hmi_none.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/230_ATF_usage_and_error_counts_update_minutes_in_hmi_none.lua
@@ -446,6 +446,7 @@ function Test:StopSDL2()
 end
 
 function Test:CheckPTUinLocalPT()
+  os.execute("sleep 5")
   TestData:store("Store LocalPT after test", constructPathToDatabase(), "final_policy.sqlite" )
   local checks = {
     {

--- a/test_scripts/Policies/Validation_of_PolicyTables/231_ATF_usage_and_error_counts_update_minutes_in_hmi_limited.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/231_ATF_usage_and_error_counts_update_minutes_in_hmi_limited.lua
@@ -469,6 +469,7 @@ function Test:StopSDL2()
 end
 
 function Test:CheckPTUinLocalPT()
+  os.execute("sleep 5")
   TestData:store("Store LocalPT after test", constructPathToDatabase(), "final_policy.sqlite" )
   local checks = {
     {

--- a/test_scripts/Policies/Validation_of_PolicyTables/232_ATF_usage_and_error_counts_update_minutes_in_hmi_full.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/232_ATF_usage_and_error_counts_update_minutes_in_hmi_full.lua
@@ -447,6 +447,7 @@ function Test:StopSDL2()
 end
 
 function Test:CheckPTUinLocalPT()
+  os.execute("sleep 5")
   TestData:store("Store LocalPT after test", constructPathToDatabase(), "final_policy.sqlite" )
   local checks = {
     {

--- a/test_scripts/Policies/Validation_of_PolicyTables/233_ATF_usage_and_error_counts_update_minutes_in_hmi_background.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/233_ATF_usage_and_error_counts_update_minutes_in_hmi_background.lua
@@ -449,6 +449,7 @@ function Test:StopSDL2()
 end
 
 function Test:CheckPTUinLocalPT()
+  os.execute("sleep 5")
   TestData:store("Store LocalPT after test", constructPathToDatabase(), "final_policy.sqlite" )
   local checks = {
     {

--- a/test_scripts/Policies/user_consent_of_Policies/221_ATF_Factory_reset.lua
+++ b/test_scripts/Policies/user_consent_of_Policies/221_ATF_Factory_reset.lua
@@ -26,6 +26,7 @@ local testCasesForPolicyTable = require ('user_modules/shared_testcases/testCase
 local mobile_session = require('mobile_session')
 local sdl = require('SDL')
 local utils = require ('user_modules/utils')
+local commonTestCases = require ('user_modules/shared_testcases/commonTestCases')
 
 --[[ Local Functions ]]
 
@@ -33,7 +34,7 @@ local function ReplacePreloadedFile()
   os.execute('cp ' .. config.pathToSDL .. 'sdl_preloaded_pt.json' .. ' ' .. config.pathToSDL .. 'backup_sdl_preloaded_pt.json')
   --os.execute('cp -f ' .. 'files/jsons/Policy/Related_HMI_API/OnAppPermissionConsent.json' .. ' ' .. config.pathToSDL .. 'sdl_preloaded_pt.json')
   os.execute('cp files/jsons/Policies/Related_HMI_API/OnAppPermissionConsent.json ' .. config.pathToSDL .. 'sdl_preloaded_pt.json')
-  os.execute('rm ' .. config.pathToSDL .. 'policy.sqlite')
+  os.execute('rm ' .. config.pathToSDL .. 'storage/policy.sqlite')
 end
 
 local function RestorePreloadedPT()
@@ -42,15 +43,14 @@ local function RestorePreloadedPT()
 end
 
 local function FACTORY_DEFAULTS(self)--, appNumber)
-  -- if appNumber == nil then
-  -- appNumber = 1
-  -- end
   self.hmiConnection:SendNotification("BasicCommunication.OnExitAllApplications",
     {
       reason = "FACTORY_DEFAULTS"
     })
-  --EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose", {})
-  --DelayedExp(1000)
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered")
+  EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
+  EXPECT_NOTIFICATION("OnAppInterfaceUnregistered", { reason = "IGNITION_OFF" })
+  commonTestCases:DelayedExp(5000)
 end
 
 --[[ General preconditions before ATF start]]
@@ -118,10 +118,6 @@ end
 
 function Test:Precondition_Execute_Factory_reset()
   FACTORY_DEFAULTS(self)
-end
-
-function Test.Precondition_Wait_SDL_stop()
-  os.execute("sleep 15")
 end
 
 --TODO(istoimenova): Remove when "[ATF] ATF stops execution of scripts at IGNITION_OFF." is resolved.

--- a/test_scripts/Smoke/Policies/001_PTU_all_flows.lua
+++ b/test_scripts/Smoke/Policies/001_PTU_all_flows.lua
@@ -34,6 +34,7 @@ local function allowSDL(self)
   -- sending notification OnAllowSDLFunctionality from HMI to allow connected device
   self.hmiConnection:SendNotification("SDL.OnAllowSDLFunctionality",
     { allowed = true, source = "GUI", device = { id = commonSmoke.getDeviceMAC(), name = commonSmoke.getDeviceName() }})
+  return commonSmoke.wait(500)
 end
 
 -- Start SDL and HMI, establish connection between SDL and HMI, open mobile connection via TCP
@@ -50,7 +51,6 @@ local function start(self)
               self:connectMobile()
               :Do(function()
                   commonFunctions:userPrint(35, "Mobile connected")
-                  allowSDL(self)
                 end)
             end)
         end)
@@ -238,7 +238,7 @@ end
 local function raiPTU(self)
   expOnStatusUpdate() -- temp solution due to issue in SDL:
   -- SDL.OnStatusUpdate(UPDATE_NEEDED) notification is sent before BC.OnAppRegistered (EXTERNAL_PROPRIETARY flow)
-
+  allowSDL(self):Do(function()
   -- creation mobile session
   self.mobileSession = mobile_session.MobileSession(self, self.mobileConnection)
   -- open RPC service in created session
@@ -311,6 +311,7 @@ local function raiPTU(self)
           :Times(2)
         end)
     end)
+  end)
 end
 
 -- Check update status

--- a/test_scripts/Smoke/commonSmoke.lua
+++ b/test_scripts/Smoke/commonSmoke.lua
@@ -35,6 +35,7 @@ commonSmoke.is_table_equal = commonFunctions.is_table_equal
 commonSmoke.read_parameter_from_smart_device_link_ini =  commonFunctions.read_parameter_from_smart_device_link_ini
 commonSmoke.GetPathToSDL = commonPreconditions.GetPathToSDL
 commonSmoke.jsonFileToTable = utils.jsonFileToTable
+commonSmoke.wait = utils.wait
 
 local preloadedPT = commonSmoke:read_parameter_from_smart_device_link_ini("PreloadedPT")
 

--- a/user_modules/sequences/actions.lua
+++ b/user_modules/sequences/actions.lua
@@ -567,6 +567,10 @@ local function registerApp(pAppId, pMobConnId, hasPTU)
             { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
           session:ExpectNotification("OnPermissionsChange")
           :Times(AnyNumber())
+          local policyMode = SDL.buildOptions.extendedPolicy
+          if policyMode == policyModes.P or policyMode == policyModes.EP then
+            session:ExpectNotification("OnSystemRequest", { requestType = "LOCK_SCREEN_ICON_URL" })
+          end
         end)
     end)
 end


### PR DESCRIPTION
Fixed issue [#2259](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2259)

This PR is **[ready]** for review.

### Summary
Improve stability of policy scripts - additional updates

### ATF version
develop

### Changelog
  - in `registerApp()` function of `actions` module added expectation on `OnSystemRequest(LOCK_SCREEN_ICON_URL)` message. It will make PTU sequence more stable since another  `OnSystemRequest` is also used in this sequence
 - in `001_PTU_all_flows.lua` added delay for `allowSDL` as in `action` module
 - in `002_ATF_HP_OnPermissionsChange_With_Assigned_Policy_After_App_Registration.lua` message to HMI is removed from ordering verification since Mobile and HMI connections are not depends on each other
 - in `186` delay is added before postconditions 
 - in `227`, `228` delay is added when system messages are send from HMI
 - in `227` - `233` delay is added before verification if Policy Database content since SDL need some time to Back up data
 - in `221` added expectation of additional messages when `FACTORY_DEFAULTS` is sent from HMI

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
