### PR TITLE
Test set for defects included in Release 7.0

### DIFF
--- a/test_sets/Defects/6_2/2395.txt
+++ b/test_sets/Defects/6_2/2395.txt
@@ -1,1 +1,0 @@
-./test_scripts/Defects/6_2/2395_SDL_must_store_OnWayPointChange_internally_and_resend_this_notification_to_each_subscribed_apps.lua

--- a/test_sets/Defects/6_2/955.txt
+++ b/test_sets/Defects/6_2/955.txt
@@ -1,1 +1,0 @@
-./test_scripts/Defects/6_2/955_incorrect_response_on_send_SystemRequest.lua

--- a/test_sets/Defects/Defects_release_7_0.txt
+++ b/test_sets/Defects/Defects_release_7_0.txt
@@ -1,0 +1,9 @@
+./test_scripts/Defects/7_0/955_incorrect_response_on_send_SystemRequest.lua
+./test_scripts/Defects/7_0/1398_RAI_duplicate_name.lua
+./test_scripts/Defects/7_0/1581_SubscribeVehicleData_Twice_Ignored.lua
+./test_scripts/Defects/7_0/2116_OnButtonPress_LimitedHMILevel.lua
+./test_scripts/Defects/7_0/2395_SDL_must_store_OnWayPointChange_internally_and_resend_this_notification_to_each_subscribed_apps.lua
+./test_scripts/Defects/7_0/2430_AppSendsRPCWIthProtocolVersionAboveMax_IsUnregistered.lua
+./test_scripts/Defects/7_0/2461_UnsubscribeWaypoints_OnDisconnect.lua
+./test_scripts/Defects/7_0/3119_ChangeRegistration_with_unsupported_language.lua
+./test_scripts/Defects/7_0/3372_StaySubscribedWaypoints_OnOtherAppDisconnect.lua


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Introduced test set for fixed defects in scope of Release 7.0

### ATF version
develop

### Changelog
 - Added new test set for defects of 7.0
 - Removed obsolete test sets for 6.2

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
