### PR TITLE
Actualization of the script 221_ATF_Factory_reset

### DIFF
--- a/test_scripts/Policies/user_consent_of_Policies/221_ATF_Factory_reset.lua
+++ b/test_scripts/Policies/user_consent_of_Policies/221_ATF_Factory_reset.lua
@@ -49,7 +49,7 @@ local function FACTORY_DEFAULTS(self)--, appNumber)
     })
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered")
   EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
-  EXPECT_NOTIFICATION("OnAppInterfaceUnregistered", { reason = "IGNITION_OFF" })
+  EXPECT_NOTIFICATION("OnAppInterfaceUnregistered", { reason = "FACTORY_DEFAULTS" })
   commonTestCases:DelayedExp(5000)
 end
 


### PR DESCRIPTION
Fix for #2355

This PR is **[ready]** for review.

### Summary
Change incorrect reason in OnAppInterfaceUnregistered from IGNITION_OFF to FACTORY_DEFAULTS according to requirements.

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
