### PR TITLE
Add test to check legacy app sending newer rpc's

### DIFF
--- a/test_scripts/API/ShowAppMenu/commonShowAppMenu.lua
+++ b/test_scripts/API/ShowAppMenu/commonShowAppMenu.lua
@@ -47,11 +47,18 @@ function m.showAppMenuSuccess(pMenuID)
   m.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
 end
 
-function m.showAppMenuUnsuccess(pMenuID, pResultCode)
+function m.showAppMenuUnsuccess(pMenuID, pResultCode, infoExists)
   local cid = m.getMobileSession():SendRPC("ShowAppMenu", { menuID = pMenuID })
   m.getHMIConnection():ExpectRequest("UI.ShowAppMenu")
   :Times(0)
   m.getMobileSession():ExpectResponse(cid, { success = false, resultCode = pResultCode })
+  :ValidIf(function(_,data)
+    if (infoExists == true) then
+      return data.payload.info ~= nil
+    else
+      return true
+    end
+  end)
   m.getMobileSession():ExpectNotification("OnHashChange")
   :Times(0)
 end

--- a/test_scripts/SDL5_0/MobileVersioning/VersionNegotiation/003_legacy_app_new_rpc_fail.lua
+++ b/test_scripts/SDL5_0/MobileVersioning/VersionNegotiation/003_legacy_app_new_rpc_fail.lua
@@ -1,0 +1,32 @@
+---------------------------------------------------------------------------------------------------
+-- Description:
+-- In case:
+-- 1) Mobile application is registered with 5.x rpc spec version
+-- 2) Mobile application is added SubMenu with menuID  = 5
+-- 3) Mobile sends ShowAppMenu request with menuID = 5 parameter to SDL
+-- SDL does:
+-- 1) Sends INVALID_DATA with info string saying the RPC is not available for 5.x
+---------------------------------------------------------------------------------------------------
+-- [[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/API/ShowAppMenu/commonShowAppMenu')
+
+-- [[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+config.application1.registerAppInterfaceParams.appHMIType = { "PROJECTION" }
+config.application1.registerAppInterfaceParams.syncMsgVersion.majorVersion = 5
+local menuID = 5
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("App registration", common.registerApp)
+
+runner.Title("Test")
+runner.Step("App activate, HMI SystemContext MAIN", common.activateApp)
+runner.Step("Add menu", common.addSubMenu, { menuID })
+runner.Step("Send show app menu, HMI SystemContext MAIN", common.showAppMenuUnsuccess, { menuID, "INVALID_DATA", true })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_sets/SDL5_0/mobile_api_versioning.txt
+++ b/test_sets/SDL5_0/mobile_api_versioning.txt
@@ -1,6 +1,7 @@
 ;Version Negotiation
 ./test_scripts/SDL5_0/MobileVersioning/VersionNegotiation/001_register_legacy_app.lua
 ./test_scripts/SDL5_0/MobileVersioning/VersionNegotiation/002_register_app_on_legacy_module.lua
+./test_scripts/SDL5_0/MobileVersioning/VersionNegotiation/003_legacy_app_new_rpc_fail.lua
 ./test_scripts/Smoke/API/008_CreateInteractionChoiceSet_PositiveCase_SUCCESS.lua
 ./test_scripts/Smoke/API/012_PerfomInteraction_PositiveCase_SUCCESS.lua
 ;VR-Command Optional


### PR DESCRIPTION
ATF Test Scripts to check #[3466](https://github.com/smartdevicelink/sdl_core/issues/3466)

This PR is **Ready** for review.

### Summary
Adds a test to check that an older app sending a newer rpc receives invalid data with an info string.

### ATF version
Develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
