### PR TITLE
Fix sdl sending of PerformInteraction unsuccess response to mobile in case choice id selected via VR

### DIFF
--- a/test_scripts/SDL5_0/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
+++ b/test_scripts/SDL5_0/Transfer_RPC_with_invalid_image/005_PerfomInteraction.lua
@@ -300,7 +300,7 @@ local function PI_PerformViaBOTH(paramsSend)
       RUN_AFTER(uiResponse, 30)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI("BOTH")
-  common.getMobileSession():ExpectResponse(cid, { success = false, resultCode = "WARNINGS",
+  common.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "WARNINGS",
     info = "Requested image(s) not found., Perform Interaction error response." })
 end
 

--- a/test_scripts/Smoke/API/012_PerfomInteraction_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/012_PerfomInteraction_PositiveCase_SUCCESS.lua
@@ -385,6 +385,114 @@ local function PI_PerformViaBOTH(paramsSend, self)
   self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "TIMED_OUT" })
 end
 
+--! @PI_PerformViaBOTHuiChoice: Processing PI with interaction mode BOTH with user choice on UI part
+--! @parameters:
+--! paramsSend - parameters for PI request
+--! self - test object
+--! @return: none
+local function PI_PerformViaBOTHuiChoice(paramsSend, self)
+  paramsSend.interactionMode = "BOTH"
+  local cid = self.mobileSession1:SendRPC("PerformInteraction",paramsSend)
+  EXPECT_HMICALL("VR.PerformInteraction", {
+      helpPrompt = paramsSend.helpPrompt,
+      initialPrompt = paramsSend.initialPrompt,
+      timeout = paramsSend.timeout,
+      timeoutPrompt = paramsSend.timeoutPrompt
+    })
+  :Do(function(_,data)
+      self.hmiConnection:SendNotification("VR.Started")
+      self.hmiConnection:SendNotification("TTS.Started")
+      SendOnSystemContext(self,"VRSESSION")
+      local function firstSpeakTimeOut()
+        self.hmiConnection:SendNotification("TTS.Stopped")
+        self.hmiConnection:SendNotification("TTS.Started")
+      end
+      RUN_AFTER(firstSpeakTimeOut, 1000)
+      local function vrResponse()
+        self.hmiConnection:SendError(data.id, data.method, "TIMED_OUT", "Perform Interaction error response.")
+        self.hmiConnection:SendNotification("VR.Stopped")
+      end
+      RUN_AFTER(vrResponse, 2000)
+    end)
+  EXPECT_HMICALL("UI.PerformInteraction", {
+      timeout = paramsSend.timeout,
+      choiceSet = setExChoiceSet(paramsSend.interactionChoiceSetIDList),
+      initialText = {
+        fieldName = "initialInteractionText",
+        fieldText = paramsSend.initialText
+      },
+      vrHelp = paramsSend.vrHelp,
+      vrHelpTitle = paramsSend.initialText
+    })
+  :Do(function(_,data)
+      local function choiceIconDisplayed()
+        SendOnSystemContext(self,"HMI_OBSCURED")
+      end
+      RUN_AFTER(choiceIconDisplayed, 2050)
+      local function uiResponse()
+        self.hmiConnection:SendNotification("TTS.Stopped")
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+          { choiceID = paramsSend.interactionChoiceSetIDList[1] })
+        SendOnSystemContext(self,"MAIN")
+      end
+      RUN_AFTER(uiResponse, 3000)
+    end)
+  ExpectOnHMIStatusWithAudioStateChanged_PI(self, "BOTH")
+  self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+  choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "MENU" })
+end
+
+--! @PI_PerformViaBOTHvrChoice: Processing PI with interaction mode BOTH with user choice on VR part
+--! @parameters:
+--! paramsSend - parameters for PI request
+--! self - test object
+--! @return: none
+local function PI_PerformViaBOTHvrChoice(paramsSend, self)
+  paramsSend.interactionMode = "BOTH"
+  local cid = self.mobileSession1:SendRPC("PerformInteraction",paramsSend)
+  EXPECT_HMICALL("VR.PerformInteraction", {
+      helpPrompt = paramsSend.helpPrompt,
+      initialPrompt = paramsSend.initialPrompt,
+      timeout = paramsSend.timeout,
+      timeoutPrompt = paramsSend.timeoutPrompt
+    })
+  :Do(function(_,data)
+      self.hmiConnection:SendNotification("TTS.Started")
+      self.hmiConnection:SendNotification("VR.Started")
+      SendOnSystemContext(self,"VRSESSION")
+      local function firstSpeakTimeOut()
+        self.hmiConnection:SendNotification("TTS.Stopped")
+      end
+      RUN_AFTER(firstSpeakTimeOut, 1000)
+      local function vrResponse()
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+          { choiceID = paramsSend.interactionChoiceSetIDList[1] })
+        self.hmiConnection:SendNotification("VR.Stopped")
+        SendOnSystemContext(self, "MAIN")
+      end
+      RUN_AFTER(vrResponse, 2000)
+    end)
+  EXPECT_HMICALL("UI.PerformInteraction", {
+      timeout = paramsSend.timeout,
+      choiceSet = setExChoiceSet(paramsSend.interactionChoiceSetIDList),
+      initialText = {
+        fieldName = "initialInteractionText",
+        fieldText = paramsSend.initialText
+      },
+      vrHelp = paramsSend.vrHelp,
+      vrHelpTitle = paramsSend.initialText
+    })
+  :Do(function(_,data)
+      EXPECT_HMICALL("UI.ClosePopUp", { methodName = "UI.PerformInteraction" })
+        :Do(function()
+          self.hmiConnection:SendError(data.id, data.method, "ABORTED", "Error message")
+        end)
+    end)
+  ExpectOnHMIStatusWithAudioStateChanged_PI(self, "VR")
+  self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+  choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "VR" })
+end
+
 --[[ Scenario ]]
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
@@ -400,8 +508,11 @@ runner.Step("CreateInteractionChoiceSet no VR commands with id 400", CreateInter
 runner.Title("Test")
 runner.Step("PerformInteraction with VR_ONLY interaction mode", PI_PerformViaVR_ONLY, {requestParams})
 runner.Step("PerformInteraction with MANUAL_ONLY interaction mode", PI_PerformViaMANUAL_ONLY, {requestParams})
-runner.Step("PerformInteraction with MANUAL_ONLY interaction mode no VR commands", PI_PerformViaMANUAL_ONLY, {requestParams_noVR})
-runner.Step("PerformInteraction with BOTH interaction mode", PI_PerformViaBOTH, {requestParams})
+runner.Step("PerformInteraction with MANUAL_ONLY interaction mode no VR commands", PI_PerformViaMANUAL_ONLY,
+  {requestParams_noVR})
+runner.Step("PerformInteraction with BOTH interaction mode TIMED_OUT", PI_PerformViaBOTH, {requestParams})
+runner.Step("PerformInteraction with BOTH interaction mode choice via UI", PI_PerformViaBOTHuiChoice, {requestParams})
+runner.Step("PerformInteraction with BOTH interaction mode choice via VR", PI_PerformViaBOTHvrChoice, {requestParams})
 
 
 runner.Title("Postconditions")

--- a/test_scripts/Smoke/API/012_PerfomInteraction_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/012_PerfomInteraction_PositiveCase_SUCCESS.lua
@@ -282,7 +282,10 @@ local function PI_PerformViaVR_ONLY(paramsSend, self)
       vrHelpTitle = paramsSend.initialText,
     })
   :Do(function(_,data)
-      self.hmiConnection:SendResponse( data.id, data.method, "SUCCESS", { } )
+      EXPECT_HMICALL("UI.ClosePopUp", { methodName = "UI.PerformInteraction" })
+        :Do(function()
+          self.hmiConnection:SendError(data.id, data.method, "ABORTED", "Error message")
+        end)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI(self, "VR")
   self.mobileSession1:ExpectResponse(cid,
@@ -439,7 +442,7 @@ local function PI_PerformViaBOTHuiChoice(paramsSend, self)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI(self, "BOTH")
   self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-  choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "MENU" })
+    choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "MENU" })
 end
 
 --! @PI_PerformViaBOTHvrChoice: Processing PI with interaction mode BOTH with user choice on VR part
@@ -490,7 +493,7 @@ local function PI_PerformViaBOTHvrChoice(paramsSend, self)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI(self, "VR")
   self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-  choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "VR" })
+    choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "VR" })
 end
 
 --[[ Scenario ]]

--- a/test_scripts/Smoke/API/039_PerfomInteraction_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/039_PerfomInteraction_Non_Media_PositiveCase_SUCCESS.lua
@@ -127,11 +127,11 @@ local function SendOnSystemContext(self, ctx)
     { appID = commonSmoke.getHMIAppId(), systemContext = ctx })
 end
 
---! @setExChoiseSet: ChoiceSet structure for UI.PerformInteraction request
+--! @setExChoiceSet: ChoiceSet structure for UI.PerformInteraction request
 --! @parameters:
 --! choiceIDValues - value of choice id
 --! @return: none
-local function setExChoiseSet(choiceIDValues)
+local function setExChoiceSet(choiceIDValues)
   local exChoiceSet = { }
   for i = 1, #choiceIDValues do
     exChoiceSet[i] = {
@@ -254,7 +254,7 @@ local function PI_PerformViaMANUAL_ONLY(paramsSend, self)
     end)
   EXPECT_HMICALL("UI.PerformInteraction", {
       timeout = paramsSend.timeout,
-      choiceSet = setExChoiseSet(paramsSend.interactionChoiceSetIDList),
+      choiceSet = setExChoiceSet(paramsSend.interactionChoiceSetIDList),
       initialText = {
         fieldName = "initialInteractionText",
         fieldText = paramsSend.initialText
@@ -306,7 +306,7 @@ local function PI_PerformViaBOTH(paramsSend, self)
     end)
   EXPECT_HMICALL("UI.PerformInteraction", {
       timeout = paramsSend.timeout,
-      choiceSet = setExChoiseSet(paramsSend.interactionChoiceSetIDList),
+      choiceSet = setExChoiceSet(paramsSend.interactionChoiceSetIDList),
       initialText = {
         fieldName = "initialInteractionText",
         fieldText = paramsSend.initialText
@@ -330,6 +330,114 @@ local function PI_PerformViaBOTH(paramsSend, self)
   self.mobileSession1:ExpectResponse(cid, { success = false, resultCode = "TIMED_OUT" })
 end
 
+--! @PI_PerformViaBOTHuiChoice: Processing PI with interaction mode BOTH with user choice on UI part
+--! @parameters:
+--! paramsSend - parameters for PI request
+--! self - test object
+--! @return: none
+local function PI_PerformViaBOTHuiChoice(paramsSend, self)
+  paramsSend.interactionMode = "BOTH"
+  local cid = self.mobileSession1:SendRPC("PerformInteraction",paramsSend)
+  EXPECT_HMICALL("VR.PerformInteraction", {
+      helpPrompt = paramsSend.helpPrompt,
+      initialPrompt = paramsSend.initialPrompt,
+      timeout = paramsSend.timeout,
+      timeoutPrompt = paramsSend.timeoutPrompt
+    })
+  :Do(function(_,data)
+      self.hmiConnection:SendNotification("VR.Started")
+      self.hmiConnection:SendNotification("TTS.Started")
+      SendOnSystemContext(self,"VRSESSION")
+      local function firstSpeakTimeOut()
+        self.hmiConnection:SendNotification("TTS.Stopped")
+        self.hmiConnection:SendNotification("TTS.Started")
+      end
+      RUN_AFTER(firstSpeakTimeOut, 1000)
+      local function vrResponse()
+        self.hmiConnection:SendError(data.id, data.method, "TIMED_OUT", "Perform Interaction error response.")
+        self.hmiConnection:SendNotification("VR.Stopped")
+      end
+      RUN_AFTER(vrResponse, 2000)
+    end)
+  EXPECT_HMICALL("UI.PerformInteraction", {
+      timeout = paramsSend.timeout,
+      choiceSet = setExChoiceSet(paramsSend.interactionChoiceSetIDList),
+      initialText = {
+        fieldName = "initialInteractionText",
+        fieldText = paramsSend.initialText
+      },
+      vrHelp = paramsSend.vrHelp,
+      vrHelpTitle = paramsSend.initialText
+    })
+  :Do(function(_,data)
+      local function choiceIconDisplayed()
+        SendOnSystemContext(self,"HMI_OBSCURED")
+      end
+      RUN_AFTER(choiceIconDisplayed, 2050)
+      local function uiResponse()
+        self.hmiConnection:SendNotification("TTS.Stopped")
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+          { choiceID = paramsSend.interactionChoiceSetIDList[1] })
+        SendOnSystemContext(self,"MAIN")
+      end
+      RUN_AFTER(uiResponse, 3000)
+    end)
+  ExpectOnHMIStatusWithAudioStateChanged_PI(self, "BOTH")
+  self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+  choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "MENU" })
+end
+
+--! @PI_PerformViaBOTHvrChoice: Processing PI with interaction mode BOTH with user choice on VR part
+--! @parameters:
+--! paramsSend - parameters for PI request
+--! self - test object
+--! @return: none
+local function PI_PerformViaBOTHvrChoice(paramsSend, self)
+  paramsSend.interactionMode = "BOTH"
+  local cid = self.mobileSession1:SendRPC("PerformInteraction",paramsSend)
+  EXPECT_HMICALL("VR.PerformInteraction", {
+      helpPrompt = paramsSend.helpPrompt,
+      initialPrompt = paramsSend.initialPrompt,
+      timeout = paramsSend.timeout,
+      timeoutPrompt = paramsSend.timeoutPrompt
+    })
+  :Do(function(_,data)
+      self.hmiConnection:SendNotification("TTS.Started")
+      self.hmiConnection:SendNotification("VR.Started")
+      SendOnSystemContext(self,"VRSESSION")
+      local function firstSpeakTimeOut()
+        self.hmiConnection:SendNotification("TTS.Stopped")
+      end
+      RUN_AFTER(firstSpeakTimeOut, 1000)
+      local function vrResponse()
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS",
+          { choiceID = paramsSend.interactionChoiceSetIDList[1] })
+        self.hmiConnection:SendNotification("VR.Stopped")
+        SendOnSystemContext(self, "MAIN")
+      end
+      RUN_AFTER(vrResponse, 2000)
+    end)
+  EXPECT_HMICALL("UI.PerformInteraction", {
+      timeout = paramsSend.timeout,
+      choiceSet = setExChoiceSet(paramsSend.interactionChoiceSetIDList),
+      initialText = {
+        fieldName = "initialInteractionText",
+        fieldText = paramsSend.initialText
+      },
+      vrHelp = paramsSend.vrHelp,
+      vrHelpTitle = paramsSend.initialText
+    })
+  :Do(function(_,data)
+      EXPECT_HMICALL("UI.ClosePopUp", { methodName = "UI.PerformInteraction" })
+        :Do(function()
+          self.hmiConnection:SendError(data.id, data.method, "ABORTED", "Error message")
+        end)
+    end)
+  ExpectOnHMIStatusWithAudioStateChanged_PI(self, "VR")
+  self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+  choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "VR" })
+end
+
 --[[ Scenario ]]
 runner.Title("Preconditions")
 runner.Step("Clean environment", commonSmoke.preconditions)
@@ -344,7 +452,9 @@ runner.Step("CreateInteractionChoiceSet with id 300", CreateInteractionChoiceSet
 runner.Title("Test")
 runner.Step("PerformInteraction with VR_ONLY interaction mode", PI_PerformViaVR_ONLY, {requestParams})
 runner.Step("PerformInteraction with MANUAL_ONLY interaction mode", PI_PerformViaMANUAL_ONLY, {requestParams})
-runner.Step("PerformInteraction with BOTH interaction mode", PI_PerformViaBOTH, {requestParams})
+runner.Step("PerformInteraction with BOTH interaction mode TIMED_OUT", PI_PerformViaBOTH, {requestParams})
+runner.Step("PerformInteraction with BOTH interaction mode choice via UI", PI_PerformViaBOTHuiChoice, {requestParams})
+runner.Step("PerformInteraction with BOTH interaction mode choice via VR", PI_PerformViaBOTHvrChoice, {requestParams})
 
 runner.Title("Postconditions")
 runner.Step("Stop SDL", commonSmoke.postconditions)

--- a/test_scripts/Smoke/API/039_PerfomInteraction_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/039_PerfomInteraction_Non_Media_PositiveCase_SUCCESS.lua
@@ -96,11 +96,11 @@ local requestParams = {
 
 --[[ Local Functions ]]
 
---! @setChoiseSet: Creates Choice structure
+--! @setChoiceSet: Creates Choice structure
 --! @parameters:
 --! choiceIDValue - Id for created choice
 --! @return: table of created choice structure
-local function setChoiseSet(choiceIDValue)
+local function setChoiceSet(choiceIDValue)
   local temp = {
     {
       choiceID = choiceIDValue,
@@ -180,7 +180,7 @@ local function CreateInteractionChoiceSet(choiceSetID, self)
   local choiceID = choiceSetID
   local cid = self.mobileSession1:SendRPC("CreateInteractionChoiceSet", {
       interactionChoiceSetID = choiceSetID,
-      choiceSet = setChoiseSet(choiceID),
+      choiceSet = setChoiceSet(choiceID),
     })
   EXPECT_HMICALL("VR.AddCommand", {
       cmdID = choiceID,
@@ -227,7 +227,10 @@ local function PI_PerformViaVR_ONLY(paramsSend, self)
       vrHelpTitle = paramsSend.initialText,
     })
   :Do(function(_,data)
-      self.hmiConnection:SendResponse( data.id, data.method, "SUCCESS", { } )
+      EXPECT_HMICALL("UI.ClosePopUp", { methodName = "UI.PerformInteraction" })
+        :Do(function()
+          self.hmiConnection:SendError(data.id, data.method, "ABORTED", "Error message")
+        end)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI(self, "VR")
   self.mobileSession1:ExpectResponse(cid,
@@ -384,7 +387,7 @@ local function PI_PerformViaBOTHuiChoice(paramsSend, self)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI(self, "BOTH")
   self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-  choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "MENU" })
+    choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "MENU" })
 end
 
 --! @PI_PerformViaBOTHvrChoice: Processing PI with interaction mode BOTH with user choice on VR part
@@ -435,7 +438,7 @@ local function PI_PerformViaBOTHvrChoice(paramsSend, self)
     end)
   ExpectOnHMIStatusWithAudioStateChanged_PI(self, "VR")
   self.mobileSession1:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
-  choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "VR" })
+    choiceID = paramsSend.interactionChoiceSetIDList[1], triggerSource = "VR" })
 end
 
 --[[ Scenario ]]

--- a/test_scripts/WidgetSupport/OnHMIStatus/007_SystemContext_from_MAIN_to_VRSESSION_and_HMI_OBSCURED_for_the_main_and_a_widget_windows.lua
+++ b/test_scripts/WidgetSupport/OnHMIStatus/007_SystemContext_from_MAIN_to_VRSESSION_and_HMI_OBSCURED_for_the_main_and_a_widget_windows.lua
@@ -119,12 +119,11 @@ local function performInteraction(pAppId)
     RUN_AFTER(choiceIconDisplayed, 25)
     local function uiResponse()
       common.getHMIConnection():SendNotification("TTS.Stopped")
-      common.getHMIConnection():SendError(data.id, data.method, "TIMED_OUT")
+      common.getHMIConnection():SendError(data.id, data.method, "TIMED_OUT", "Perform Interaction error response.")
       sendOnSystemContext("MAIN", pMainId)
       sendOnSystemContext("MAIN", params.windowID)
     end
     RUN_AFTER(uiResponse, 30)
-    common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
   end)
   common.getMobileSession(pAppId):ExpectNotification("OnHMIStatus",
   { systemContext = "MAIN", hmiLevel = "FULL", windowID = pMainId },


### PR DESCRIPTION
ATF Test Scripts to check [#2830](https://github.com/smartdevicelink/sdl_core/issues/2830) & [#3112](https://github.com/smartdevicelink/sdl_core/issues/3112)

This PR is **ready** for review.

### Summary
Added cases for PerformInteraction response handling in VR only/BOTH modes
Updated existing tests.

### ATF version
develop

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
