### PR TITLE
Align scripts with fix for 2932

### DIFF
--- a/test_scripts/Policies/build_options/052_ATF_PTU_Trigger_IGN_Cycles_HTTP.lua
+++ b/test_scripts/Policies/build_options/052_ATF_PTU_Trigger_IGN_Cycles_HTTP.lua
@@ -206,7 +206,7 @@ function Test:TestStep_Register_app()
       self.mobileSession:ExpectResponse(correlationId, { success = true, resultCode = "SUCCESS" })
       self.mobileSession:ExpectNotification("OnHMIStatus", {hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN"})
     end)
-  EXPECT_NOTIFICATION("OnSystemRequest"):Times(2)-- {requestType = "LOCK_SCREEN_ICON_URL"}, {requestType = "HTTP"}
+  EXPECT_NOTIFICATION("OnSystemRequest")
   EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate")
   :ValidIf(function(exp,data)
       if exp.occurences == 1 and data.params.status == "UPDATE_NEEDED" then

--- a/test_scripts/Policies/build_options/053_ATF_Policy_Table_Update_Trigger_After_N_Days_HTTP.lua
+++ b/test_scripts/Policies/build_options/053_ATF_Policy_Table_Update_Trigger_After_N_Days_HTTP.lua
@@ -118,7 +118,7 @@ function Test:TestStep_Register_App_And_Check_That_PTU_Triggered()
 
   EXPECT_HMICALL("BasicCommunication.PolicyUpdate"):Times(0)
   EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status="UPDATE_NEEDED" }, { status="UPDATING" }):Times(2)
-  EXPECT_NOTIFICATION("OnSystemRequest"):Times(2) -- { requestType = "LOCK_SCREEN_ICON_URL" }, { requestType = "HTTP" }
+  EXPECT_NOTIFICATION("OnSystemRequest")
 
 end
 

--- a/test_scripts/Policies/build_options/078_ATF_PTU_HMI_Level_Affected_Apps_FULL_LIMITED_HTTP.lua
+++ b/test_scripts/Policies/build_options/078_ATF_PTU_HMI_Level_Affected_Apps_FULL_LIMITED_HTTP.lua
@@ -141,7 +141,7 @@ function Test:TestStep_RegisterSecondApp()
       self.mobileSession1:ExpectNotification("OnPermissionsChange")
     end)
 
-  self.mobileSession1:ExpectNotification("OnSystemRequest"):Times(Between(1,2)) --"LOCK_SCREEN_ICON_URL" + HTTP
+  self.mobileSession1:ExpectNotification("OnSystemRequest"):Times(Between(0,1)) --HTTP
   :Do(function(_,data)
       print("SDL -> MOB2: OnSystemRequest, requestType: " .. data.payload.requestType)
       if(data.payload.requestType == "HTTP") then

--- a/test_scripts/Policies/build_options/101_ATF_SDL_Build_EXTENDED_POLICY_HTTP.lua
+++ b/test_scripts/Policies/build_options/101_ATF_SDL_Build_EXTENDED_POLICY_HTTP.lua
@@ -56,7 +56,7 @@ function Test:TestStep_Trigger_PTU_Check_HTTP_flow()
   local corId = self.mobileSession2:SendRPC("RegisterAppInterface", config.application2.registerAppInterfaceParams)
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { appName = config.application2.registerAppInterfaceParams.appName }})
 
-  self.mobileSession2:ExpectNotification("OnSystemRequest"):Times(Between(1,2))
+  self.mobileSession2:ExpectNotification("OnSystemRequest"):Times(Between(0,1))
   :Do(function(_,data)
       print("SDL-> MOB2: OnSystemRequest, requestType: "..data.payload.requestType)
       if(data.payload.requestType == "HTTP") then

--- a/test_scripts/Policies/build_options/118_ATF_Request_PTU_Trigger_App_Excluded_PT_HTTP.lua
+++ b/test_scripts/Policies/build_options/118_ATF_Request_PTU_Trigger_App_Excluded_PT_HTTP.lua
@@ -82,7 +82,7 @@ function Test:TestStep_PTU_AppID_SecondApp_NotListed_PT()
         end
       end
     end)
-  :Times(Between(1,2))
+  :Times(Between(0,1))
 
   self.mobileSession:ExpectNotification("OnSystemRequest")
   :Do(function(_, data)


### PR DESCRIPTION
Fixed issue #2349

This PR is **[ready]** for review.

### Summary
Some policy scripts expect to receive `OnSystemRequest(LOCK_SCREEN_ICON_URL)` even if no endpoint

### ATF version
develop

### Changelog
In case if no endpoint expectation on `OnSystemRequest(LOCK_SCREEN_ICON_URL)` is removed

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
