### PR TITLE
delete contents of the storage folder instead of the entire folde

### DIFF
--- a/test_scripts/API/SetAppIcon/commonIconResumed.lua
+++ b/test_scripts/API/SetAppIcon/commonIconResumed.lua
@@ -188,8 +188,8 @@ local preconditionsOrig = m.preconditions
 --]]
 function m.preconditions()
   preconditionsOrig()
-  local storage = commonPreconditions:GetPathToSDL() .. "storage"
-  os.execute("rm -rf " .. storage)
+  local storage = commonPreconditions:GetPathToSDL() .. "storage/*"
+  assert(os.execute("rm -rf " .. storage))
 end
 
 return m

--- a/test_scripts/API/SubMenuIcon/commonSubMenuIcon.lua
+++ b/test_scripts/API/SubMenuIcon/commonSubMenuIcon.lua
@@ -91,8 +91,8 @@ local preconditionsOrig = m.preconditions
 
 function m.preconditions()
   preconditionsOrig()
-  local storage = commonPreconditions:GetPathToSDL() .. "storage"
-  os.execute("rm -rf " .. storage)
+  local storage = commonPreconditions:GetPathToSDL() .. "storage/*"
+  assert(os.execute("rm -rf " .. storage))
 end
 
 return m

--- a/test_scripts/CloudAppRPCs/commonCloudAppRPCs.lua
+++ b/test_scripts/CloudAppRPCs/commonCloudAppRPCs.lua
@@ -74,12 +74,12 @@ end
 function commonCloudAppRPCs.DeleteStorageFolder()
   local ExistDirectoryResult = commonCloudAppRPCs:Directory_exist( tostring(config.pathToSDL .. "storage"))
   if ExistDirectoryResult == true then
-    local RmFolder  = assert( os.execute( "rm -rf " .. tostring(config.pathToSDL .. "storage" )))
+    local RmFolder  = assert( os.execute( "rm -rf " .. tostring(config.pathToSDL .. "storage/*" )))
     if RmFolder ~= true then
       print("Folder 'storage' is not deleted")
     end
   else
-    print("Folder 'storage' is absent")
+    print("Folder 'storage' is empty")
   end
 end
 

--- a/test_scripts/SDL5_0/TTSChunks/common.lua
+++ b/test_scripts/SDL5_0/TTSChunks/common.lua
@@ -25,8 +25,8 @@ local preconditionsOrig = m.preconditions
 --]]
 function m.preconditions()
   preconditionsOrig()
-  local storage = commonPreconditions:GetPathToSDL() .. "storage"
-  os.execute("rm -rf " .. storage)
+  local storage = commonPreconditions:GetPathToSDL() .. "storage/*"
+  assert(os.execute("rm -rf " .. storage))
 end
 
 local startOrigin = m.start

--- a/test_scripts/smoke_api.lua
+++ b/test_scripts/smoke_api.lua
@@ -15,7 +15,7 @@ commonSteps:DeleteLogsFileAndPolicyTable()
 
 commonPreconditions:BackupFile("sdl_preloaded_pt.json")
 os.execute("cp -f files/jsons/sdl_preloaded_pt_smoke_api.json " .. commonPreconditions:GetPathToSDL() .. "sdl_preloaded_pt.json")
-local appStorageFolder = commonPreconditions:GetPathToSDL() .. commonFunctions:read_parameter_from_smart_device_link_ini("AppStorageFolder")
+local appStorageFolder = commonPreconditions:GetPathToSDL() .. commonFunctions:read_parameter_from_smart_device_link_ini("AppStorageFolder") .. "/*"
 os.execute("rm -rf " .. appStorageFolder)
 
 Test = require('connecttest')

--- a/user_modules/shared_testcases/testCasesForExternalUCS.lua
+++ b/user_modules/shared_testcases/testCasesForExternalUCS.lua
@@ -59,9 +59,10 @@ local m = { }
 --]]
   function m.removeLPT()
     local data = { "AppStorageFolder", "AppInfoStorage" }
-    for _, v in pairs(data) do
-      os.execute("rm -rf " .. commonPreconditions:GetPathToSDL()
-        .. commonFunctions:read_parameter_from_smart_device_link_ini(v))
+    for i, v in pairs(data) do
+      assert(os.execute("rm -rf " .. commonPreconditions:GetPathToSDL()
+        .. commonFunctions:read_parameter_from_smart_device_link_ini(v)
+        .. (i == 1 and "/*" or "")))
     end
   end
 


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Change removal of the storage folder to actually remove storage folder contents.

This is needed because in our parallel atf runner, I recently added a ramdisk mount at core's storage folder to ease the stress on disk. Now Core's backup thread will be writing to RAM instead of disk making the whole system faster. This causes one test to fail: `./test_scripts/CloudAppRPCs/010_get_icon_url.lua` because it cannot delete a folder that is a mount. This PR will enable all tests to pass with storage as a ramdisk.

### ATF version
latest

### Changelog

##### Enhancements
* core's storage folder can be a mount

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
