### PR TITLE
Add dd capability to persisting hmi capability tests

### DIFF
--- a/test_scripts/Capabilities/PersistingHMICapabilities/017_getSystemCapability_use_default_capability_cache_is_not_exist.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/017_getSystemCapability_use_default_capability_cache_is_not_exist.lua
@@ -25,7 +25,8 @@ local systemCapabilities = {
   PHONE_CALL = { phoneCapability = hmiCapabilities.UI.systemCapabilities.phoneCapability },
   VIDEO_STREAMING = { videoStreamingCapability = hmiCapabilities.UI.systemCapabilities.videoStreamingCapability },
   REMOTE_CONTROL = { remoteControlCapability = hmiCapabilities.RC.remoteControlCapability },
-  SEAT_LOCATION = { seatLocationCapability = hmiCapabilities.RC.seatLocationCapability }
+  SEAT_LOCATION = { seatLocationCapability = hmiCapabilities.RC.seatLocationCapability },
+  DRIVER_DISTRACTION = { driverDistractionCapability = hmiCapabilities.UI.systemCapabilities.driverDistractionCapability }
 }
 
 --[[ Scenario ]]

--- a/test_scripts/Capabilities/PersistingHMICapabilities/018_getSystemCapability_use_default_does_not_contain_correspond_cap.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/018_getSystemCapability_use_default_does_not_contain_correspond_cap.lua
@@ -31,7 +31,9 @@ local systemCapabilities = {
   UI = {
     NAVIGATION = { navigationCapability = hmiCapabilities.UI.systemCapabilities.navigationCapability },
     PHONE_CALL = { phoneCapability = hmiCapabilities.UI.systemCapabilities.phoneCapability },
-    VIDEO_STREAMING = { videoStreamingCapability = hmiCapabilities.UI.systemCapabilities.videoStreamingCapability }},
+    VIDEO_STREAMING = { videoStreamingCapability = hmiCapabilities.UI.systemCapabilities.videoStreamingCapability },
+    DRIVER_DISTRACTION = { driverDistractionCapability = hmiCapabilities.UI.systemCapabilities.driverDistractionCapability }
+  },
   RC = {
     REMOTE_CONTROL = { remoteControlCapability = hmiCapabilities.RC.remoteControlCapability },
     SEAT_LOCATION = { seatLocationCapability = hmiCapabilities.RC.seatLocationCapability }

--- a/test_scripts/Capabilities/PersistingHMICapabilities/021_getSystemCapability_use_cache_capability.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/021_getSystemCapability_use_cache_capability.lua
@@ -42,7 +42,9 @@ local systemCapabilities = {
   REMOTE_CONTROL = {
     remoteControlCapability = getRcCapabilitiesWithUpdatedAllowMultipleAccess() },
   SEAT_LOCATION = {
-    seatLocationCapability = hmiCap.RC.GetCapabilities.params.seatLocationCapability }
+    seatLocationCapability = hmiCap.RC.GetCapabilities.params.seatLocationCapability },
+  DRIVER_DISTRACTION = { 
+    driverDistractionCapability = hmiCap.UI.GetCapabilities.params.systemCapabilities.driverDistractionCapability }
 }
 
 --[[ Scenario ]]

--- a/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
@@ -268,6 +268,8 @@ function m.updateHMICapabilitiesTable(isRemainData)
     hmiCapTbl.UI.systemCapabilities.navigationCapability.sendLocationEnabled = false
     hmiCapTbl.UI.systemCapabilities.phoneCapability.dialNumberEnabled = false
     hmiCapTbl.UI.systemCapabilities.videoStreamingCapability.maxBitrate = 50000
+    hmiCapTbl.UI.systemCapabilities.driverDistractionCapability.menuLength = 4
+    hmiCapTbl.UI.systemCapabilities.driverDistractionCapability.subMenuDepth = 2
     table.remove(hmiCapTbl.Buttons.capabilities, 1)
     hmiCapTbl.VehicleInfo.vehicleType.modelYear = 2000
     hmiCapTbl.UI.language = "JA-JP"


### PR DESCRIPTION
ATF Test Scripts to check Core pr: https://github.com/smartdevicelink/sdl_core/pull/3478/files
This PR is **ready** for review.

### Summary
Add driver distraction capability to the persisting hmi capabilities tests

### ATF version
Develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
