### PR TITLE
Add restrictions to 028 script for Web Engine

### DIFF
--- a/test_scripts/WebEngine/028_PTU_snapshot_validation_no_app_connected.lua
+++ b/test_scripts/WebEngine/028_PTU_snapshot_validation_no_app_connected.lua
@@ -14,17 +14,14 @@
 --------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
 local common = require('test_scripts/WebEngine/commonWebEngine')
-local hmi_ptu = require('test_scripts/Policies/HMI_PTU/common_hmi_ptu')
---[[ Local Variables ]]
-local appStoreConfig = {
-  keep_context = false,
-  steal_focus = false,
-  priority = "NONE",
-  default_hmi = "NONE",
-  groups = { "Base-4" }
-}
 
+--[[ General configuration parameters ]]
+runner.testSettings.isSelfIncluded = false
+runner.testSettings.restrictions.sdlBuildOptions = {{ extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" }}}
+
+--[[ Local Variables ]]
 local appProperties = {
   nicknames = { "Test Web Application_21", "Test Web Application_22" },
   policyAppID = "0000002",
@@ -43,10 +40,6 @@ local appPropExpected = {
 }
 
 --[[ Local Functions ]]
-local function PTUfunc(tbl)
-  tbl.policy_table.app_policies[common.getConfigAppParams().fullAppID] = appStoreConfig;
-end
-
 local function setAppProperties(pData)
   local corId = common.getHMIConnection():SendRequest("BasicCommunication.SetAppProperties",
     { properties = pData })


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
028 script for Web Engine was designed to check if PTU is started without registered application. However for `HTTP` policy mode at least one registered application is required for PTU. So this script needs to be excluded for `HTTP` policy mode.

### ATF version
develop

### Changelog
* Added policy mode restriction to 028 script for Web Engine: only `PROPRIETARAY` and `EXTERNAL_PROPRIETARAY` modes are supported. 
* Removed unused code

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
