### PR TITLE
Add validation to PT snapshot creation for webengine

### DIFF
--- a/test_scripts/WebEngine/026_PTU_snapshot_validation.lua
+++ b/test_scripts/WebEngine/026_PTU_snapshot_validation.lua
@@ -38,7 +38,7 @@ local appPropExpected = {
   nicknames = { "Test Web Application_21", "Test Web Application_22" },
   auth_token = "ABCD12345",
   cloud_transport_type = "WS",
-  enabled = "true",
+  enabled = true,
   hybrid_app_preference = "CLOUD"
 }
 

--- a/test_scripts/WebEngine/028_PTU_snapshot_validation_no_app_connected.lua
+++ b/test_scripts/WebEngine/028_PTU_snapshot_validation_no_app_connected.lua
@@ -10,11 +10,13 @@
 -- 1. HMI sends BC.SetAppProperties request with new application properties of the policyAppID to SDL
 --  a. SDL sends successful response to HMI
 --  b. PTU is triggered, SDL sends UPDATE_NEDDED to HMI
---  с. PTS is created with application properties of the policyAppID and other mandatory fields
+--  с. PTS is created with application properties of the policyAppID and other mandatory pts
 --------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local common = require('test_scripts/WebEngine/commonWebEngine')
+local hmi_ptu = require('test_scripts/Policies/HMI_PTU/common_hmi_ptu')
+
 
 --[[ Local Variables ]]
 local  appStoreConfig = {
@@ -62,8 +64,6 @@ common.Step("Clean environment", common.preconditions)
 common.Step("Start SDL, HMI, connect regular mobile, start Session", common.start)
 
 common.Title("Test")
-common.Step("RAI", common.registerApp)
-common.Step("PTU", common.policyTableUpdate, { PTUfunc })
 common.Step("SetAppProperties request to check: PTU is triggered", setAppProperties, { appProperties })
 common.Step("Validate PTS", common.verifyPTSnapshot, { appProperties, appPropExpected })
 

--- a/test_scripts/WebEngine/028_PTU_snapshot_validation_no_app_connected.lua
+++ b/test_scripts/WebEngine/028_PTU_snapshot_validation_no_app_connected.lua
@@ -38,7 +38,7 @@ local appPropExpected = {
   nicknames = { "Test Web Application_21", "Test Web Application_22" },
   auth_token = "ABCD12345",
   cloud_transport_type = "WS",
-  enabled = "true",
+  enabled = true,
   hybrid_app_preference = "CLOUD"
 }
 

--- a/test_scripts/WebEngine/commonWebEngine.lua
+++ b/test_scripts/WebEngine/commonWebEngine.lua
@@ -385,11 +385,7 @@ function common.verifyPTSnapshot(appProperties, appPropExpected)
   end
 
   local enabled = snp_tbl.policy_table.app_policies[app_id].enabled
-<<<<<<< HEAD
   if (enabled ~= appPropExpected.enabled) then
-=======
-  if not (enabled == appPropExpected.enabled) then
->>>>>>> d9e55795a736d48f675b39f7b75475bb0d803ed6
     msg = msg .. "Incorrect enabled value\n"..
       " Expected: " .. tostring(appPropExpected.enabled) .. "\n" ..
       " Actual: " .. tostring(enabled) .. "\n"

--- a/test_scripts/WebEngine/commonWebEngine.lua
+++ b/test_scripts/WebEngine/commonWebEngine.lua
@@ -327,81 +327,75 @@ function common.verifyPTSnapshot(appProperties, appPropExpected)
   local result = {}
   local msg = ""
 
-  result.app_policies = snp_tbl.policy_table.app_policies ~= nil
-  if not (result.app_policies) then
+  if (snp_tbl.policy_table.app_policies == nil) then
     msg = msg .. "Incorrect app_policies value\n" ..
       " Expected: exists \n" ..
-      " Actual: " .. result.hybrid_app_preference .. "\n"
+      " Actual: nil \n"
   end
 
-  result.consumer_friendly_messages = snp_tbl.policy_table.consumer_friendly_messages ~= nil
-  if not (result.consumer_friendly_messages) then
+  if (snp_tbl.policy_table.consumer_friendly_messages == nil) then
     msg = msg .. "Incorrect consumer_friendly_messages value\n" ..
       " Expected: exists \n" ..
-      " Actual: " .. result.consumer_friendly_messages .. "\n"
+      " Actual: nil \n"
   end
 
-  result.device_data = snp_tbl.policy_table.device_data ~= nil
-  if not (result.device_data) then
+  if (snp_tbl.policy_table.device_data == nil) then
     msg = msg .. "Incorrect device_data value\n" ..
       " Expected: exists \n" ..
-      " Actual: " .. result.device_data .. "\n"
+      " Actual: nil \n"
   end
 
-  result.functional_groupings = snp_tbl.policy_table.functional_groupings ~= nil
-  if not (result.functional_groupings) then
+  if (snp_tbl.policy_table.functional_groupings == nil) then
     msg = msg .. "Incorrect functional_groupings value\n" ..
       " Expected: exists \n" ..
-      " Actual: " .. result.functional_groupings .. "\n"
+      " Actual: nil \n"
   end
 
-  result.module_config = snp_tbl.policy_table.module_config ~= nil
-  if not (result.module_config) then
+  if (snp_tbl.policy_table.module_config == nil) then
     msg = msg .. "Incorrect module_config value\n" ..
       " Expected: exists \n" ..
-      " Actual: " .. result.module_config .. "\n"
+      " Actual: nil \n"
   end
 
-  result.usage_and_error_counts = snp_tbl.policy_table.usage_and_error_counts ~= nil
-  if not (result.usage_and_error_counts) then
+  if (snp_tbl.policy_table.usage_and_error_counts == nil) then
     msg = msg .. "Incorrect usage_and_error_counts value\n" ..
       " Expected: exists \n" ..
-      " Actual: " .. result.usage_and_error_counts .. "\n"
+      " Actual: nil \n"
   end  
 
-  result.nicknames = snp_tbl.policy_table.app_policies[app_id].nicknames
-  if not common.isTableEqual(result.nicknames, appPropExpected.nicknames) then
+  local nicknames = snp_tbl.policy_table.app_policies[app_id].nicknames
+  if not common.isTableEqual(nicknames, appPropExpected.nicknames) then
     msg = msg .. "Incorrect nicknames\n" ..
       " Expected: " .. common.tableToString(appPropExpected.nicknames) .. "\n" ..
-      " Actual: " .. common.tableToString(result.nicknames) .. "\n"
+      " Actual: " .. common.tableToString(nicknames) .. "\n"
   end
 
-  result.auth_token = snp_tbl.policy_table.app_policies[app_id].auth_token
-  if not (result.auth_token == appPropExpected.auth_token) then
+  local auth_token = snp_tbl.policy_table.app_policies[app_id].auth_token
+  if not (auth_token == appPropExpected.auth_token) then
     msg = msg .. "Incorrect auth token value\n" ..
       " Expected: " .. appPropExpected.auth_token .. "\n" ..
-      " Actual: " .. result.auth_token .. "\n"
+      " Actual: " .. auth_token .. "\n"
   end
 
-  result.cloud_transport_type = snp_tbl.policy_table.app_policies[app_id].cloud_transport_type
-  if not (result.cloud_transport_type == appPropExpected.cloud_transport_type) then
+  local cloud_transport_type = snp_tbl.policy_table.app_policies[app_id].cloud_transport_type
+  if not (cloud_transport_type == appPropExpected.cloud_transport_type) then
     msg = msg ..     "Incorrect cloud_transport_type value\n" ..
       " Expected: " .. appPropExpected.cloud_transport_type .. "\n" ..
-      " Actual: " .. result.cloud_transport_type .. "\n"
+      " Actual: " .. cloud_transport_type .. "\n"
   end
 
-  result.enabled = tostring(snp_tbl.policy_table.app_policies[app_id].enabled)
-  if not (result.enabled == appPropExpected.enabled) then
+  local enabled = tostring(snp_tbl.policy_table.app_policies[app_id].enabled)
+  if not (enabled == appPropExpected.enabled) then
     msg = msg .. "Incorrect enabled value\n"..
       " Expected: " .. appPropExpected.enabled .. "\n" ..
-      " Actual: " .. result.enabled .. "\n"
+      " Actual: " .. enabled .. "\n"
   end
 
-  result.hybrid_app_preference = snp_tbl.policy_table.app_policies[app_id].hybrid_app_preference
-  if not (result.hybrid_app_preference == appPropExpected.hybrid_app_preference) then
+  local hybrid_app_preference = snp_tbl.policy_table.app_policies[app_id].hybrid_app_preference
+  if not (hybrid_app_preference == appPropExpected.hybrid_app_preference) then
     msg = msg .. "Incorrect hybrid_app_preference value\n" ..
       " Expected: " .. appPropExpected.hybrid_app_preference .. "\n" ..
-      " Actual: " .. result.hybrid_app_preference .. "\n"
+      " Actual: " .. hybrid_app_preference .. "\n"
   end
 
   if string.len(msg) > 0 then

--- a/test_scripts/WebEngine/commonWebEngine.lua
+++ b/test_scripts/WebEngine/commonWebEngine.lua
@@ -321,4 +321,94 @@ function common.checkUpdateAppList(pPolicyAppID, pTimes, pExpNumOfApps)
   common.wait()
 end
 
+function common.verifyPTSnapshot(appProperties, appPropExpected)
+  local snp_tbl = common.ptsTable()
+  local app_id = appProperties.policyAppID
+  local result = {}
+  local msg = ""
+
+  result.app_policies = snp_tbl.policy_table.app_policies ~= nil
+  if not (result.app_policies) then
+    msg = msg .. "Incorrect app_policies value\n" ..
+      " Expected: exists \n" ..
+      " Actual: " .. result.hybrid_app_preference .. "\n"
+  end
+
+  result.consumer_friendly_messages = snp_tbl.policy_table.consumer_friendly_messages ~= nil
+  if not (result.consumer_friendly_messages) then
+    msg = msg .. "Incorrect consumer_friendly_messages value\n" ..
+      " Expected: exists \n" ..
+      " Actual: " .. result.consumer_friendly_messages .. "\n"
+  end
+
+  result.device_data = snp_tbl.policy_table.device_data ~= nil
+  if not (result.device_data) then
+    msg = msg .. "Incorrect device_data value\n" ..
+      " Expected: exists \n" ..
+      " Actual: " .. result.device_data .. "\n"
+  end
+
+  result.functional_groupings = snp_tbl.policy_table.functional_groupings ~= nil
+  if not (result.functional_groupings) then
+    msg = msg .. "Incorrect functional_groupings value\n" ..
+      " Expected: exists \n" ..
+      " Actual: " .. result.functional_groupings .. "\n"
+  end
+
+  result.module_config = snp_tbl.policy_table.module_config ~= nil
+  if not (result.module_config) then
+    msg = msg .. "Incorrect module_config value\n" ..
+      " Expected: exists \n" ..
+      " Actual: " .. result.module_config .. "\n"
+  end
+
+  result.usage_and_error_counts = snp_tbl.policy_table.usage_and_error_counts ~= nil
+  if not (result.usage_and_error_counts) then
+    msg = msg .. "Incorrect usage_and_error_counts value\n" ..
+      " Expected: exists \n" ..
+      " Actual: " .. result.usage_and_error_counts .. "\n"
+  end  
+
+  result.nicknames = snp_tbl.policy_table.app_policies[app_id].nicknames
+  if not common.isTableEqual(result.nicknames, appPropExpected.nicknames) then
+    msg = msg .. "Incorrect nicknames\n" ..
+      " Expected: " .. common.tableToString(appPropExpected.nicknames) .. "\n" ..
+      " Actual: " .. common.tableToString(result.nicknames) .. "\n"
+  end
+
+  result.auth_token = snp_tbl.policy_table.app_policies[app_id].auth_token
+  if not (result.auth_token == appPropExpected.auth_token) then
+    msg = msg .. "Incorrect auth token value\n" ..
+      " Expected: " .. appPropExpected.auth_token .. "\n" ..
+      " Actual: " .. result.auth_token .. "\n"
+  end
+
+  result.cloud_transport_type = snp_tbl.policy_table.app_policies[app_id].cloud_transport_type
+  if not (result.cloud_transport_type == appPropExpected.cloud_transport_type) then
+    msg = msg ..     "Incorrect cloud_transport_type value\n" ..
+      " Expected: " .. appPropExpected.cloud_transport_type .. "\n" ..
+      " Actual: " .. result.cloud_transport_type .. "\n"
+  end
+
+  result.enabled = tostring(snp_tbl.policy_table.app_policies[app_id].enabled)
+  if not (result.enabled == appPropExpected.enabled) then
+    msg = msg .. "Incorrect enabled value\n"..
+      " Expected: " .. appPropExpected.enabled .. "\n" ..
+      " Actual: " .. result.enabled .. "\n"
+  end
+
+  result.hybrid_app_preference = snp_tbl.policy_table.app_policies[app_id].hybrid_app_preference
+  if not (result.hybrid_app_preference == appPropExpected.hybrid_app_preference) then
+    msg = msg .. "Incorrect hybrid_app_preference value\n" ..
+      " Expected: " .. appPropExpected.hybrid_app_preference .. "\n" ..
+      " Actual: " .. result.hybrid_app_preference .. "\n"
+  end
+
+  if string.len(msg) > 0 then
+    common.failTestStep("PTS is incorrect\n".. msg)
+  end
+end
+
 return common
+
+

--- a/test_scripts/WebEngine/commonWebEngine.lua
+++ b/test_scripts/WebEngine/commonWebEngine.lua
@@ -371,28 +371,28 @@ function common.verifyPTSnapshot(appProperties, appPropExpected)
   end
 
   local auth_token = snp_tbl.policy_table.app_policies[app_id].auth_token
-  if not (auth_token == appPropExpected.auth_token) then
+  if (auth_token ~= appPropExpected.auth_token) then
     msg = msg .. "Incorrect auth token value\n" ..
       " Expected: " .. appPropExpected.auth_token .. "\n" ..
       " Actual: " .. auth_token .. "\n"
   end
 
   local cloud_transport_type = snp_tbl.policy_table.app_policies[app_id].cloud_transport_type
-  if not (cloud_transport_type == appPropExpected.cloud_transport_type) then
+  if (cloud_transport_type ~= appPropExpected.cloud_transport_type) then
     msg = msg ..     "Incorrect cloud_transport_type value\n" ..
       " Expected: " .. appPropExpected.cloud_transport_type .. "\n" ..
       " Actual: " .. cloud_transport_type .. "\n"
   end
 
-  local enabled = tostring(snp_tbl.policy_table.app_policies[app_id].enabled)
-  if not (enabled == appPropExpected.enabled) then
+  local enabled = snp_tbl.policy_table.app_policies[app_id].enabled
+  if (enabled ~= appPropExpected.enabled) then
     msg = msg .. "Incorrect enabled value\n"..
-      " Expected: " .. appPropExpected.enabled .. "\n" ..
-      " Actual: " .. enabled .. "\n"
+      " Expected: " .. tostring(appPropExpected.enabled) .. "\n" ..
+      " Actual: " .. tostring(enabled) .. "\n"
   end
 
   local hybrid_app_preference = snp_tbl.policy_table.app_policies[app_id].hybrid_app_preference
-  if not (hybrid_app_preference == appPropExpected.hybrid_app_preference) then
+  if (hybrid_app_preference ~= appPropExpected.hybrid_app_preference) then
     msg = msg .. "Incorrect hybrid_app_preference value\n" ..
       " Expected: " .. appPropExpected.hybrid_app_preference .. "\n" ..
       " Actual: " .. hybrid_app_preference .. "\n"

--- a/test_sets/webengine.txt
+++ b/test_sets/webengine.txt
@@ -25,3 +25,4 @@
 ./test_scripts/WebEngine/025_PTU_update_app_properties.lua
 ./test_scripts/WebEngine/026_PTU_snapshot_validation.lua
 ./test_scripts/WebEngine/027_UpdateAppList_unregister_2apps.lua
+./test_scripts/WebEngine/028_PTU_snapshot_validation_no_app_connected.lua


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Tests the changes for Core PR [#3349](https://github.com/smartdevicelink/sdl_core/pull/3349)

SDL Server implements the following pts validation logic:"

```
function validateCorePost (req, res) {
    if (!req.body.policy_table) {
        return res.errorMsg = "Please provide policy table information";
    } else if (!req.body.policy_table.app_policies) {
        return res.errorMsg = "Please provide app policies information";
    } else if (!req.body.policy_table.consumer_friendly_messages) {
        return res.errorMsg = "Please provide consumer friendly messages information";
    } else if (!req.body.policy_table.device_data) {
        return res.errorMsg = "Please provide device data information";
    } else if (!req.body.policy_table.functional_groupings) {
        return res.errorMsg = "Please provide functional groupings information";
    } else if (!req.body.policy_table.module_config) {
        return res.errorMsg = "Please provide module config information";
    } else if (!req.body.policy_table.usage_and_error_counts) {
        return res.errorMsg = "Please provide usage and error counts information";
    }
}
```

These test updates ensure that all of the following fields are present in the PTS snapshot in a case when a mobile app is connected, and a secondary case when there is no mobile app connected.

### ATF version
Develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
