### PR TITLE
Fix/iAP tests corrupting INI file

### DIFF
--- a/test_scripts/iAP2TransportSwitch/common.lua
+++ b/test_scripts/iAP2TransportSwitch/common.lua
@@ -16,6 +16,7 @@ local mobile = require("mobile_connection")
 local events = require("events")
 local expectations = require('expectations')
 local module = require("user_modules/dummy_connecttest")
+local actions = require('user_modules/sequences/actions')
 
 --[[ Local Variables ]]
 local Expectation = expectations.Expectation
@@ -120,13 +121,14 @@ function m.preconditions()
   commonSteps:DeletePolicyTable()
   commonPreconditions:BackupFile(ptFileName)
   os.execute("cp -f " .. ptName .. " " .. commonPreconditions:GetPathToSDL() .. "/" .. ptFileName)
-  commonFunctions:SetValuesInIniFile("AppTransportChangeTimer%s-=%s-[%d]-%s-\n", "AppTransportChangeTimer", "5000")
+  actions.setSDLIniParameter("AppTransportChangeTimer", "5000")
 end
 
 function m.postconditions()
   SDL:StopSDL()
   local ptFileName = commonFunctions:read_parameter_from_smart_device_link_ini("PreloadedPT")
   commonPreconditions:RestoreFile(ptFileName)
+  actions.restoreSDLIniParameters()
 end
 
 function m:start()


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Currently the iAP2TransportSwitch tests corrupt the `smartDeviceLink.ini` since the common file doesn't have a backup step for the INI file

This PR adds backup and restore steps for the INI file in `iAP2TransportSwitch/common.lua`

### ATF version
[develop](https://github.com/smartdevicelink/sdl_atf/tree/develop)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
