### PR TITLE
Improve stability of scripts #4

### DIFF
--- a/test_scripts/API/SetAppIcon/commonIconResumed.lua
+++ b/test_scripts/API/SetAppIcon/commonIconResumed.lua
@@ -166,6 +166,7 @@ end
 function m.closeConnection()
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = true })
   actions.mobile.disconnect()
+  actions.run.wait(1000)
 end
 
 --[[ @openConnection: Open mobile connection successfully
@@ -173,12 +174,10 @@ end
 --! return: none
 --]]
 function m.openConnection()
-  test.mobileSession[1] = mobile_session.MobileSession(
-    test,
-    test.mobileConnection,
-    config.application1.registerAppInterfaceParams)
-  test.mobileConnection:Connect()
-  test.mobileSession[1]:StartRPC()
+  actions.mobile.connect()
+  :Do(function()
+      m.mobile.createSession():StartRPC()
+    end)
 end
 
 local preconditionsOrig = m.preconditions

--- a/test_scripts/Defects/4_5/commonDefects.lua
+++ b/test_scripts/Defects/4_5/commonDefects.lua
@@ -275,7 +275,7 @@ function commonDefect.ignitionOff(self)
       EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
       EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
       :Do(function()
-          sdl:StopSDL()
+          StopSDL()
         end)
     end)
 end

--- a/test_scripts/Defects/5_0/2447_Resumption_revoked_app_still_be_resumed_as_FULL.lua
+++ b/test_scripts/Defects/5_0/2447_Resumption_revoked_app_still_be_resumed_as_FULL.lua
@@ -33,9 +33,10 @@ local function cleanMobileSessions()
 end
 
 local function unexpectedDisconnect()
-  common.getMobileConnection():Close()
+  common.mobile.disconnect()
   common.getHMIConnection():ExpectNotification("BasicCommunication.OnAppUnregistered",
     { unexpectedDisconnect = true })
+  common.run.wait(1000)
 end
 
 local function reconnectMobileConnection()

--- a/test_scripts/Defects/5_0/959_resumption_limited_non_media.lua
+++ b/test_scripts/Defects/5_0/959_resumption_limited_non_media.lua
@@ -23,14 +23,15 @@ end
 
 local function reconnect(pAppId)
   if not pAppId then pAppId = 1 end
-  test.mobileSession[pAppId]:Stop()
   actions.getHMIConnection():ExpectNotification("BasicCommunication.OnAppUnregistered",
     {appID = actions.getHMIAppId(pAppId), unexpectedDisconnect = true})
+  actions.mobile.disconnect()
+  actions.run.wait(1000)
   :Do(function()
     test.mobileSession[pAppId] = mobile_session.MobileSession(
-    test,
-    test.mobileConnection,
-    config["application" .. pAppId].registerAppInterfaceParams)
+      test,
+      test.mobileConnection,
+      config["application" .. pAppId].registerAppInterfaceParams)
     test.mobileConnection:Connect()
   end)
 end

--- a/test_scripts/Defects/commonDefects.lua
+++ b/test_scripts/Defects/commonDefects.lua
@@ -276,7 +276,7 @@ function commonDefect.ignitionOff(self)
       EXPECT_HMINOTIFICATION("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
       EXPECT_HMINOTIFICATION("BasicCommunication.OnSDLClose")
       :Do(function()
-          sdl:StopSDL()
+          StopSDL()
         end)
     end)
 end

--- a/test_scripts/Policies/App_Permissions/003_ATF_HP_User_Consent_Yes.lua
+++ b/test_scripts/Policies/App_Permissions/003_ATF_HP_User_Consent_Yes.lua
@@ -74,8 +74,7 @@ end
 
 --[[ Test ]]
 commonFunctions:newTestCasesGroup("Test")
-function Test:Precondition_Activate_App_And_Consent_Device()
-
+function Test:Precondition_RegisterApp()
   local CorIdRAI = self.mobileSession:SendRPC("RegisterAppInterface",
     {
       syncMsgVersion =
@@ -116,7 +115,11 @@ function Test:Precondition_Activate_App_And_Consent_Device()
     })
   :Do(function(_,data)
       self.applications["SPT"] = data.params.application.appID
+    end)
+  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
+end
 
+function Test:Precondition_Activate_App_And_Consent_Device()
       local RequestId = self.hmiConnection:SendRequest("SDL.ActivateApp", {appID = self.applications["SPT"]})
       EXPECT_HMIRESPONSE(RequestId, { result = {
             code = 0,
@@ -134,8 +137,6 @@ function Test:Precondition_Activate_App_And_Consent_Device()
                 end)
             end)
         end)
-    end)
-  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
 end
 
 function Test:Precondition_UpdatePolicyWithPTU()

--- a/test_scripts/Policies/App_Permissions/004_ATF_HP_User_Consent_NO.lua
+++ b/test_scripts/Policies/App_Permissions/004_ATF_HP_User_Consent_NO.lua
@@ -74,8 +74,7 @@ end
 
 --[[ Test ]]
 commonFunctions:newTestCasesGroup("Test")
-function Test:Precondition_Activate_App_And_Consent_Device()
-
+function Test:Precondition_RegisterApp()
   local CorIdRAI = self.mobileSession:SendRPC("RegisterAppInterface",
     {
       syncMsgVersion =
@@ -116,7 +115,11 @@ function Test:Precondition_Activate_App_And_Consent_Device()
     })
   :Do(function(_,data)
       self.applications["SPT"] = data.params.application.appID
+    end)
+  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
+end
 
+function Test:Precondition_Activate_App_And_Consent_Device()
       local RequestId = self.hmiConnection:SendRequest("SDL.ActivateApp", {appID = self.applications["SPT"]})
       EXPECT_HMIRESPONSE(RequestId, { result = {
             code = 0,
@@ -134,8 +137,6 @@ function Test:Precondition_Activate_App_And_Consent_Device()
                 end)
             end)
         end)
-    end)
-  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
 end
 
 function Test:Precondition_UpdatePolicyWithPTU()

--- a/test_scripts/Policies/App_Permissions/005_ATF_DISALLOWED_app_Id_policies_And_RequestType_Validation.lua
+++ b/test_scripts/Policies/App_Permissions/005_ATF_DISALLOWED_app_Id_policies_And_RequestType_Validation.lua
@@ -61,7 +61,7 @@ function Test:Precondition_StartNewSession()
   self.mobileSession:StartService(7)
 end
 
-function Test:Precondition_Activate_App_And_Consent_Device()
+function Test:Precondition_RegisterApp()
   local CorIdRAI = self.mobileSession:SendRPC("RegisterAppInterface",
     {
       syncMsgVersion =
@@ -102,7 +102,11 @@ function Test:Precondition_Activate_App_And_Consent_Device()
     })
   :Do(function(_,data)
       self.applications["SPT"] = data.params.application.appID
+    end)
+  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
+end
 
+function Test:Precondition_Activate_App_And_Consent_Device()
       local RequestId = self.hmiConnection:SendRequest("SDL.ActivateApp", {appID = self.applications["SPT"]})
       EXPECT_HMIRESPONSE(RequestId, { result = {
             code = 0,
@@ -120,8 +124,6 @@ function Test:Precondition_Activate_App_And_Consent_Device()
                 end)
             end)
         end)
-    end)
-  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
 end
 
 function Test:Precondition_DeactivateApp()

--- a/test_scripts/Policies/App_Permissions/006_ATF_Steal_focus_validation_false_PTU.lua
+++ b/test_scripts/Policies/App_Permissions/006_ATF_Steal_focus_validation_false_PTU.lua
@@ -56,12 +56,17 @@ function Test:Precondition_StartNewSession()
   self.mobileSession:StartService(7)
 end
 
-function Test:Precondition_ActivateApplication()
+function Test:Precondition_RegisterApp()
   config.application1.registerAppInterfaceParams.fullAppID = "123456"
   local CorIdRAI = self.mobileSession:SendRPC("RegisterAppInterface", config.application1.registerAppInterfaceParams)
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { policyAppID = "123456"} })
   :Do(function(_,data)
       self.applications[config.application1.registerAppInterfaceParams.appName] = data.params.application.appID
+    end)
+  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
+end
+
+function Test:Precondition_ActivateApplication()
       local RequestId = self.hmiConnection:SendRequest("SDL.ActivateApp", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
       EXPECT_HMIRESPONSE(RequestId, { result = {
             code = 0,
@@ -79,8 +84,6 @@ function Test:Precondition_ActivateApplication()
                 end)
             end)
         end)
-    end)
-  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
 end
 
 function Test:Precondition_DeactivateApp()

--- a/test_scripts/Policies/App_Permissions/007_ATF_StealFocus_validation_true_PTU.lua
+++ b/test_scripts/Policies/App_Permissions/007_ATF_StealFocus_validation_true_PTU.lua
@@ -61,12 +61,17 @@ function Test:Precondition_StartNewSession()
   self.mobileSession:StartService(7)
 end
 
-function Test:Precondition_ActivateApplication()
+function Test:Precondition_RegisterApp()
   config.application1.registerAppInterfaceParams.fullAppID = "123456"
   local CorIdRAI = self.mobileSession:SendRPC("RegisterAppInterface", config.application1.registerAppInterfaceParams)
   EXPECT_HMINOTIFICATION("BasicCommunication.OnAppRegistered", { application = { policyAppID = "123456"} })
   :Do(function(_,data)
       self.applications[config.application1.registerAppInterfaceParams.appName] = data.params.application.appID
+    end)
+  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
+end
+
+function Test:Precondition_ActivateApplication()
       local RequestId = self.hmiConnection:SendRequest("SDL.ActivateApp", {appID = self.applications[config.application1.registerAppInterfaceParams.appName]})
       EXPECT_HMIRESPONSE(RequestId, { result = {
             code = 0,
@@ -84,8 +89,6 @@ function Test:Precondition_ActivateApplication()
                 end)
             end)
         end)
-    end)
-  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
 end
 
 function Test:Precondition_DeactivateApp()

--- a/test_scripts/Policies/App_Permissions/025_ATF_ChangeRegistration_With_AppName_Not_Listed_In_NickNames.lua
+++ b/test_scripts/Policies/App_Permissions/025_ATF_ChangeRegistration_With_AppName_Not_Listed_In_NickNames.lua
@@ -113,7 +113,7 @@ function Test:Precondition_RestorePreloadedPT()
   RestorePreloadedPT()
 end
 
-function Test:Precondition_Register_App_Activate_And_consent_Device()
+function Test:Precondition_RegisterApp()
   local CorIdRAI = self.mobileSession:SendRPC("RegisterAppInterface",
     {
       syncMsgVersion =
@@ -153,7 +153,13 @@ function Test:Precondition_Register_App_Activate_And_consent_Device()
       }
     })
   :Do(function(_,data)
-      local RequestIdActivateApp = self.hmiConnection:SendRequest("SDL.ActivateApp", {appID = data.params.application.appID})
+      self.applications["SPT"] = data.params.application.appID
+    end)
+  EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
+end
+
+function Test:App_Activate_And_consent_Device()
+      local RequestIdActivateApp = self.hmiConnection:SendRequest("SDL.ActivateApp", {appID = self.applications["SPT"]})
       EXPECT_HMIRESPONSE(RequestIdActivateApp, {result = {code = 0, isSDLAllowed = false}, method = "SDL.ActivateApp"})
       :Do(function(_,_)
           local RequestIdGetUserFriendlyMessage = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = {"DataConsent"}})
@@ -167,8 +173,6 @@ function Test:Precondition_Register_App_Activate_And_consent_Device()
                 end)
             end)
         end)
-    end)
-    EXPECT_RESPONSE(CorIdRAI, { success = true, resultCode = "SUCCESS"})
 end
 
 --[[ Test ]]

--- a/test_scripts/Policies/HMI_PTU/008_reseting_timeout_after_receiving_OnSystemRequest.lua
+++ b/test_scripts/Policies/HMI_PTU/008_reseting_timeout_after_receiving_OnSystemRequest.lua
@@ -37,7 +37,7 @@ local function resetTimeoutAfterOnSystemRequest()
   local systemRequestTime = timestamp()
   common.hmi():SendNotification("BasicCommunication.OnSystemRequest",
     { requestType = "PROPRIETARY", fileName = "files/ptu.json" })
-  common.mobile():ExpectNotification("OnSystemRequest", { requestType = "PROPRIETARY" })
+  common.mobile():ExpectNotification("OnSystemRequest", { requestType = "PROPRIETARY" }):Times(AtLeast(1))
   common.hmi():ExpectNotification("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }):Times(AtLeast(1))
   :ValidIf(function(e)
     if e.occurences == 1 then

--- a/test_scripts/Policies/Policy_Table_Update/151_ATF_Apply_PTU_and_OnPermissionChange_notify.lua
+++ b/test_scripts/Policies/Policy_Table_Update/151_ATF_Apply_PTU_and_OnPermissionChange_notify.lua
@@ -98,6 +98,7 @@ end
 
 function Test:ActivateAppInFull()
   commonSteps:ActivateAppInSpecificLevel(self, HMIAppID, "FULL")
+  EXPECT_NOTIFICATION("OnHMIStatus", { hmiLevel = "FULL" })
 end
 
 function Test:UpdatePolicy_ExpectOnAppPermissionChangedWithAppID()

--- a/test_scripts/Policies/Validation_of_PolicyTables/268_ATF_pt_update_validation_rules_general.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/268_ATF_pt_update_validation_rules_general.lua
@@ -84,6 +84,7 @@ function Test:ActivateApp()
   HMIAppId = self.applications[config.application1.registerAppInterfaceParams.appName]
 
   commonSteps:ActivateAppInSpecificLevel(Test, HMIAppId)
+  EXPECT_NOTIFICATION("OnHMIStatus", { hmiLevel = "FULL" })
   EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
   :Do(function(_,data3)
       self.hmiConnection:SendResponse(data3.id, data3.method, "SUCCESS", {})

--- a/test_scripts/Policies/Validation_of_PolicyTables/280_ATF_Reset_ignition_cycles_since_last_exchange_in_PT.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/280_ATF_Reset_ignition_cycles_since_last_exchange_in_PT.lua
@@ -158,6 +158,7 @@ end
 
 function Test:ActivateAppInFULLLevel()
   commonSteps:ActivateAppInSpecificLevel(self,self.applications[config.application1.registerAppInterfaceParams.appName],"FULL")
+  EXPECT_NOTIFICATION("OnHMIStatus", { hmiLevel = "FULL" })
 end
 
 function Test:TestStep_flow_SUCCEESS_EXTERNAL_PROPRIETARY()

--- a/test_scripts/Policies/Validation_of_PolicyTables/308_ATF_Check_app_registration_language_gui.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/308_ATF_Check_app_registration_language_gui.lua
@@ -166,6 +166,7 @@ commonFunctions:newTestCasesGroup("Test")
 
 function Test:ActivateAppInFULLLevel()
   commonSteps:ActivateAppInSpecificLevel(self,HMIAppID,"FULL")
+  EXPECT_NOTIFICATION("OnHMIStatus", { hmiLevel = "FULL" })
 end
 
 function Test:InitiatePTUForGetSnapshot()

--- a/test_scripts/Policies/Validation_of_PolicyTables/312_ATF_Check_count_of_removals_for_bad_behavior_too_many_requests.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/312_ATF_Check_count_of_removals_for_bad_behavior_too_many_requests.lua
@@ -97,6 +97,7 @@ end
 
 function Test:ActivateAppInFull()
   commonSteps:ActivateAppInSpecificLevel(self,HMIAppID)
+  EXPECT_NOTIFICATION("OnHMIStatus", { hmiLevel = "FULL" })
 end
 
 --[[ end of Preconditions ]]

--- a/test_scripts/Policies/build_options/064_ATF_Received_PTU_From_Mobile_Application_HTTP.lua
+++ b/test_scripts/Policies/build_options/064_ATF_Received_PTU_From_Mobile_Application_HTTP.lua
@@ -132,6 +132,7 @@ function Test:RAI_PTU()
         end)
       :Times(3)
       -- workaround due to issue in Mobile API: APPLINK-30390
+    end)
       local onSystemRequestRecieved = false
       self.mobileSession:ExpectNotification("OnSystemRequest")
       :Do(
@@ -145,7 +146,6 @@ function Test:RAI_PTU()
           end
         end)
       :Times(2)
-    end)
   self.mobileSession:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
   :Do(
     function()

--- a/test_scripts/Policies/build_options/072_ATF_PTU_PM_Sets_Status_UPDATE_NEEDED_HTTP.lua
+++ b/test_scripts/Policies/build_options/072_ATF_PTU_PM_Sets_Status_UPDATE_NEEDED_HTTP.lua
@@ -99,6 +99,7 @@ function Test:RAI_PTU()
         end)
       :Times(4)
       :Timeout(65000)
+    end)
 
       local onSystemRequestRecieved = false
       self.mobileSession:ExpectNotification("OnSystemRequest")
@@ -114,7 +115,6 @@ function Test:RAI_PTU()
       :Times(3) -- LOCK_SCREEN_ICON_URL, HTTP, HTTP
       :Timeout(65000)
 
-    end)
   self.mobileSession:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
   :Do(
     function()

--- a/test_scripts/SDL5_0/ConditionalResumption/common.lua
+++ b/test_scripts/SDL5_0/ConditionalResumption/common.lua
@@ -213,9 +213,10 @@ end
 
 function common.reconnect(pAppId)
   if not pAppId then pAppId = 1 end
-  common.getMobileSession(pAppId):Stop()
   common.getHMIConnection():ExpectNotification("BasicCommunication.OnAppUnregistered",
     {appID = common.getHMIAppId(pAppId), unexpectedDisconnect = true})
+  actions.mobile.disconnect()
+  actions.run.wait(1000)
   :Do(function()
     test.mobileSession[pAppId] = mobile_session.MobileSession(
       test,

--- a/test_scripts/SDL5_0/Handling_VR_help_requests/commonVRhelp.lua
+++ b/test_scripts/SDL5_0/Handling_VR_help_requests/commonVRhelp.lua
@@ -246,9 +246,10 @@ end
 
 function m.reconnect(pAppId)
   if not pAppId then pAppId = 1 end
-  m.getMobileSession(pAppId):Stop()
   m.getHMIConnection():ExpectNotification("BasicCommunication.OnAppUnregistered",
     {appID = m.getHMIAppId(pAppId), unexpectedDisconnect = true})
+  actions.mobile.disconnect()
+  actions.run.wait(1000)
   :Do(function()
     test.mobileSession[pAppId] = mobile_session.MobileSession(
       test,

--- a/test_scripts/Smoke/commonSmoke.lua
+++ b/test_scripts/Smoke/commonSmoke.lua
@@ -269,13 +269,11 @@ function common.ignitionOff(pExpFunc)
           isOnSDLCloseSent = true
           SDL.DeleteFile()
         end)
-      :Times(AtMost(1))
     end)
   common.wait(3000)
   :Do(function()
       if isOnSDLCloseSent == false then common.cprint(35, "BC.OnSDLClose was not sent") end
-      if SDL:CheckStatusSDL() == SDL.RUNNING then SDL:StopSDL() end
-      common.getMobileConnection():Close()
+      StopSDL()
     end)
 end
 
@@ -288,12 +286,10 @@ function common.masterReset(pExpFunc)
       isOnSDLCloseSent = true
       SDL.DeleteFile()
     end)
-  :Times(AtMost(1))
   common.wait(3000)
   :Do(function()
       if isOnSDLCloseSent == false then common.cprint(35, "BC.OnSDLClose was not sent") end
-      if SDL:CheckStatusSDL() == SDL.RUNNING then SDL:StopSDL() end
-      common.getMobileConnection():Close()
+      StopSDL()
     end)
 end
 

--- a/test_scripts/WidgetSupport/common.lua
+++ b/test_scripts/WidgetSupport/common.lua
@@ -493,11 +493,7 @@ end
 --! @return: none
 --]]
 function m.connectMobile()
-  test.mobileConnection:Connect()
-  EXPECT_EVENT(events.connectedEvent, "Connected")
-  :Do(function()
-      utils.cprint(35, "Mobile connected")
-    end)
+  actions.mobile.connect()
 end
 
 --[[ @ignitionOff: IGNITION_OFF sequence

--- a/user_modules/sequences/actions.lua
+++ b/user_modules/sequences/actions.lua
@@ -268,7 +268,15 @@ local function registerConnectionExpectations(pMobConnId)
       utils.cprint(35, "Mobile #" .. pMobConnId .. " disconnected")
     end)
 
-  local ret = connection:ExpectEvent(events.connectedEvent, "Connected")
+  local event = m.run.createEvent()
+  connection:ExpectEvent(events.connectedEvent, "Connected")
+  :Do(function()
+      local timeout = 0
+      local con_type = connection.type or config.defaultMobileAdapterType
+      if con_type == m.mobile.CONNECTION_TYPE.WSS then timeout = m.minTimeout end
+      m.run.runAfter(function() m.hmi.getConnection():RaiseEvent(event, "DelayedConnect") end, timeout)
+    end)
+  local ret = m.hmi.getConnection():ExpectEvent(event, "DelayedConnect")
   ret:Do(function()
     utils.cprint(35, "Mobile #" .. pMobConnId .. " connected")
   end)


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Various fixes related to scripts which improve stability on a high loads.

### ATF version
develop

### Changelog

##### Enhancements
* added delay to disconnect function(s)
* added delay to connect function for `WSS` connection
* improved stability of Ignition Off sequence
* improved stability of some Policy scripts:
   - moved app registration to separate test step
   - added missing expectation on `OnHMIStatus(FULL)` in `ActivateAppInSpecificLevel() `function
   - reworked script to get rid of `Unpin()` function

##### Bug Fixes
* [Bug Fix Info]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
