### PR TITLE
Clean up all events in Smoke postconditions step

### DIFF
--- a/test_scripts/Smoke/commonSmoke.lua
+++ b/test_scripts/Smoke/commonSmoke.lua
@@ -63,7 +63,7 @@ end
 local isPreloadedUpdated = false
 
 function common.postconditions()
-  if SDL:CheckStatusSDL() == SDL.RUNNING then SDL:StopSDL() end
+  StopSDL()
   common.restoreSDLIniParameters()
   if isPreloadedUpdated == true then SDL.PreloadedPT.restore() end
 end


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Fix issue with smoke tests for remote connection mode.
Tests were aborted with error:
```
Lua panic: ./modules/hmi_adapter/remote_hmi_adapter.lua:57: attempt to index field 'connection' (a nil value) (/home/developer/sdl/sdl_atf/src/remote_adapter/remote_adapter_client/lua_remote_library.cc:16)
```

### ATF version
develop

### Changelog
Function `SDL:StopSDL()` with condition has replaced by `StopSDL()` which stops SDL and cleans up all outstanding events and expectations. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
