### PR TITLE
Improve stability of scripts #3

### DIFF
--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/036_4_Subscribtion_after_removing_VD_from_permissions_from_1_app_2_apps.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/036_4_Subscribtion_after_removing_VD_from_permissions_from_1_app_2_apps.lua
@@ -139,10 +139,10 @@ runner.Step("Set ApplicationListUpdateTimeout=4000", common.setSDLIniParameter,
   { "ApplicationListUpdateTimeout", 4000 })
 runner.Step("App1 registration", common.registerAppWOPTU, {appSessionId1})
 runner.Step("App2 registration", common.registerAppWOPTU, {appSessionId2})
+runner.Step("PTU with VehicleDataItems", common.ptuWithPolicyUpdateReq,
+  { common.ptuFuncWithCustomData2Apps })
 runner.Step("App1 activation", common.activateApp, {appSessionId1})
 runner.Step("App2 activation", common.activateApp, {appSessionId2})
-runner.Step("PTU with VehicleDataItems", common.policyTableUpdateWithOnPermChange,
-  { common.ptuFuncWithCustomData2Apps })
 
 runner.Title("Test")
 runner.Step("App1 SubscribeVehicleData " .. itemToRemove, common.VDsubscription,

--- a/test_scripts/API/VehicleData/GenericNetworkSignalData/036_5_Subscribtion_after_removing_VD_from_permissions_from_2_apps.lua
+++ b/test_scripts/API/VehicleData/GenericNetworkSignalData/036_5_Subscribtion_after_removing_VD_from_permissions_from_2_apps.lua
@@ -164,10 +164,10 @@ runner.Step("Set ApplicationListUpdateTimeout=4000", common.setSDLIniParameter,
   { "ApplicationListUpdateTimeout", 4000 })
 runner.Step("App1 registration", common.registerAppWOPTU, {appSessionId1})
 runner.Step("App2 registration", common.registerAppWOPTU, {appSessionId2})
+runner.Step("PTU with VehicleDataItems", common.ptuWithPolicyUpdateReq,
+  { common.ptuFuncWithCustomData2Apps })
 runner.Step("App1 activation", common.activateApp, {appSessionId1})
 runner.Step("App2 activation", common.activateApp, {appSessionId2})
-runner.Step("PTU with VehicleDataItems", common.policyTableUpdateWithOnPermChange,
-  { common.ptuFuncWithCustomData2Apps })
 
 runner.Title("Test")
 runner.Step("App1 SubscribeVehicleData " .. itemToRemove, common.VDsubscription,

--- a/test_scripts/Defects/6_1/common_3139_3140_3142.lua
+++ b/test_scripts/Defects/6_1/common_3139_3140_3142.lua
@@ -30,6 +30,7 @@ m.seq = {
   app1 = {},
   app2 = {}
 }
+actions.minTimeout = 1000
 
 --[[ Proxy Functions ]]
 m.start = actions.start

--- a/user_modules/sequences/actions.lua
+++ b/user_modules/sequences/actions.lua
@@ -698,7 +698,7 @@ function m.app.activate(pAppId)
   local requestId = m.hmi.getConnection():SendRequest("SDL.ActivateApp", { appID = m.app.getHMIId(pAppId) })
   m.hmi.getConnection():ExpectResponse(requestId)
   m.mobile.getSession(pAppId):ExpectNotification("OnHMIStatus", { hmiLevel = "FULL", systemContext = "MAIN" })
-  if m.mobile.getAppsCount() > 1 then m.run.wait(500) end
+  if m.mobile.getAppsCount() > 1 then m.run.wait(m.minTimeout) end
 end
 
 --[[ @app.unRegister: perform unregistration of application sequence


### PR DESCRIPTION
Various fixes related to scripts stability.

This PR is **ready** for review.

### Summary
Various fixes related to scripts stability and maintenance.

### ATF version
develop

### Changelog
 - In two scripts for the `RGNSD` there was an issue for `HTTP` flow due to missing call of `isPTUStarted` function. `policyTableUpdateWithOnPermChange` function is replaced by `ptuWithPolicyUpdateReq` one which has such call.
 - Sometimes `500ms` timeout for app activation is not enough especially for `EXTERNAL_PROPRIETARY` policy flow, so for issues related to streaming this timeout is increased

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
