### PR TITLE
Improve stability of API/049 script from smoke

### DIFF
--- a/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
+++ b/test_scripts/Smoke/API/049_SetMenuLayout_SUCCESS.lua
@@ -119,21 +119,22 @@ local function setMenuLayoutTiles(self)
   
   onSystemCapabilityUpdatedParams.appID = nil
   self.mobileSession1:ExpectNotification("OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
-
-  local cid = self.mobileSession1:SendRPC("SetGlobalProperties", setGlobalPropertiesParams)
+  :Do(function()
+    local cid = self.mobileSession1:SendRPC("SetGlobalProperties", setGlobalPropertiesParams)
   
-  EXPECT_HMICALL("UI.SetGlobalProperties", {})
-  :Do(function(_, data)
-    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    self.mobileSession1:ExpectResponse(cid, successResponse)
-  end)
+    EXPECT_HMICALL("UI.SetGlobalProperties", {})
+    :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+      self.mobileSession1:ExpectResponse(cid, successResponse)
+    end)
 
-  local cid2 = self.mobileSession1:SendRPC("AddSubMenu", addSubMenuParams)
+    local cid2 = self.mobileSession1:SendRPC("AddSubMenu", addSubMenuParams)
   
-  EXPECT_HMICALL("UI.AddSubMenu", {})
-  :Do(function(_, data)
-    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    self.mobileSession1:ExpectResponse(cid2, successResponse)
+    EXPECT_HMICALL("UI.AddSubMenu", {})
+    :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+      self.mobileSession1:ExpectResponse(cid2, successResponse)
+    end)
   end)
 end
 

--- a/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
+++ b/test_scripts/Smoke/API/050_SetMenuLayout_unsupported_WARNINGS.lua
@@ -120,21 +120,22 @@ local function setMenuLayoutTiles(self)
   
   onSystemCapabilityUpdatedParams.appID = nil
   self.mobileSession1:ExpectNotification("OnSystemCapabilityUpdated", onSystemCapabilityUpdatedParams)
-
-  local cid = self.mobileSession1:SendRPC("SetGlobalProperties", setGlobalPropertiesParams)
+  :Do(function()
+    local cid = self.mobileSession1:SendRPC("SetGlobalProperties", setGlobalPropertiesParams)
   
-  EXPECT_HMICALL("UI.SetGlobalProperties", {})
-  :Do(function(_, data)
-    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    self.mobileSession1:ExpectResponse(cid, warningsResponse)
-  end)
+    EXPECT_HMICALL("UI.SetGlobalProperties", {})
+    :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+      self.mobileSession1:ExpectResponse(cid, warningsResponse)
+    end)
 
-  local cid2 = self.mobileSession1:SendRPC("AddSubMenu", addSubMenuParams)
+    local cid2 = self.mobileSession1:SendRPC("AddSubMenu", addSubMenuParams)
   
-  EXPECT_HMICALL("UI.AddSubMenu", {})
-  :Do(function(_, data)
-    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    self.mobileSession1:ExpectResponse(cid2, warningsResponse)
+    EXPECT_HMICALL("UI.AddSubMenu", {})
+    :Do(function(_, data)
+      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+      self.mobileSession1:ExpectResponse(cid2, warningsResponse)
+    end)
   end)
 end
 


### PR DESCRIPTION
ATF Test Scripts to check #[2270](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2270)

This PR is **[ready]** for review.

### Summary
Implemented ordering of messages: `SetGlobalProperties` and `AddSubMenu` are send only after receiving of `OnSystemCapabilityUpdated`, 

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
