### PR TITLE
move MenuLayoutsAvailable to WindowCapability

### DIFF
--- a/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
+++ b/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
@@ -26,7 +26,6 @@
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local commonSmoke = require('test_scripts/Smoke/commonSmoke')
-local hmi_values = require('user_modules/hmi_values')
 
 --[[ Local Variables ]]
 local addSubMenuParams = { 
@@ -44,8 +43,83 @@ local successResponse = {
   resultCode = "SUCCESS"
 }
 
+local onSystemCapabilityUpdatedParams = {
+  systemCapability = {
+    systemCapabilityType = "DISPLAYS",
+    displayCapabilities = {
+      {
+        displayName = "displayName",
+        windowTypeSupported = {
+          {
+            type = "MAIN",
+            maximumNumberOfWindows = 1
+          },
+          {
+            type = "WIDGET",
+            maximumNumberOfWindows = 2
+          }
+        },
+        windowCapabilities = {
+          {
+            menuLayoutsAvailable = { "LIST", "TILES" },
+            textFields = {
+              {
+                name = "mainField1",
+                characterSet = "TYPE2SET",
+                width = 1,
+                rows = 1
+              }
+            },
+            imageFields = {
+              {
+                name = "choiceImage",
+                imageTypeSupported = { "GRAPHIC_PNG"
+                },
+                imageResolution = {
+                  resolutionWidth = 35,
+                  resolutionHeight = 35
+                }
+              }
+            },
+            imageTypeSupported = {
+              "STATIC"
+            },
+            templatesAvailable = {
+              "Template1", "Template2", "Template3", "Template4", "Template5"
+            },
+            numCustomPresetsAvailable = 100,
+            buttonCapabilities = {
+              {
+                longPressAvailable = true,
+                name = "VOLUME_UP",
+                shortPressAvailable = true,
+                upDownAvailable = false
+              }
+            },
+            softButtonCapabilities = {
+              {
+                shortPressAvailable = true,
+                longPressAvailable = true,
+                upDownAvailable = true,
+                imageSupported = true,
+                textSupported = true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 --[[ Local Functions ]]
 local function setMenuLayoutTiles(self)
+  onSystemCapabilityUpdatedParams.appID = commonSmoke.getHMIAppId()
+  local cid0 = self.hmiConnection:SendNotification("BasicCommunication.OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
+  
+  onSystemCapabilityUpdatedParams.appID = nil
+  self.mobileSession1:ExpectNotification("OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
+
   local cid = self.mobileSession1:SendRPC("SetGlobalProperties", setGlobalPropertiesParams)
   
   EXPECT_HMICALL("UI.SetGlobalProperties", {})
@@ -63,16 +137,10 @@ local function setMenuLayoutTiles(self)
   end)
 end
 
-local function getHMIParams()
-  local params = hmi_values.getDefaultHMITable()
-  params.UI.GetCapabilities.params.displayCapabilities.menuLayoutsAvailable = { "LIST", "TILES" }
-  return params
-end
-
 --[[ Scenario ]]
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start, { getHMIParams() })
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
 runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 

--- a/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
+++ b/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
@@ -115,7 +115,7 @@ local onSystemCapabilityUpdatedParams = {
 --[[ Local Functions ]]
 local function setMenuLayoutTiles(self)
   onSystemCapabilityUpdatedParams.appID = commonSmoke.getHMIAppId()
-  local cid0 = self.hmiConnection:SendNotification("BasicCommunication.OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
+  self.hmiConnection:SendNotification("BasicCommunication.OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
   
   onSystemCapabilityUpdatedParams.appID = nil
   self.mobileSession1:ExpectNotification("OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)

--- a/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
+++ b/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
@@ -26,7 +26,6 @@
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
 local commonSmoke = require('test_scripts/Smoke/commonSmoke')
-local hmi_values = require('user_modules/hmi_values')
 
 --[[ Local Variables ]]
 local addSubMenuParams = { 
@@ -45,8 +44,83 @@ local warningsResponse = {
   resultCode = "WARNINGS"
 }
 
+local onSystemCapabilityUpdatedParams = {
+  systemCapability = {
+    systemCapabilityType = "DISPLAYS",
+    displayCapabilities = {
+      {
+        displayName = "displayName",
+        windowTypeSupported = {
+          {
+            type = "MAIN",
+            maximumNumberOfWindows = 1
+          },
+          {
+            type = "WIDGET",
+            maximumNumberOfWindows = 2
+          }
+        },
+        windowCapabilities = {
+          {
+            menuLayoutsAvailable = { "LIST" },
+            textFields = {
+              {
+                name = "mainField1",
+                characterSet = "TYPE2SET",
+                width = 1,
+                rows = 1
+              }
+            },
+            imageFields = {
+              {
+                name = "choiceImage",
+                imageTypeSupported = { "GRAPHIC_PNG"
+                },
+                imageResolution = {
+                  resolutionWidth = 35,
+                  resolutionHeight = 35
+                }
+              }
+            },
+            imageTypeSupported = {
+              "STATIC"
+            },
+            templatesAvailable = {
+              "Template1", "Template2", "Template3", "Template4", "Template5"
+            },
+            numCustomPresetsAvailable = 100,
+            buttonCapabilities = {
+              {
+                longPressAvailable = true,
+                name = "VOLUME_UP",
+                shortPressAvailable = true,
+                upDownAvailable = false
+              }
+            },
+            softButtonCapabilities = {
+              {
+                shortPressAvailable = true,
+                longPressAvailable = true,
+                upDownAvailable = true,
+                imageSupported = true,
+                textSupported = true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 --[[ Local Functions ]]
 local function setMenuLayoutTiles(self)
+  onSystemCapabilityUpdatedParams.appID = commonSmoke.getHMIAppId()
+  local cid0 = self.hmiConnection:SendNotification("BasicCommunication.OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
+  
+  onSystemCapabilityUpdatedParams.appID = nil
+  self.mobileSession1:ExpectNotification("OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
+
   local cid = self.mobileSession1:SendRPC("SetGlobalProperties", setGlobalPropertiesParams)
   
   EXPECT_HMICALL("UI.SetGlobalProperties", {})
@@ -64,16 +138,10 @@ local function setMenuLayoutTiles(self)
   end)
 end
 
-local function getHMIParams()
-  local params = hmi_values.getDefaultHMITable()
-  params.UI.GetCapabilities.params.displayCapabilities.menuLayoutsAvailable = { "LIST" }
-  return params
-end
-
 --[[ Scenario ]]
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start, { getHMIParams() })
+runner.Step("Start SDL, HMI, connect Mobile, start Session", commonSmoke.start)
 runner.Step("RAI", commonSmoke.registerApp)
 runner.Step("Activate App", commonSmoke.activateApp)
 

--- a/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
+++ b/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
@@ -116,7 +116,7 @@ local onSystemCapabilityUpdatedParams = {
 --[[ Local Functions ]]
 local function setMenuLayoutTiles(self)
   onSystemCapabilityUpdatedParams.appID = commonSmoke.getHMIAppId()
-  local cid0 = self.hmiConnection:SendNotification("BasicCommunication.OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
+  self.hmiConnection:SendNotification("BasicCommunication.OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
   
   onSystemCapabilityUpdatedParams.appID = nil
   self.mobileSession1:ExpectNotification("OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)


### PR DESCRIPTION
ATF Test Scripts to check #2925 

#2925 was closed with the expectation that this change would be made as part of the fix for #2918 

This PR is **ready** for review.

### Summary
`MenuLayoutsAvailable` is no longer a member of HMI capabilities and is not loaded by HMI values but instead by the `BasicCommunication.OnSystemCapabilityUpdated`

### ATF version
develop

### Changelog

##### Enhancements
* Updated tests to work with new core changes in [#3043](https://github.com/smartdevicelink/sdl_core/pull/3043)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
