### PR TITLE
Fixing of wrong OnHMIStatus expectation after streaming end 

### DIFF
--- a/test_scripts/MobileProjection/Phase2/025_Media_app_must_get_ATTENUATED_streaming_state_when_navi_app_starts_streaming.lua
+++ b/test_scripts/MobileProjection/Phase2/025_Media_app_must_get_ATTENUATED_streaming_state_when_navi_app_starts_streaming.lua
@@ -18,7 +18,9 @@ local isMixingAudioSupported = true
 
 --[[ General configuration parameters ]]
 config.application1.registerAppInterfaceParams.appHMIType = { appHMIType[1] }
+config.application1.registerAppInterfaceParams.isMediaApplication = true
 config.application2.registerAppInterfaceParams.appHMIType = { appHMIType[2] }
+config.application1.registerAppInterfaceParams.isMediaApplication = false
 
 --[[ Local Functions ]]
 local function getHMIParams(pIsMixingSupported)
@@ -47,15 +49,16 @@ local function appStartAudioStreaming(pApp1Id, pApp2Id)
         end)
     end)
   common.getMobileSession(pApp1Id):ExpectNotification("OnHMIStatus", {
-  	hmiLevel = "FULL",
-  	audioStreamingState = "ATTENUATED"
-  	})
+    hmiLevel = "FULL",
+    audioStreamingState = "ATTENUATED"
+    })
   :Times(1)
 end
 
 local function appStopStreaming()
   common.getMobileSession():StopStreaming("files/MP3_1140kb.mp3")
-  common.getMobileSession():ExpectNotification("OnHMIStatus")
+  common.getMobileSession():ExpectNotification("OnHMIStatus", { hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
+  common.getMobileSession(2):ExpectNotification("OnHMIStatus")
   :Times(0)
 end
 
@@ -73,7 +76,7 @@ runner.Step("Set App Config", common.setAppConfig, { 1, "MEDIA", true })
 runner.Step("Register " .. appHMIType[1] .. " App", common.registerApp, { 1 })
 runner.Step("Activate App1, audioState:" .. "AUDIBLE", activateApp, { 1, 001, "AUDIBLE", "App1" })
 
-runner.Step("App starts Audio streaming", appStartAudioStreaming, {1, 2})
+runner.Step("App starts Audio streaming", appStartAudioStreaming, { 1, 2 })
 
 runner.Step("App stops streaming", appStopStreaming)
 

--- a/test_scripts/MobileProjection/Phase2/025_Media_app_must_get_ATTENUATED_streaming_state_when_navi_app_starts_streaming.lua
+++ b/test_scripts/MobileProjection/Phase2/025_Media_app_must_get_ATTENUATED_streaming_state_when_navi_app_starts_streaming.lua
@@ -18,9 +18,7 @@ local isMixingAudioSupported = true
 
 --[[ General configuration parameters ]]
 config.application1.registerAppInterfaceParams.appHMIType = { appHMIType[1] }
-config.application1.registerAppInterfaceParams.isMediaApplication = true
 config.application2.registerAppInterfaceParams.appHMIType = { appHMIType[2] }
-config.application1.registerAppInterfaceParams.isMediaApplication = false
 
 --[[ Local Functions ]]
 local function getHMIParams(pIsMixingSupported)

--- a/test_scripts/MobileProjection/Phase2/025_Media_app_must_get_ATTENUATED_streaming_state_when_navi_app_starts_streaming.lua
+++ b/test_scripts/MobileProjection/Phase2/025_Media_app_must_get_ATTENUATED_streaming_state_when_navi_app_starts_streaming.lua
@@ -56,7 +56,7 @@ local function appStartAudioStreaming(pApp1Id, pApp2Id)
 end
 
 local function appStopStreaming()
-  common.getMobileSession():StopStreaming("files/MP3_1140kb.mp3")
+  common.getMobileSession(2):StopStreaming("files/MP3_1140kb.mp3")
   common.getMobileSession():ExpectNotification("OnHMIStatus", { hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
   common.getMobileSession(2):ExpectNotification("OnHMIStatus")
   :Times(0)

--- a/test_sets/SDL5_0/mobile_projection_2.txt
+++ b/test_sets/SDL5_0/mobile_projection_2.txt
@@ -21,3 +21,4 @@
 ./test_scripts/MobileProjection/Phase2/021_two_apps_and_deactivation.lua
 ./test_scripts/MobileProjection/Phase2/022_two_apps_proj_media_and_deactivation_streaming.lua
 ./test_scripts/MobileProjection/Phase2/023_two_apps_navi_comm_and_deactivation_streaming.lua
+./test_scripts/MobileProjection/Phase2/025_Media_app_must_get_ATTENUATED_streaming_state_when_navi_app_starts_streaming.lua


### PR DESCRIPTION
Update to fix #2404 

This PR is **[ready]** for review.

### Summary
The first app should expect the changing of audioStreamingState back to `AUDIBLE` state, and the second app should expect 0 OnHMIlevel notification.

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
