### PR TITLE
Update additionalExp for webSocketServerSupport == OFF

### DIFF
--- a/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
@@ -637,7 +637,11 @@ local function initHmiOnReady(hmi_table)
   end
 
   local additionalExp = nil
-  local additionalExpName = "BasicCommunication.UpdateDeviceList"
+  local additionalExpName = "BasicCommunication.GetSystemInfo"
+  if SDL.buildOptions.webSocketServerSupport == "ON" then
+    additionalExpName = "BasicCommunication.UpdateDeviceList"
+  end
+
   for k_module, v_module in pairs(hmi_table_internal) do
     if type(v_module) ~= "table" then
       break


### PR DESCRIPTION
Fix https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2455

This PR is **[ready]** for review.

### Summary

The `hmiOnReady()` function does not work as expected if the SDL was built with `BUILD_WEBSOCKET_SERVER_SUPPORT=OFF` because SDL doesn't send UpdateDeviceList before the connectMobile()

Now additionalExp will contain UpdateDeviceList only if `BUILD_WEBSOCKET_SERVER_SUPPORT=ON` and GetSystemInfo if `BUILD_WEBSOCKET_SERVER_SUPPORT=OFF` 

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
