### PR TITLE
Re-add fixed test to HTTP policy test set

### DIFF
--- a/test_sets/policies_all_flows.txt
+++ b/test_sets/policies_all_flows.txt
@@ -11,7 +11,7 @@
 ./test_scripts/Policies/build_options/054_ATF_Request_PTU_UPDATE_NEEDED_new_PTU_Request_HTTP.lua
 ./test_scripts/Policies/build_options/055_ATF_Policy_Table_Snapshot_Creation_HTTP.lua
 ./test_scripts/Policies/build_options/056_ATF_PTU_Transfer_Several_Apps_Different_HMI_Levels_HTTP.lua
-;./test_scripts/Policies/build_options/057_ATF_PTS_Define_URL_to_send_PTS_HTTP.lua 1219
+./test_scripts/Policies/build_options/057_ATF_PTS_Define_URL_to_send_PTS_HTTP.lua
 ./test_scripts/Policies/build_options/058_ATF_HMI_gets_URLs_via_GetPolicyConfigurationData_HTTP.lua
 ./test_scripts/Policies/build_options/060_ATF_Timeout_to_wait_response_PTU_HTTP.lua
 ./test_scripts/Policies/build_options/061_ATF_Sending_PTS_to_Mobile_Application_HTTP.lua

--- a/test_sets/policies_happy_paths_HTTP.txt
+++ b/test_sets/policies_happy_paths_HTTP.txt
@@ -5,7 +5,7 @@
 ./test_scripts/Policies/build_options/054_ATF_Request_PTU_UPDATE_NEEDED_new_PTU_Request_HTTP.lua
 ./test_scripts/Policies/build_options/055_ATF_Policy_Table_Snapshot_Creation_HTTP.lua
 ./test_scripts/Policies/build_options/056_ATF_PTU_Transfer_Several_Apps_Different_HMI_Levels_HTTP.lua
-;./test_scripts/Policies/build_options/057_ATF_PTS_Define_URL_to_send_PTS_HTTP.lua 1219
+./test_scripts/Policies/build_options/057_ATF_PTS_Define_URL_to_send_PTS_HTTP.lua
 ./test_scripts/Policies/build_options/058_ATF_HMI_gets_URLs_via_GetPolicyConfigurationData_HTTP.lua
 ./test_scripts/Policies/build_options/060_ATF_Timeout_to_wait_response_PTU_HTTP.lua
 ./test_scripts/Policies/build_options/061_ATF_Sending_PTS_to_Mobile_Application_HTTP.lua


### PR DESCRIPTION
Re-add previously broken test after https://github.com/SmartDeviceLink/sdl_core/issues/1219 was fixed

This PR is **ready** for review.

### Changelog

##### Enhancements
* Re-add previously broken test to HTTP policy test set

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
