### PR TITLE
Update test to accept PTU with invalid params and pass rpc request tests

### DIFF
--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/045_PTU_unknown_types_of_parameters.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/045_PTU_unknown_types_of_parameters.lua
@@ -1,19 +1,19 @@
 ---------------------------------------------------------------------------------------------------
 -- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0173-Read-Generic-Network-Signal-data.md
 --
--- Description: Description: Processing PTU with invalid types of custom VD parameters
+-- Description: Description: Processing PTU with unknown types of custom VD parameters
 
 -- Precondition:
 -- 1. Preloaded file contains VehicleDataItems for all RPC spec VD
 -- 2. App is registered and activated
 -- 3. PTU is started
--- 4. The update received from cloud contains the custom VD items with invalid type of parameter
+-- 4. The update received from cloud contains the custom VD items with an unknown enum data type of parameter
 
 -- Sequence:
 -- 1. Mobile app requests RPC with RPC spec data
 --   a. SDL processes the request successfully
 -- 2. Mobile app requests RPC with custom data from PTU
---   a. SDL rejects requests with INVALID_DATA resultCode
+--   a. SDL processes the request successfully, allowing arbitrary string values for the modified parameter
 ---------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -25,6 +25,7 @@ runner.testSettings.isSelfIncluded = false
 --[[ Local Variables ]]
 common.writeCustomDataToGeneralArray(common.customDataTypeSample)
 common.setDefaultValuesForCustomData()
+common.VehicleDataItemsWithData.custom_vd_item1_integer.value = "FUTURE_VALUE"
 
 local appSessionId = 1
 local customData, rpcSpecData = common.getCustomAndRpcSpecDataNames()
@@ -36,9 +37,9 @@ runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 runner.Step("App registration", common.registerApp)
 runner.Step("App activation", common.activateApp)
 runner.Step("UpdateCustomDataTypeSample", common.updateCustomDataTypeSample,
-  {"custom_vd_item1_integer", "type", "Int" } )
+  {"custom_vd_item1_integer", "type", "FutureType" } )
 runner.Step("PTU with VehicleDataItems", common.policyTableUpdate,
-  { common.ptuFuncWithCustomData, common.expUpdateNeeded })
+  { common.ptuFuncWithCustomData })
 
 runner.Title("Test")
 for _, vehicleDataItem in pairs(rpcSpecData) do
@@ -59,14 +60,17 @@ for _, vehicleDataItem in pairs(rpcSpecData) do
   end
 end
 for _, vehicleDataItem in pairs(customData) do
-  runner.Step("SubscribeVehicleData INVALID_DATA " .. vehicleDataItem, common.errorRPCprocessing,
-    { appSessionId, vehicleDataItem, "SubscribeVehicleData", "INVALID_DATA" })
+  --if vehicleDataItem == "custom_vd_item1_integer" then
+  runner.Step("SubscribeVehicleData " .. vehicleDataItem, common.VDsubscription,
+    { appSessionId, vehicleDataItem, "SubscribeVehicleData" })
+  runner.Step("OnVehicleData " .. vehicleDataItem, common.onVD,
+    { appSessionId, vehicleDataItem })
+  runner.Step("GetVehicleData " .. vehicleDataItem, common.GetVD,
+    { appSessionId, vehicleDataItem })
+  runner.Step("UnsubscribeVehicleData CUSTOM_DATA " .. vehicleDataItem, common.VDsubscription,
+    { appSessionId, vehicleDataItem, "UnsubscribeVehicleData" })
   runner.Step("OnVehicleData " .. vehicleDataItem, common.onVD,
     { appSessionId, vehicleDataItem, common.VD.NOT_EXPECTED })
-  runner.Step("GetVehicleData INVALID_DATA " .. vehicleDataItem, common.errorRPCprocessing,
-    { appSessionId, vehicleDataItem, "GetVehicleData", "INVALID_DATA" })
-  runner.Step("UnsubscribeVehicleData INVALID_DATA " .. vehicleDataItem, common.errorRPCprocessing,
-    { appSessionId, vehicleDataItem, "UnsubscribeVehicleData", "INVALID_DATA" })
 end
 
 runner.Title("Postconditions")

--- a/test_sets/read_generic_network_signal_data.txt
+++ b/test_sets/read_generic_network_signal_data.txt
@@ -42,7 +42,7 @@
 ./test_scripts/API/VehicleData/GenericNetworkSignalData/042_Initial_data_in_PTU.lua
 ./test_scripts/API/VehicleData/GenericNetworkSignalData/043_VD_is_invalid_in_preloaded.lua
 ./test_scripts/API/VehicleData/GenericNetworkSignalData/044_PTU_missed_mandatory_parameter_in_VDI.lua
-./test_scripts/API/VehicleData/GenericNetworkSignalData/045_PTU_invalid_types_of_parameters.lua
+./test_scripts/API/VehicleData/GenericNetworkSignalData/045_PTU_unknown_types_of_parameters.lua
 ./test_scripts/API/VehicleData/GenericNetworkSignalData/046_PTU_missed_params_in_VDI_of_type_Struct.lua
 ./test_scripts/API/VehicleData/GenericNetworkSignalData/047_VDI_permissions_after_ptu_with_VDI_without_VD_schema_version.lua
 ./test_scripts/API/VehicleData/GenericNetworkSignalData/048_PTU_without_version_in_endpoint_properties.lua


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/sdl_core/pull/3062

This PR is **ready** for review.

### Summary
Update failing test after revisions to the Generic Network Signal Data proposal, allowing for unknown enum data types in a PTU

### ATF version
develop

### Changelog

##### Bug Fixes
* Modify PTU validation test to handle unknown enum data types

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
