### PR TITLE
Add closeSession to unregisterApp

### DIFF
--- a/test_scripts/Defects/6_1/3267_1_RAI_OnSystemRequest_LOCK_SCREEN_ICON_URL.lua
+++ b/test_scripts/Defects/6_1/3267_1_RAI_OnSystemRequest_LOCK_SCREEN_ICON_URL.lua
@@ -36,7 +36,6 @@ local function registerAppWOPTU(pAppId)
       mobileSession:ExpectNotification("OnSystemRequest", { requestType = "LOCK_SCREEN_ICON_URL" })
     end)
   end)
-  utils.wait(500)
 end
 
 --[[ Scenario ]]

--- a/user_modules/sequences/actions.lua
+++ b/user_modules/sequences/actions.lua
@@ -715,7 +715,7 @@ function m.app.unRegister(pAppId)
     { unexpectedDisconnect = false, appID = m.app.getHMIId(pAppId) })
   :Do(function()
     m.app.deleteHMIId(pAppId)
-    m.mobile.deleteSession(pAppId)
+    m.mobile.closeSession(pAppId)
     end)
 end
 


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Update fixed an issue with `HeartBeat` which is still continue works when application has been unregistered and session has removed.

### ATF version
develop

### Changelog
 - Replace `deleteSession()` by `closeSession()` in app.unRegister() in `actions` module
Function `closeSession()` invokes both `deleteSession()` and `session:Stop()` which is also invokes `StopHeartbeat()`
 - Remove delay in script for `3267` that was added previously in [#2378](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2378) 
This delay is not required anymore

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
