### PR TITLE
Make IgnitionOff function more stable

### DIFF
--- a/test_scripts/TheSameApp/commonTheSameApp.lua
+++ b/test_scripts/TheSameApp/commonTheSameApp.lua
@@ -627,6 +627,7 @@ function common.rpcRejectWithConsent(pAppId, pModuleType)
 end
 
 function common.ignitionOff(pDevices, pExpFunc)
+  config.ExitOnCrash = false
   local isOnSDLCloseSent = false
   local hmi = common.hmi.getConnection()
   if pExpFunc then pExpFunc() end
@@ -647,6 +648,7 @@ function common.ignitionOff(pDevices, pExpFunc)
       for i in pairs(pDevices) do
         common.mobile.deleteConnection(i)
       end
+      RUN_AFTER(function() config.ExitOnCrash = true end, 500)
     end)
 end
 


### PR DESCRIPTION
ATF Test Scripts to fix #[2278](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2284)

This PR is **[ready]** for review.

### Summary
During script execution ATF checks SDL status every 400ms in `CheckStatus()` function in `modules/testbase.lua` module.
In case if SDL process is stopped ATF will abort script and report corresponding status.
Fix is to let ATF know that SDL could be in stopped state by setting `config.ExitOnCrash` parameter and to continue script execution.

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
