### PR TITLE
Fix RC scripts within persisting hmi cpabilities 

### DIFF
--- a/test_scripts/RC/CLIMATE_RADIO/Capabilities/008_Default_capabilities_if_HMI_doesnt_respond_to_RC_IsReady_and_doesnt_respond_to_RC_GetCapabilities_RADIO.lua
+++ b/test_scripts/RC/CLIMATE_RADIO/Capabilities/008_Default_capabilities_if_HMI_doesnt_respond_to_RC_IsReady_and_doesnt_respond_to_RC_GetCapabilities_RADIO.lua
@@ -34,12 +34,17 @@ local function getHMIParams()
   return params
 end
 
+local function start(pHMIParams)
+  commonRC.start(pHMIParams)
+  commonRC.wait(11000)
+end
+
 --[[ Scenario ]]
 runner.Title("Preconditions")
 runner.Step("Backup HMI capabilities file", commonRC.backupHMICapabilities)
 runner.Step("Update HMI capabilities file", commonRC.updateDefaultCapabilities, { { disabledModule } })
 runner.Step("Clean environment", commonRC.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", commonRC.start, { getHMIParams() })
+runner.Step("Start SDL, HMI, connect Mobile, start Session", start, { getHMIParams() })
 runner.Step("RAI", commonRC.registerAppWOPTU)
 runner.Step("Activate App", commonRC.activateApp)
 

--- a/test_scripts/RC/CLIMATE_RADIO/Capabilities/009_Default_capabilities_if_HMI_doesnt_respond_to_RC_IsReady_and_doesnt_respond_to_RC_GetCapabilities_CLIMATE.lua
+++ b/test_scripts/RC/CLIMATE_RADIO/Capabilities/009_Default_capabilities_if_HMI_doesnt_respond_to_RC_IsReady_and_doesnt_respond_to_RC_GetCapabilities_CLIMATE.lua
@@ -34,12 +34,17 @@ local function getHMIParams()
   return params
 end
 
+local function start(pHMIParams)
+  commonRC.start(pHMIParams)
+  commonRC.wait(11000)
+end
+
 --[[ Scenario ]]
 runner.Title("Preconditions")
 runner.Step("Backup HMI capabilities file", commonRC.backupHMICapabilities)
 runner.Step("Update HMI capabilities file", commonRC.updateDefaultCapabilities, { { disabledModule } })
 runner.Step("Clean environment", commonRC.preconditions)
-runner.Step("Start SDL, HMI, connect Mobile, start Session", commonRC.start, { getHMIParams() })
+runner.Step("Start SDL, HMI, connect Mobile, start Session", start, { getHMIParams() })
 runner.Step("RAI", commonRC.registerAppWOPTU)
 runner.Step("Activate App", commonRC.activateApp)
 

--- a/test_scripts/RC/CLIMATE_RADIO/Capabilities/014_Default_capabilities_if_HMI_doesnt_respond_to_RC_IsReady_and_doesnt_respond_to_RC_GetCapabilities.lua
+++ b/test_scripts/RC/CLIMATE_RADIO/Capabilities/014_Default_capabilities_if_HMI_doesnt_respond_to_RC_IsReady_and_doesnt_respond_to_RC_GetCapabilities.lua
@@ -31,7 +31,7 @@ end
 
 local function updateDefaultHMIcapabilities()
   local defaultHMIcapabilities = commonRC.HMICap.get()
-  defaultHMIcapabilitiesRC = defaultHMIcapabilities.UI.systemCapabilities.remoteControlCapability
+  defaultHMIcapabilitiesRC = defaultHMIcapabilities.RC.remoteControlCapability
   defaultHMIcapabilitiesRC.climateControlCapabilities[1].climateEnableAvailable = false
   defaultHMIcapabilitiesRC.radioControlCapabilities[1].availableHdChannelsAvailable = false
   commonRC.HMICap.set(defaultHMIcapabilities)

--- a/test_scripts/RC/commonRC.lua
+++ b/test_scripts/RC/commonRC.lua
@@ -968,7 +968,7 @@ end
 
 function commonRC.updateDefaultCapabilities(pDisabledModuleTypes, pIsHmiCapCorrect)
   local hmiCapTbl = SDL.HMICap.get()
-  local rcCapTbl = hmiCapTbl.UI.systemCapabilities.remoteControlCapability
+  local rcCapTbl = hmiCapTbl.RC.remoteControlCapability
   if not pIsHmiCapCorrect then
     updateModuleId(rcCapTbl)
   end


### PR DESCRIPTION
This PR is **[not ready]** for review.

### Summary
There are following updates:
  Update according to changes in hmi_capabilities.json for RC 
  Add delay to avoid holding for RAI sequence due to the "DefaultTimeout" for RC.GetCapabilities response 

### ATF version
[ATF version to use]

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
