### PR TITLE
Improve stability of scripts - additional updates

### DIFF
--- a/test_scripts/MobileProjection/Phase2/005_audioStreamingState_111-118.lua
+++ b/test_scripts/MobileProjection/Phase2/005_audioStreamingState_111-118.lua
@@ -88,12 +88,14 @@ local function appStartStreaming(pTC, pStreamingAppId, pAudioSSApp)
   common.getMobileSession(pStreamingAppId):ExpectNotification("OnHMIStatus")
   :Times(0)
   common.getMobileSession(notStreamingAppId):ExpectNotification("OnHMIStatus")
-  :Do(function()
-      RUN_AFTER(function() common.getMobileSession(pStreamingAppId):StopStreaming("files/MP3_1140kb.mp3") end, 500)
-    end)
   :ValidIf(function(_, data)
       return common.checkAudioSS(pTC, "App" .. notStreamingAppId, pAudioSSApp, data.payload.audioStreamingState)
     end)
+end
+
+local function stopStreaming(pStreamingAppId)
+  common.getHMIConnection():ExpectNotification("Navigation.OnAudioDataStreaming", { available = false })
+  common.getMobileSession(pStreamingAppId):StopStreaming("files/MP3_1140kb.mp3")
 end
 
 --[[ Scenario ]]
@@ -111,6 +113,7 @@ for n, tc in common.spairs(testCases) do
   runner.Step("Activate App 1", common.activateApp, { 1 })
   runner.Step("Activate App 2", common.activateApp, { 2 })
   runner.Step("App " .. tc.a .. " starts streaming", appStartStreaming, { n, tc.a, tc.s })
+  runner.Step("Stop streaming", stopStreaming, { tc.a })
   runner.Step("Clean sessions", common.cleanSessions)
   runner.Step("Stop SDL", common.postconditions)
 end

--- a/test_scripts/MobileProjection/Phase2/smoke/005_audioStreamingState_111-118.lua
+++ b/test_scripts/MobileProjection/Phase2/smoke/005_audioStreamingState_111-118.lua
@@ -53,12 +53,14 @@ local function appStartStreaming(pTC, pStreamingAppId, pAudioSSApp)
   common.getMobileSession(pStreamingAppId):ExpectNotification("OnHMIStatus")
   :Times(0)
   common.getMobileSession(notStreamingAppId):ExpectNotification("OnHMIStatus")
-  :Do(function()
-      RUN_AFTER(function() common.getMobileSession(pStreamingAppId):StopStreaming("files/MP3_1140kb.mp3") end, 500)
-    end)
   :ValidIf(function(_, data)
       return common.checkAudioSS(pTC, "App" .. notStreamingAppId, pAudioSSApp, data.payload.audioStreamingState)
     end)
+end
+
+local function stopStreaming(pStreamingAppId)
+  common.getHMIConnection():ExpectNotification("Navigation.OnAudioDataStreaming", { available = false })
+  common.getMobileSession(pStreamingAppId):StopStreaming("files/MP3_1140kb.mp3")
 end
 
 --[[ Scenario ]]
@@ -76,6 +78,7 @@ for n, tc in common.spairs(testCases) do
   runner.Step("Activate App 1", common.activateApp, { 1 })
   runner.Step("Activate App 2", common.activateApp, { 2 })
   runner.Step("App " .. tc.a .. " starts streaming", appStartStreaming, { n, tc.a, tc.s })
+  runner.Step("Stop streaming", stopStreaming, { tc.a })
   runner.Step("Clean sessions", common.cleanSessions)
   runner.Step("Stop SDL", common.postconditions)
 end

--- a/test_scripts/Policies/App_Permissions/022_ATF_No_Permission_Notification_To_HMI_In_First_App_Registration.lua
+++ b/test_scripts/Policies/App_Permissions/022_ATF_No_Permission_Notification_To_HMI_In_First_App_Registration.lua
@@ -87,12 +87,6 @@ function Test:TestStep_Firs_Time_Register_App_And_Check_That_No_Permission_Notif
       }
     })
   :Do(function(_,data)
-      if(order_communication ~= 1 and order_communication ~= 2) then
-        commonFunctions:printError("BasicCommunication.OnAppRegistered is not received 1 or 2 in message order. Real: received number: "..order_communication)
-        is_test_fail = true
-      end
-      order_communication = order_communication + 1
-
       self.hmiConnection:SendResponse(data.id,"BasicCommunication.ActivateApp", "SUCCESS", {})
     end)
   EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", {}):Times(0)
@@ -100,8 +94,8 @@ function Test:TestStep_Firs_Time_Register_App_And_Check_That_No_Permission_Notif
 
   EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
   :Do(function(_,_)
-      if(order_communication ~= 2 and order_communication ~= 1) then
-        commonFunctions:printError("RAI response is not received 1 or 2 in message order. Real: received number: "..order_communication)
+      if(order_communication ~= 1) then
+        commonFunctions:printError("RAI response is not received 1 in message order. Real: received number: "..order_communication)
         is_test_fail = true
       end
       order_communication = order_communication + 1
@@ -109,8 +103,8 @@ function Test:TestStep_Firs_Time_Register_App_And_Check_That_No_Permission_Notif
 
   EXPECT_NOTIFICATION("OnHMIStatus", {hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN"})
   :Do(function(_,_)
-      if(order_communication ~= 3) then
-        commonFunctions:printError("OnHMIStatus is not received 3 in message order. Real: received number: "..order_communication)
+      if(order_communication ~= 2) then
+        commonFunctions:printError("OnHMIStatus is not received 2 in message order. Real: received number: "..order_communication)
         is_test_fail = true
       end
       order_communication = order_communication + 1
@@ -118,8 +112,8 @@ function Test:TestStep_Firs_Time_Register_App_And_Check_That_No_Permission_Notif
 
   EXPECT_NOTIFICATION("OnPermissionsChange", {})
   :Do(function(_,_)
-      if(order_communication ~= 4) then
-        commonFunctions:printError("OnPermissionsChange is not received 4 in message order. Real: received number: "..order_communication)
+      if(order_communication ~= 3) then
+        commonFunctions:printError("OnPermissionsChange is not received 3 in message order. Real: received number: "..order_communication)
         is_test_fail = true
       end
 

--- a/test_scripts/Policies/build_options/072_ATF_PTU_PM_Sets_Status_UPDATE_NEEDED_HTTP.lua
+++ b/test_scripts/Policies/build_options/072_ATF_PTU_PM_Sets_Status_UPDATE_NEEDED_HTTP.lua
@@ -157,7 +157,7 @@ function Test:ValidateResult()
   print("Expected: " .. r_expected_timeout)
   print("Actual: " .. r_actual_timeout)
   -- tolerance 2 sec.
-  if (r_actual_timeout < r_expected_timeout) or (r_actual_timeout > r_expected_timeout + 1) then
+  if (r_actual_timeout < r_expected_timeout - 1) or (r_actual_timeout > r_expected_timeout + 1) then
     local msg = "\nExpected timeout '" .. r_expected_timeout .. "', actual '" .. r_actual_timeout .. "'"
     self:FailTestCase(msg)
   end


### PR DESCRIPTION
ATF Test Scripts to check #[2276](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2276)

This PR is **[ready]** for review.

### Summary
  - Scripts `005_audioStreamingState_111-118` may abort to the following reason:
Function `StopStreaming` was defined in callback of `OnHMIStatus`.
In this case if app stops streaming SDL sends 2nd `OnHMIStatus` message with `audioStreamingState=AUDIBLE` which is correct.
However this may lead to 2nd invocation of the same callback with `StopStreaming` function and ATF in this case can't stop streaming which is already stopped.
Fix is to move `StopStreaming` function to a separate step.
  - Script `022_ATF_No_Permission_Notification_To_HMI_In_First_App_Registration` may fail due to the reason that `BC.OnAppRegistered` may be sent in a different order than expected. However it's Ok from SDL perspective since messages on HMI and Mobile connections are sent asynchronously.
Fix is to remove this notification from order verification since it belongs to HMI connection and leave only messages related to Mobile connection  .
  - Script `072_ATF_PTU_PM_Sets_Status_UPDATE_NEEDED_HTTP` may fail due to the fact that actual timeout could be 1 sec lower than expected
Fix is to add tolerance to lower boundary as it currently defined for upper boundary.

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
