### PR TITLE
Fix info msg check for RC Multiple Modules

### DIFF
--- a/test_scripts/RC/MultipleModules/commonRCMulModules.lua
+++ b/test_scripts/RC/MultipleModules/commonRCMulModules.lua
@@ -507,8 +507,7 @@ local function getInfo(pModuleType, pModuleId, pInfoType)
   }
 
   if pInfoType == "INCORRECT_MODULE_TYPE" then
-    return "RPC.msg_params.moduleType: Ignored invalid value - " .. pModuleType
-      .."\nRPC.msg_params: Missing mandatory parameter: moduleType"
+    return "Ignored invalid value"
   elseif pInfoType == "NOT_EXISTING_MODULE" then
     return "Accessing not supported module"
   end
@@ -537,7 +536,10 @@ function common.releaseModuleWithInfoCheck(pAppId, pModuleType, pModuleId, pResu
   end
   local cid = mobSession:SendRPC("ReleaseInteriorVehicleDataModule",
       { moduleType = pModuleType, moduleId = pModuleId })
-  mobSession:ExpectResponse(cid, { success = isSuccess, resultCode = pResultCode, info = infoMsg })
+  mobSession:ExpectResponse(cid, { success = isSuccess, resultCode = pResultCode })
+  :ValidIf(function(_, data)
+    return string.find(data.payload.info, infoMsg, 1, true) and true or false
+  end)
 end
 
 function common.releaseModuleNoModuleId(pAppId, pModuleType, pModuleId, pResultCode, pInfoType, pRCAppIds)

--- a/test_scripts/RC/MultipleModules/commonRCMulModules.lua
+++ b/test_scripts/RC/MultipleModules/commonRCMulModules.lua
@@ -423,7 +423,7 @@ function common.driverConsentForReallocationToApp(pAppId, pModuleType, pModuleCo
   if pAccessMode == "ASK_DRIVER" then
     if type(pSdlDecisions) == "table" then
       for moduleId, isSdlDecision in pairs(pSdlDecisions) do
-        if not isSdlDecision then 
+        if not isSdlDecision then
           isHmiRequestExpected = true
           filteredConsentsArray[moduleId] = pModuleConsentArray[moduleId]
         end
@@ -507,7 +507,8 @@ local function getInfo(pModuleType, pModuleId, pInfoType)
   }
 
   if pInfoType == "INCORRECT_MODULE_TYPE" then
-    return "Ignored invalid value"
+    return "RPC.msg_params.moduleType: Ignored invalid value - " .. pModuleType
+      .."\nRPC.msg_params: Missing mandatory parameter: moduleType"
   elseif pInfoType == "NOT_EXISTING_MODULE" then
     return "Accessing not supported module"
   end
@@ -536,10 +537,7 @@ function common.releaseModuleWithInfoCheck(pAppId, pModuleType, pModuleId, pResu
   end
   local cid = mobSession:SendRPC("ReleaseInteriorVehicleDataModule",
       { moduleType = pModuleType, moduleId = pModuleId })
-  mobSession:ExpectResponse(cid, { success = isSuccess, resultCode = pResultCode })
-  :ValidIf(function(_, data)
-    return string.match(data.payload.info, infoMsg)
-  end)
+  mobSession:ExpectResponse(cid, { success = isSuccess, resultCode = pResultCode, info = infoMsg })
 end
 
 function common.releaseModuleNoModuleId(pAppId, pModuleType, pModuleId, pResultCode, pInfoType, pRCAppIds)

--- a/test_scripts/RC/MultipleModules/commonRCMulModules.lua
+++ b/test_scripts/RC/MultipleModules/commonRCMulModules.lua
@@ -538,7 +538,7 @@ function common.releaseModuleWithInfoCheck(pAppId, pModuleType, pModuleId, pResu
       { moduleType = pModuleType, moduleId = pModuleId })
   mobSession:ExpectResponse(cid, { success = isSuccess, resultCode = pResultCode })
   :ValidIf(function(_, data)
-    return string.find(data.payload.info, infoMsg, 1, true) and true or false
+    return string.find(data.payload.info, infoMsg, 1, true) ~= nil
   end)
 end
 


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Within merge of https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2419 it was introduced `string.match` function to validate `info` message. However 2nd argument of this function may have special characters that need to be escaped. These are ` ( ) . % + - * ? [ ^ $`. Unfortunately some tests failed since info message contains `[` character which is in the list:
```
./test_scripts/RC/MultipleModules/ModulesAllocation/052_ReleaseInteriorVehicleDataModule_current_app.lua
./test_scripts/RC/MultipleModules/ModulesAllocation/053_ReleaseInteriorVehicleDataModule_another_app.lua
./test_scripts/RC/MultipleModules/ModulesAllocation/054_ReleaseInteriorVehicleDataModule_free.lua	
```

### ATF version
develop

### Changelog
 - Function `string.match` has replaced by regular `=`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
