### PR TITLE
Align scripts for 3142 with fix for 3123

### DIFF
--- a/test_scripts/Defects/6_1/3142_01_Absence_of_misplaced_OnVideoDataStreaming.lua
+++ b/test_scripts/Defects/6_1/3142_01_Absence_of_misplaced_OnVideoDataStreaming.lua
@@ -11,6 +11,10 @@
 -- 7. App_1 and App_2 continue streaming data within 'StopStreamingTimeout' timeout
 -- SDL does:
 --   - switch streaming between apps and provides HMI with streaming data from App_2
+--     - sends 'Navi.StopStream' for App_1
+--     - sends Navi.OnVideoDataStreaming(false)
+--     - sends 'Navi.StartStream' for App_2
+--     - sends Navi.OnVideoDataStreaming(true)
 --   - not unregister App_1 since timeout is not yet expired
 -- 8. App_1 stops streaming within 'StopStreamingTimeout' timeout
 -- SDL does:
@@ -29,11 +33,12 @@ common.app.getParams(1).appHMIType = { "NAVIGATION" }
 common.app.getParams(2).appHMIType = { "NAVIGATION" }
 
 --[[ Local Functions ]]
-local function stopStreaming(pAppId, pServiceId)
+local function stopStreaming(pAppId)
   common.hmi.getConnection():ExpectRequest("Navigation.StopStream", { appID = common.app.getHMIId(pAppId)})
-  :Do(function(_, data) common.hmi.getConnection():SendResponse(data.id, data.method, "SUCCESS", { }) end)
-  common.mobile.getSession(pAppId):ExpectEndService(pServiceId)
-  :Do(function() common.mobile.getSession(pAppId):SendEndServiceAck(pServiceId) end)
+  :Do(function(_, data)
+      common.log("Navigation.StopStream for App " .. pAppId)
+      common.hmi.getConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
 end
 
 local function startStreaming(pAppId, pServiceId)
@@ -44,7 +49,10 @@ local function startStreaming(pAppId, pServiceId)
       common.streamingStatus[pAppId] = true
     end)
   common.hmi.getConnection():ExpectRequest("Navigation.StartStream", { appID = common.app.getHMIId(pAppId) })
-  :Do(function(_, data) common.hmi.getConnection():SendResponse(data.id, data.method, "SUCCESS", { }) end)
+  :Do(function(_, data)
+      common.log("Navigation.StartStream for App " .. pAppId)
+      common.hmi.getConnection():SendResponse(data.id, data.method, "SUCCESS", { })
+    end)
 end
 
 local function activateApp2()
@@ -53,9 +61,12 @@ local function activateApp2()
   common.mobile.getSession(2):ExpectNotification("OnHMIStatus",
     { hmiLevel = "FULL", videoStreamingState = "STREAMABLE" })
   :Do(function()
+      stopStreaming(1, 11)
       startStreaming(2, 11)
     end)
-  common.hmi.getConnection():ExpectNotification("Navigation.OnVideoDataStreaming"):Times(0)
+  common.hmi.getConnection():ExpectNotification("Navigation.OnVideoDataStreaming",
+    { available = false }, { available = true })
+  :Times(2)
 end
 
 local function stopStreamingWONotification()


### PR DESCRIPTION
Fixed issue #2345

This PR is **[ready]** for review.

### Summary
Existing expectation are modified to conform the logic described in [#3123](https://github.com/smartdevicelink/sdl_core/issues/3123)

### ATF version
develop

### Changelog
In case if 1st app is currently streaming and 2nd app is activated and starts streaming the following messages are sent to HMI:
- `Navi.StopStream` for App_1
- `Navi.OnVideoDataStreaming(false)`
- `Navi.StartStream` for App_2
- `Navi.OnVideoDataStreaming(true)`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
