### PR TITLE
changes to accomodate sdl_core #3357

### DIFF
--- a/test_scripts/Smoke/API/002_ResetGlobalProperties_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/002_ResetGlobalProperties_PositiveCase_SUCCESS.lua
@@ -55,17 +55,37 @@ local requestParams = {
 
 local responseUiParams = {
 	menuTitle = "",
-	vrHelpTitle = "Test Application",
+	vrHelpTitle = "Available Vr Commands List",
 	keyboardProperties = {
 		keyboardLayout = "QWERTY",
 		autoCompleteList = {},
 		language = "EN-US"
-	}
+  },
+  vrHelp = {
+    {
+      position = 1,
+      text = "Test Application"
+    }
+  }
 }
 
 local responseTtsParams = {
-  helpPrompt = {},
+  helpPrompt = {
+    {
+      text = "Please speak one of the following commands,",
+      type = "TEXT"
+    },
+    {
+      text = "Please say a command,",
+      type = "TEXT"
+    }
+  },
   timeoutPrompt = {}
+}
+
+local vrHelpArray = {
+  position = 1,
+  text = "Test Application"
 }
 
 local allParams = {
@@ -95,14 +115,6 @@ local function resetGlobalProperties(pParams)
   :Do(function(_, data)
       common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
     end)
-  :ValidIf(function(_, data)
-    if data.params.vrHelp == nil then
-      return true
-    else
-      return false, "vrHelp array in UI.SetGlobalProperties request is not empty."
-        .. " Expected array size 0, actual " .. tostring(#data.params.vrHelp)
-    end
-  end)
 
   local ttsDelimiter = common.readParameterFromSDLINI("TTSDelimiter")
   local helpPromptString = common.readParameterFromSDLINI("HelpPromt")

--- a/test_scripts/Smoke/API/002_ResetGlobalProperties_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/002_ResetGlobalProperties_PositiveCase_SUCCESS.lua
@@ -83,11 +83,6 @@ local responseTtsParams = {
   timeoutPrompt = {}
 }
 
-local vrHelpArray = {
-  position = 1,
-  text = "Test Application"
-}
-
 local allParams = {
   requestParams = requestParams,
   responseUiParams = responseUiParams,

--- a/test_scripts/iAP2TransportSwitch/003_resume_failed_remove_data_check.lua
+++ b/test_scripts/iAP2TransportSwitch/003_resume_failed_remove_data_check.lua
@@ -362,8 +362,7 @@ local function connectUSBDevice(self)
     keyboardProperties = {
       keyboardLayout = "QWERTY",
       language = "EN-US"
-    },
-    vrHelpTitle = "Test Application"
+    }
   })
   :Do(function(_, data)
       common.print("UI global properties removed")


### PR DESCRIPTION
ATF Test Scripts to accomodate changes in https://github.com/smartdevicelink/sdl_core/pull/3357

This PR is **ready** for review.

### Summary
Update expectations in `test_scripts/Smoke/API/002_ResetGlobalProperties_PositiveCase_SUCCESS.lua` to include `vrHelp` and `helpPrompt`.

Remove the expectation of appName to be sent as `vrHelpTitle ` in `test_scripts/iAP2TransportSwitch/003_resume_failed_remove_data_check.lua`

### ATF version
master

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
