### PR TITLE
Fix/hmi states management

### DIFF
--- a/test_scripts/API/SDL_Passenger_Mode/commonPassengerMode.lua
+++ b/test_scripts/API/SDL_Passenger_Mode/commonPassengerMode.lua
@@ -116,7 +116,7 @@ end
 
 local function deactivateAppToBackground()
   c.getHMIConnection():SendNotification("BasicCommunication.OnEventChanged", {
-    eventName = "AUDIO_SOURCE", isActive = true
+    eventName = "EMBEDDED_NAVI", isActive = true
   })
   c.getMobileSession():ExpectNotification("OnHMIStatus",
     { hmiLevel = "BACKGROUND", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })

--- a/test_scripts/MobileProjection/Phase2/003_audioStreamingState_069-103.lua
+++ b/test_scripts/MobileProjection/Phase2/003_audioStreamingState_069-103.lua
@@ -33,7 +33,7 @@ local testCases = {
   [081] = { t = "MEDIA",         m = true,  s = "NOT_AUDIBLE", e = "EMERGENCY_EVENT" },
   [082] = { t = "DEFAULT",       m = true,  s = "NOT_AUDIBLE", e = "EMERGENCY_EVENT" },
   [083] = { t = "NAVIGATION",    m = false, s = "AUDIBLE",     e = "AUDIO_SOURCE" },
-  [084] = { t = "NAVIGATION",    m = true,  s = "NOT_AUDIBLE", e = "AUDIO_SOURCE" },
+  [084] = { t = "NAVIGATION",    m = true,  s = "AUDIBLE",     e = "AUDIO_SOURCE" },
   [085] = { t = "COMMUNICATION", m = false, s = "AUDIBLE",     e = "AUDIO_SOURCE" },
   [086] = { t = "COMMUNICATION", m = true,  s = "NOT_AUDIBLE", e = "AUDIO_SOURCE" },
   [087] = { t = "PROJECTION",    m = true,  s = "NOT_AUDIBLE", e = "AUDIO_SOURCE" },

--- a/test_scripts/MobileProjection/Phase2/015_audio_083-089_097-103_video_031-038_states_not_FULL.lua
+++ b/test_scripts/MobileProjection/Phase2/015_audio_083-089_097-103_video_031-038_states_not_FULL.lua
@@ -33,7 +33,7 @@ local testCases = {
   [008] = { t = "MEDIA",         m = false, e = "DEACTIVATE_HMI" },
   [009] = { t = "DEFAULT",       m = true,  e = "DEACTIVATE_HMI" },
   [010] = { t = "DEFAULT",       m = false, e = "DEACTIVATE_HMI" },
-  [011] = { t = "NAVIGATION",    m = true,  e = "AUDIO_SOURCE", v = "STREAMABLE", h = "LIMITED" },
+  [011] = { t = "NAVIGATION",    m = true,  e = "AUDIO_SOURCE", a = "AUDIBLE", v = "STREAMABLE", h = "LIMITED" },
   [012] = { t = "NAVIGATION",    m = false, e = "AUDIO_SOURCE", a = "AUDIBLE", v = "STREAMABLE", h = "LIMITED" },
   [013] = { t = "PROJECTION",    m = true,  e = "AUDIO_SOURCE", v = "STREAMABLE", h = "LIMITED" },
   [014] = { t = "PROJECTION",    m = false, e = "AUDIO_SOURCE", v = "STREAMABLE", h = "LIMITED" },

--- a/test_scripts/WebEngine/WebEngineProjection/012_audioStreamingState_transitions_on_HMI_events.lua
+++ b/test_scripts/WebEngine/WebEngineProjection/012_audioStreamingState_transitions_on_HMI_events.lua
@@ -10,8 +10,10 @@
 --
 -- Sequence:
 -- 1) One of the events below is received from HMI within 'BC.OnEventChanged' notification:
---    PHONE_CALL, EMERGENCY_EVENT, AUDIO_SOURCE, EMBEDDED_NAVI
+--    PHONE_CALL, EMERGENCY_EVENT, AUDIO_SOURCE
 --   a. SDL sends OnHMIStatus notification with 'audioStreamingState' = NOT_AUDIBLE
+-- 2) EMBEDDED_NAVI event is received from HMI within 'BC.OnEventChanged' notification
+--   a. SDL sends OnHMIStatus notification with 'audioStreamingState' = AUDIBLE
 ---------------------------------------------------------------------------------------------------
 --[[ Required Shared libraries ]]
 local common = require('test_scripts/WebEngine/commonWebEngine')
@@ -28,7 +30,7 @@ local testCases = {
   [001] = { appType = "WEB_VIEW", isMedia = true, audioState = "NOT_AUDIBLE", event = "PHONE_CALL" },
   [002] = { appType = "WEB_VIEW", isMedia = true, audioState = "NOT_AUDIBLE", event = "EMERGENCY_EVENT" },
   [003] = { appType = "WEB_VIEW", isMedia = true, audioState = "NOT_AUDIBLE", event = "AUDIO_SOURCE" },
-  [004] = { appType = "WEB_VIEW", isMedia = true, audioState = "NOT_AUDIBLE", event = "EMBEDDED_NAVI" }
+  [004] = { appType = "WEB_VIEW", isMedia = true, audioState = "AUDIBLE", event = "EMBEDDED_NAVI" }
 }
 
 --[[ Local Functions ]]

--- a/test_scripts/WebEngine/WebEngineProjection/014_HMI_status_transitions_different_applications_interactions.lua
+++ b/test_scripts/WebEngine/WebEngineProjection/014_HMI_status_transitions_different_applications_interactions.lua
@@ -127,7 +127,7 @@ local testCase = {
       action = { event = common.userActions.embeddedNaviActivate, appId = "none" },
       checks = {
         onHmiStatus = {
-          [1] = { hmiLvl = "BACKGROUND", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE" },
+          [1] = { }, -- hmiLvl = "LIMITED", audio = "AUDIBLE", video = "NOT_STREAMABLE"
           [2] = { hmiLvl = "BACKGROUND", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE" },
           [3] = { }, -- hmiLvl = "BACKGROUND", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE"
           [4] = { hmiLvl = "BACKGROUND", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE" }
@@ -138,7 +138,7 @@ local testCase = {
       action = { event = common.userActions.embeddedNaviDeactivate, appId = "none" },
       checks = {
         onHmiStatus = {
-          [1] = { hmiLvl = "LIMITED", audio = "AUDIBLE", video = "NOT_STREAMABLE" },
+          [1] = { }, -- hmiLvl = "LIMITED", audio = "AUDIBLE", video = "NOT_STREAMABLE"
           [2] = { hmiLvl = "FULL", audio = "NOT_AUDIBLE", video = "STREAMABLE" },
           [3] = { }, -- hmiLvl = "BACKGROUND", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE"
           [4] = { hmiLvl = "LIMITED", audio = "AUDIBLE", video = "NOT_STREAMABLE" }


### PR DESCRIPTION
Fixes in ATF Test Scripts related to the https://github.com/smartdevicelink/sdl_core/pull/3476 and https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2452

This PR is **[ready]** for review.

### Summary
Update the scripts to reflect the SDL Core changes that were made in the scope of "Overhaul state manager to handle regular state changes during hmi events" PR

The user activates embedded audio source -> Navi app should get LIMITED and AUDIBLE
Ures activates embedded navigation -> Web View (isMedia = true) app should get LIMITED and AUDIBLE

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
