### PR TITLE
Force connection type in WebEngineProjection scripts

### DIFF
--- a/test_scripts/WebEngine/WebEngineProjection/014_HMI_status_transitions_different_applications_interactions.lua
+++ b/test_scripts/WebEngine/WebEngineProjection/014_HMI_status_transitions_different_applications_interactions.lua
@@ -23,6 +23,9 @@
 -- Particular values depends on app's 'appHMIType', 'isMediaApplication' flag, current app's state
 -- and described in 'testCases' table below
 ---------------------------------------------------------------------------------------------------
+--[[ General configuration parameters ]]
+config.defaultMobileAdapterType = "TCP"
+
 --[[ Required Shared libraries ]]
 local common = require('test_scripts/WebEngine/commonWebEngine')
 

--- a/test_scripts/WebEngine/WebEngineProjection/027_OnExitApplication_RESOURCE_CONSTRAINT_multiple_apps_on_different_connections.lua
+++ b/test_scripts/WebEngine/WebEngineProjection/027_OnExitApplication_RESOURCE_CONSTRAINT_multiple_apps_on_different_connections.lua
@@ -19,6 +19,9 @@
 --  d. SDL does not close mobile connection 1
 --  e. SDL does not send OnAppInterfaceUnregistered notification with reason: "RESOURCE_CONSTRAINT" to App1
 ---------------------------------------------------------------------------------------------------
+--[[ General configuration parameters ]]
+config.defaultMobileAdapterType = "TCP"
+
 --[[ Required Shared libraries ]]
 local common = require('test_scripts/WebEngine/commonWebEngine')
 


### PR DESCRIPTION
ATF Test Scripts to check [#2458](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2458)

This PR is **[ready]** for review.

### Summary
Since scripts mentioned in issue have Mobile (TCP) and WebWngine (WS) connections for different apps, the idea is to force default mobile connection to `TCP` transport and retain `WS` for WebEngine connection.

### ATF version
develop

### Changelog
Force `TCP` transport for mobile connection

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
