### PR TITLE
Make TheSameApp scripts stable by adding delay between requests

### DIFF
--- a/test_scripts/TheSameApp/Resumption/001_Resumption_IGNITION_OFF_same_app_on_different_devices.lua
+++ b/test_scripts/TheSameApp/Resumption/001_Resumption_IGNITION_OFF_same_app_on_different_devices.lua
@@ -86,7 +86,7 @@ end
 local function addContent(pAppId, pContentData)
   appData[pAppId] = { hmiAppId = common.app.getHMIId(pAppId) }
   common.addCommand(pAppId, pContentData.addCommand)
-  common.addSubMenu(pAppId, pContentData.addSubMenu)
+  common.run.runAfter(function() common.addSubMenu(pAppId, pContentData.addSubMenu) end, 100)
   common.mobile.getSession(pAppId):ExpectNotification("OnHashChange")
   :Do(function(exp, data)
       if exp.occurences == 2 then

--- a/test_scripts/TheSameApp/Resumption/002_Resumption_unexpected_disconnect_same_app_on_different_devices.lua
+++ b/test_scripts/TheSameApp/Resumption/002_Resumption_unexpected_disconnect_same_app_on_different_devices.lua
@@ -88,7 +88,7 @@ end
 local function addContent(pAppId, pContentData)
   appData[pAppId] = { hmiAppId = common.app.getHMIId(pAppId) }
   common.addCommand(pAppId, pContentData.addCommand)
-  common.addSubMenu(pAppId, pContentData.addSubMenu)
+  common.run.runAfter(function() common.addSubMenu(pAppId, pContentData.addSubMenu) end, 100)
   common.mobile.getSession(pAppId):ExpectNotification("OnHashChange")
   :Do(function(exp, data)
       if exp.occurences == 2 then


### PR DESCRIPTION
ATF Test Scripts to check #[2266](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2266)

This PR is **[ready]** for review.

### Summary
Added delay between consecutive `AddCommand` and `AddSubMenu` requests in order to SDL be able to send `OnHashChange` properly.

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
