### PR TITLE
Fix delay in scripts for Resumption Error Handling

### DIFF
--- a/test_scripts/Resumption/Handling_errors_from_HMI/commonResumptionErrorHandling.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/commonResumptionErrorHandling.lua
@@ -1659,7 +1659,7 @@ function m.reRegisterAppsCustom_SameRPC(pTimeToRegApp2, pRPC)
           m.errorResponse(data, 0)
           m.reRegisterAppCustom(2, "SUCCESS", 300):Do(function() isRAIResponseSent[2] = true end)
         else
-          m.errorResponse(data, 0)
+          m.errorResponse(data, 300)
         end
       else
         m.log(data.method .. ": SUCCESS")
@@ -1733,7 +1733,7 @@ function m.reRegisterAppsCustom_AnotherRPC(pTimeToRegApp2, pRPC)
         m.errorResponse(data, 0)
         m.reRegisterAppCustom(2, "SUCCESS", 300):Do(function() isRAIResponseSent[2] = true end)
       else
-        m.errorResponse(data, 0)
+        m.errorResponse(data, 300)
       end
     end)
 


### PR DESCRIPTION
This update in scripts is required for https://github.com/smartdevicelink/sdl_core/issues/3502

This PR is **[ready]** for review.

### Summary
Delay to send an error response from HMI is increased for the case when 2nd app is registered just after the 1st one.
This improves stability of the script.

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
