### PR TITLE
Added the expectation of the OnHMILevel(NONE)

### DIFF
--- a/test_scripts/API/ServiceStatusUpdateToHMI/001_1_Video_service_protected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/001_1_Video_service_protected.lua
@@ -24,6 +24,7 @@
 --   - finish TLS handshake successfully
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = true) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -41,6 +42,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_RECEIVED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() },
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/001_2_Audio_service_protected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/001_2_Audio_service_protected.lua
@@ -24,6 +24,7 @@
 --   - finish TLS handshake successfully
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = true) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -41,6 +42,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_RECEIVED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() },
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/001_3_RPC_service_protected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/001_3_RPC_service_protected.lua
@@ -24,6 +24,7 @@
 --   - finish TLS handshake successfully
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = true) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -41,6 +42,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_RECEIVED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() },
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/002_1_Video_service_unprotected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/002_1_Video_service_unprotected.lua
@@ -15,6 +15,7 @@
 --   - not start PTU sequence
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -51,6 +52,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_RECEIVED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() },
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 --[[ Scenario ]]

--- a/test_scripts/API/ServiceStatusUpdateToHMI/002_2_Audio_service_unprotected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/002_2_Audio_service_unprotected.lua
@@ -15,6 +15,7 @@
 --   - not start PTU sequence
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -54,6 +55,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_RECEIVED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() },
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId() })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 --[[ Scenario ]]

--- a/test_scripts/API/ServiceStatusUpdateToHMI/002_3_RPC_service_unprotected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/002_3_RPC_service_unprotected.lua
@@ -15,6 +15,7 @@
 --   - not start PTU sequence
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -61,6 +62,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     end
     return true
   end)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 --[[ Scenario ]]

--- a/test_scripts/API/ServiceStatusUpdateToHMI/002_5_Audio_service_unprotected_force_protected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/002_5_Audio_service_unprotected_force_protected.lua
@@ -16,6 +16,8 @@
 --   - not start PTU sequence
 --   - send OnServiceUpdate (<service_type>, REQUEST_REJECTED, PROTECTION_ENFORCED) to HMI
 --   - send StartServiceNACK(<service_type>, encryption = false) to App
+--   - send BC.CloseApplication to HMI
+--   - send OnHMIStatus(NONE) to mobile app
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -56,6 +58,14 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_REJECTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "PROTECTION_ENFORCED"  })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication", { appID = common.getHMIAppId() })
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus",
+    { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
 end
 
 --[[ Scenario ]]

--- a/test_scripts/API/ServiceStatusUpdateToHMI/004_Unprotected_service_GetSystemTime_Rejected_INVALID_TIME.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/004_Unprotected_service_GetSystemTime_Rejected_INVALID_TIME.lua
@@ -18,6 +18,7 @@
 -- SDL does:
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED, PROTECTION_DISABLED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -41,6 +42,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "PROTECTION_DISABLED" })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/006_Unprotected_service_GetSystemTime_invalid_response_INVALID_TIME.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/006_Unprotected_service_GetSystemTime_invalid_response_INVALID_TIME.lua
@@ -18,6 +18,7 @@
 -- SDL does:
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED, PROTECTION_DISABLED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -41,6 +42,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "PROTECTION_DISABLED" })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/007_Protected_service_GetSystemTime_no_response_INVALID_TIME.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/007_Protected_service_GetSystemTime_no_response_INVALID_TIME.lua
@@ -18,6 +18,8 @@
 -- SDL does:
 --   - send OnServiceUpdate (<service_type>, REQUEST_REJECTED, INVALID_TIME) to HMI
 --   - send StartServiceNACK(<service_type>, encryption = false) to App
+--   - send BC.CloseApplication to HMI
+--   - send OnHMIStatus(NONE) to mobile app
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -41,6 +43,14 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_REJECTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "INVALID_TIME" })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication", { appID = common.getHMIAppId() })
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus",
+    { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
 end
 
 function common.serviceResponseFunc(pServiceId)
@@ -68,6 +78,7 @@ runner.Step("App activation", common.activateApp)
 runner.Title("Test")
 runner.Step("Start Video Service protected, REJECTED",
   common.startServiceWithOnServiceUpdate, { videoServiceId, 0, 1 })
+runner.Step("App activation", common.activateApp)
 runner.Step("Start Audio Service protected, REJECTED",
   common.startServiceWithOnServiceUpdate, { audioServiceId, 0, 1 })
 

--- a/test_scripts/API/ServiceStatusUpdateToHMI/008_Unprotected_service_GetSystemTime_no_response_INVALID_TIME.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/008_Unprotected_service_GetSystemTime_no_response_INVALID_TIME.lua
@@ -18,6 +18,7 @@
 -- SDL does:
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED, PROTECTION_DISABLED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -41,6 +42,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "PROTECTION_DISABLED" })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/012_Unprotected_service_mobile_INVALID_CERT.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/012_Unprotected_service_mobile_INVALID_CERT.lua
@@ -26,6 +26,7 @@
 --   - finish TLS handshake unsuccessfully
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED, PROTECTION_DISABLED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -45,6 +46,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "PROTECTION_DISABLED" })
     :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/013_Protected_service_INVALID_CERT.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/013_Protected_service_INVALID_CERT.lua
@@ -22,6 +22,8 @@
 --   - send OnStatusUpdate(UP_TO_DATE) to HMI
 --   - send OnServiceUpdate (<service_type>, REQUEST_REJECTED, INVALID_CERT) to HMI
 --   - send StartServiceNACK(<service_type>, encryption = false) to App
+--   - send BC.CloseApplication to HMI
+--   - send OnHMIStatus(NONE) to mobile app
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -47,6 +49,14 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_REJECTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "INVALID_CERT" })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication", { appID = common.getHMIAppId() })
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus",
+    { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
 end
 
 function common.serviceResponseFunc(pServiceId)
@@ -69,6 +79,7 @@ runner.Step("App activation", common.activateApp)
 
 runner.Title("Test")
 runner.Step("Start Video Service protected, REJECTED", common.startServiceWithOnServiceUpdate, { videoServiceId, 0, 1 })
+runner.Step("App activation", common.activateApp)
 runner.Step("Start Audio Service protected, REJECTED", common.startServiceWithOnServiceUpdate, { audioServiceId, 0, 1 })
 
 runner.Title("Postconditions")

--- a/test_scripts/API/ServiceStatusUpdateToHMI/014_Unprotected_service_INVALID_CERT.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/014_Unprotected_service_INVALID_CERT.lua
@@ -22,6 +22,7 @@
 --   - send OnStatusUpdate(UP_TO_DATE) to HMI
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED, PROTECTION_DISABLED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -47,6 +48,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
    { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
      reason = "PROTECTION_DISABLED" })
    :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/016_Unprotected_service_sdl_cert_expire_in_24hr_INVALID_CERT.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/016_Unprotected_service_sdl_cert_expire_in_24hr_INVALID_CERT.lua
@@ -23,6 +23,7 @@
 --   - send OnStatusUpdate(UP_TO_DATE) to HMI
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED, PROTECTION_DISABLED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -57,6 +58,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "PROTECTION_DISABLED" })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/017_Protected_service_DecryptCertificate_rejected_INVALID_CERT_external.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/017_Protected_service_DecryptCertificate_rejected_INVALID_CERT_external.lua
@@ -26,6 +26,8 @@
 -- SDL does:
 --   - send OnServiceUpdate(<service_type>, REQUEST_REJECTED, INVALID_CERT) to HMI
 --   - send StartServiceNACK(<service_type>, encryption = false) to App
+--   - send BC.CloseApplication to HMI
+--   - send OnHMIStatus(NONE) to mobile app
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -50,6 +52,14 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_REJECTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "INVALID_CERT" })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication", { appID = common.getHMIAppId() })
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus",
+    { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
 end
 
 function common.serviceResponseFunc(pServiceId)
@@ -72,6 +82,7 @@ runner.Step("App activation", common.activateApp)
 
 runner.Title("Test")
 runner.Step("Start Video Service protected, REJECTED", common.startServiceWithOnServiceUpdate, { videoServiceId, 0, 1 })
+runner.Step("App activation", common.activateApp)
 runner.Step("Start Audio Service protected, REJECTED", common.startServiceWithOnServiceUpdate, { audioServiceId, 0, 1 })
 
 runner.Title("Postconditions")

--- a/test_scripts/API/ServiceStatusUpdateToHMI/018_Unprotected_service_DecryptCertificate_rejected_INVALID_CERT_external.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/018_Unprotected_service_DecryptCertificate_rejected_INVALID_CERT_external.lua
@@ -26,6 +26,7 @@
 -- SDL does:
 --   - send OnServiceUpdate(<service_type>, REQUEST_ACCEPTED, PROTECTION_DISABLED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -50,6 +51,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(),
       reason = "PROTECTION_DISABLED" })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/019_Video_Audio_service_protected_several_apps.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/019_Video_Audio_service_protected_several_apps.lua
@@ -31,6 +31,7 @@
 --   - send OnServiceUpdate (<service_type>, REQUEST_RECEIVED) to HMI
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = true) to App_1
+--   - leave the app in current HMI level
 -- 6) App_2 does steps 1) - 5) with the same messages and results
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
@@ -54,6 +55,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue, pAppId)
     { serviceEvent = "REQUEST_RECEIVED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(pAppId) },
     { serviceEvent = "REQUEST_ACCEPTED", serviceType = pServiceTypeValue, appID = common.getHMIAppId(pAppId) })
   :Times(2)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession(pAppId):ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId, pAppId)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/020_Video_service_protected_PTU_FAILED_TimeOut_2_failed_external.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/020_Video_service_protected_PTU_FAILED_TimeOut_2_failed_external.lua
@@ -53,6 +53,16 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     end)
   :Times(2)
   :Timeout(timeout)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication", { appID = common.getHMIAppId() })
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
+  :Timeout(timeout)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus",
+    { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+  :Timeout(timeout)
 end
 
 function common.serviceResponseFunc(pServiceId)
@@ -149,6 +159,8 @@ runner.Title("PTU 1")
 runner.Step("Start " .. common.serviceData[serviceId].serviceType .. " service protected, REJECTED",
   startServiceWithOnServiceUpdate_PTU_FAILED, { serviceId, 0, 1, 1 })
 runner.Step("Check result", common.checkResult, { result })
+
+runner.Step("App activation", common.activateApp)
 
 runner.Title("PTU 2")
 runner.Step("Start " .. common.serviceData[serviceId].serviceType .. " service protected, REJECTED",

--- a/test_scripts/API/ServiceStatusUpdateToHMI/022_Video_service_protected_PTU_FAILED_TimeOut_failed_success_2rd_try_failed_external.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/022_Video_service_protected_PTU_FAILED_TimeOut_failed_success_2rd_try_failed_external.lua
@@ -144,6 +144,16 @@ local function startServiceWithOnServiceUpdate_INVALID_CERT_2nd_try(pServiceId, 
       end)
     :Times(2)
     :Timeout(timeout)
+
+    common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication", { appID = common.getHMIAppId() })
+    :Do(function(_, data)
+        common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+      end)
+    :Timeout(timeout)
+
+    common.getMobileSession():ExpectNotification("OnHMIStatus",
+      { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+    :Timeout(timeout)
   end
   common.startServiceWithOnServiceUpdate(pServiceId, pHandShakeExpeTimes, pGSTExpTimes)
 end
@@ -165,6 +175,16 @@ local function startServiceWithOnServiceUpdate_PTU_FAILED(pServiceId, pHandShake
         end
       end)
     :Times(2)
+    :Timeout(timeout)
+
+    common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication", { appID = common.getHMIAppId() })
+    :Do(function(_, data)
+        common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+      end)
+    :Timeout(timeout)
+
+    common.getMobileSession():ExpectNotification("OnHMIStatus",
+      { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
     :Timeout(timeout)
   end
   local curRetry = 0
@@ -244,9 +264,13 @@ runner.Step("Start " .. common.serviceData[serviceId].serviceType .. " service p
     startServiceWithOnServiceUpdate_PTU_FAILED, { serviceId, 0, 1, 1 })
 runner.Step("Check result", common.checkResult, { result })
 
+runner.Step("App activation", common.activateApp)
+
 runner.Title("PTU 2")
 runner.Step("Start " .. common.serviceData[serviceId].serviceType .. " service protected, REJECTED, INVALID_CERT",
   startServiceWithOnServiceUpdate_INVALID_CERT_2nd_try, { serviceId, 0, 1 })
+
+runner.Step("App activation", common.activateApp)
 
 runner.Title("PTU 3")
 runner.Step("Start " .. common.serviceData[serviceId].serviceType .. " service protected, REJECTED, PTU_FAILED",

--- a/test_scripts/API/ServiceStatusUpdateToHMI/023_Video_service_protected_PTU_FAILED_TimeOut_unprotected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/023_Video_service_protected_PTU_FAILED_TimeOut_unprotected.lua
@@ -23,6 +23,7 @@
 --   - send OnStatusUpdate(UPDATE_NEEDED) to HMI
 --   - send OnServiceUpdate (<service_type>, REQUEST_ACCEPTED, PROTECTION_DISABLED) to HMI
 --   - send StartServiceACK(<service_type>, encryption = false) to App
+--   - leave the app in current HMI level
 -----------------------------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local runner = require('user_modules/script_runner')
@@ -64,6 +65,12 @@ function common.onServiceUpdateFunc(pServiceTypeValue)
     end)
   :Times(2)
   :Timeout(timeout)
+
+  common.getHMIConnection():ExpectRequest("BasicCommunication.CloseApplication")
+  :Times(0)
+
+  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  :Times(0)
 end
 
 function common.serviceResponseFunc(pServiceId)


### PR DESCRIPTION
ATF Test Scripts to check #[3073](https://github.com/smartdevicelink/sdl_core/issues/3073)

This PR is **ready** for review.

### Summary
Added the expectation of the OnHMILevel(NONE) notification according to https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0211-ServiceStatusUpdateToHMI.md

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
