### PR TITLE
Increase timeout for Alert response

### DIFF
--- a/test_scripts/Policies/user_consent_of_Policies/214_ATF_User_consent_prompt_persists.lua
+++ b/test_scripts/Policies/user_consent_of_Policies/214_ATF_User_consent_prompt_persists.lua
@@ -318,6 +318,7 @@ function Test:Precondition_PTU_user_consent_prompt_present()
     local RequestAlert = self.mobileSession:SendRPC("Alert", {alertText1 = "alertText1"})
 
     EXPECT_RESPONSE(RequestAlert, {success = false, resultCode = "GENERIC_ERROR"})
+    :Timeout(20000)
   end
 
   --Location-1 is disallowed by user


### PR DESCRIPTION
Update due to changes introduced by fix for [#1880](https://github.com/smartdevicelink/sdl_core/issues/1880)

This PR is **[ready]** for review.

### Summary
According to [#1880](https://github.com/smartdevicelink/sdl_core/issues/1880) timeout is calculated by the formulae:
```
DefaultTimeout(from .ini file) + RPCs_internal_timeout
```
Fix is to increase default timeout for Alert response

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
