### PR TITLE
Get rid of internal name conversion for `bitsPerSample` and `samplingRate` parameters

### DIFF
--- a/files/hmi_capabilities_SearchButton.json
+++ b/files/hmi_capabilities_SearchButton.json
@@ -279,7 +279,7 @@
         },
         "audioPassThruCapabilities": {
             "samplingRate": "44KHZ",
-            "bitsPerSample": "RATE_8_BIT",
+            "bitsPerSample": "8_BIT",
             "audioType": "PCM"
         },
         "hmiZoneCapabilities": "FRONT",

--- a/files/hmi_capabilities_Without_PRESET9.json
+++ b/files/hmi_capabilities_Without_PRESET9.json
@@ -279,7 +279,7 @@
         },
         "audioPassThruCapabilities": {
             "samplingRate": "44KHZ",
-            "bitsPerSample": "RATE_8_BIT",
+            "bitsPerSample": "8_BIT",
             "audioType": "PCM"
         },
         "hmiZoneCapabilities": "FRONT",

--- a/test_scripts/API/ATF_RegisterAppInterface.lua
+++ b/test_scripts/API/ATF_RegisterAppInterface.lua
@@ -13435,9 +13435,9 @@ local checkedCapabilities = {
 }
 
 samplingRateEnum = {"8KHZ", "16KHZ", "22KHZ", "44KHZ"}
-samplingRateEnumInternal = {"RATE_8KHZ", "RATE_16KHZ", "RATE_22KHZ", "RATE_44KHZ"}
+samplingRateEnumInternal = {"8KHZ", "16KHZ", "22KHZ", "44KHZ"}
 bitsPerSampleEnum = {"8_BIT", "16_BIT"}
-bitsPerSampleEnumInternal = {"RATE_8_BIT", "RATE_16_BIT"}
+bitsPerSampleEnumInternal = {"8_BIT", "16_BIT"}
 audioTypeEnum = {"PCM"}
 
 for keySample, smplRate in pairs(samplingRateEnum) do
@@ -13512,8 +13512,7 @@ for keySample, smplRate in pairs(samplingRateEnum) do
 			function Test:CheckPcmStreamCapabilities(...)
 				-- body
 				self.mobileSession:StartService(7)
-				:Do(function (_,data)
-					checkedCapabilities.bitsPerSample = string.sub(checkedCapabilities.bitsPerSample, 6)
+				:Do(function (_,data)					
 					RegisterAppForCheckPcmStreamCapabilities(self, checkedCapabilities)
 				end)
 			end
@@ -13553,8 +13552,7 @@ for keySample, smplRate in pairs(samplingRateEnumInternal) do
 			function Test:CheckPcmStreamCapabilities(...)
 				-- body
 				self.mobileSession:StartService(7)
-				:Do(function (_,data)
-					checkedCapabilities.samplingRate = string.sub(checkedCapabilities.samplingRate, 6)
+				:Do(function (_,data)					
 					RegisterAppForCheckPcmStreamCapabilities(self, checkedCapabilities)
 				end)
 			end
@@ -13594,9 +13592,7 @@ for keySample, smplRate in pairs(samplingRateEnumInternal) do
 			function Test:CheckPcmStreamCapabilities(...)
 				-- body
 				self.mobileSession:StartService(7)
-				:Do(function (_,data)
-					checkedCapabilities.samplingRate = string.sub(checkedCapabilities.samplingRate, 6)
-					checkedCapabilities.bitsPerSample = string.sub(checkedCapabilities.bitsPerSample, 6)
+				:Do(function (_,data)					
 					RegisterAppForCheckPcmStreamCapabilities(self, checkedCapabilities)
 				end)
 			end

--- a/test_scripts/Capabilities/PersistingHMICapabilities/019_RAI_use_default_capability_does_not_contain_correspond_cap.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/019_RAI_use_default_capability_does_not_contain_correspond_cap.lua
@@ -41,27 +41,12 @@ local function updateHMICaps(pMod, pRequest)
   end
 end
 
-local function changeInternalNameRate(pCapabilities)
-  local capTable = common.cloneTable(pCapabilities)
-    capTable.bitsPerSample = string.gsub(capTable.bitsPerSample, "RATE_", "")
-    capTable.samplingRate = string.gsub(capTable.samplingRate, "RATE_", "")
-  return capTable
-end
-
-local function changeInternalNameRateArray(pCapabilities)
-  local capTableArray = common.cloneTable(pCapabilities)
-  for key, value in ipairs(capTableArray) do
-    capTableArray[key] = changeInternalNameRate(value)
-  end
-  return capTableArray
-end
-
 local function buildCapRaiResponse(pMod, pReq)
   local capRaiResponse = {
     UI = {
       GetCapabilities = {
-        audioPassThruCapabilities = changeInternalNameRateArray(hmiCapabilities.UI.audioPassThruCapabilities),
-        pcmStreamCapabilities = changeInternalNameRate(hmiCapabilities.UI.pcmStreamCapabilities),
+        audioPassThruCapabilities = hmiCapabilities.UI.audioPassThruCapabilities,
+        pcmStreamCapabilities = hmiCapabilities.UI.pcmStreamCapabilities,
         hmiZoneCapabilities = { hmiCapabilities.UI.hmiZoneCapabilities },
         softButtonCapabilities = hmiCapabilities.UI.softButtonCapabilities,
         displayCapabilities = common.buildDisplayCapForMobileExp(hmiCapabilities.UI.displayCapabilities),

--- a/test_scripts/Capabilities/PersistingHMICapabilities/020_RAI_use_default_capability_cache_file_is_not_exist.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/020_RAI_use_default_capability_cache_file_is_not_exist.lua
@@ -22,28 +22,13 @@ local appSessionId = 1
 local hmiCapabilities = common.getHMICapabilitiesFromFile()
 
 --[[ Local Functions ]]
-local function changeInternalNameRate(pCapabilities)
-  local capTable = common.cloneTable(pCapabilities)
-    capTable.bitsPerSample = string.gsub(capTable.bitsPerSample, "RATE_", "")
-    capTable.samplingRate = string.gsub(capTable.samplingRate, "RATE_", "")
-  return capTable
-end
-
-local function changeInternalNameRateArray(pCapabilities)
-  local capTableArray = common.cloneTable(pCapabilities)
-  for key, value in ipairs(capTableArray) do
-    capTableArray[key] = changeInternalNameRate(value)
-  end
-  return capTableArray
-end
-
 local capRaiResponse = {
   buttonCapabilities = hmiCapabilities.Buttons.capabilities,
   vehicleType = hmiCapabilities.VehicleInfo.vehicleType,
-  audioPassThruCapabilities = changeInternalNameRateArray(hmiCapabilities.UI.audioPassThruCapabilities),
+  audioPassThruCapabilities = hmiCapabilities.UI.audioPassThruCapabilities,
   hmiDisplayLanguage =  hmiCapabilities.UI.language,
   language = hmiCapabilities.VR.language, -- or TTS.language
-  pcmStreamCapabilities = changeInternalNameRate(hmiCapabilities.UI.pcmStreamCapabilities),
+  pcmStreamCapabilities = hmiCapabilities.UI.pcmStreamCapabilities,
   hmiZoneCapabilities = { hmiCapabilities.UI.hmiZoneCapabilities },
   softButtonCapabilities = hmiCapabilities.UI.softButtonCapabilities,
   displayCapabilities = common.buildDisplayCapForMobileExp(hmiCapabilities.UI.displayCapabilities),

--- a/test_scripts/Capabilities/PersistingHMICapabilities/028_Suspending_of_RAI_request_processing_in_case_no_cap_response.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/028_Suspending_of_RAI_request_processing_in_case_no_cap_response.lua
@@ -27,28 +27,13 @@ local hmiCapabilities = common.getHMICapabilitiesFromFile()
 local delayRaiResponse = 10000
 
 --[[ Local Functions ]]
-local function changeInternalNameRate(pCapabilities)
-  local capTable = common.cloneTable(pCapabilities)
-    capTable.bitsPerSample = string.gsub(capTable.bitsPerSample, "RATE_", "")
-    capTable.samplingRate = string.gsub(capTable.samplingRate, "RATE_", "")
-  return capTable
-end
-
-local function changeInternalNameRateArray(pCapabilities)
-  local capTableArray = common.cloneTable(pCapabilities)
-  for key, value in ipairs(capTableArray) do
-    capTableArray[key] = changeInternalNameRate(value)
-  end
-  return capTableArray
-end
-
 local capRaiResponse = {
   buttonCapabilities = hmiCapabilities.Buttons.capabilities,
   vehicleType = hmiCapabilities.VehicleInfo.vehicleType,
-  audioPassThruCapabilities = changeInternalNameRateArray(hmiCapabilities.UI.audioPassThruCapabilities),
+  audioPassThruCapabilities = hmiCapabilities.UI.audioPassThruCapabilities,
   hmiDisplayLanguage =  hmiCapabilities.UI.language,
   language = hmiCapabilities.VR.language, -- or TTS.language
-  pcmStreamCapabilities = changeInternalNameRate(hmiCapabilities.UI.pcmStreamCapabilities),
+  pcmStreamCapabilities = hmiCapabilities.UI.pcmStreamCapabilities,
   hmiZoneCapabilities = { hmiCapabilities.UI.hmiZoneCapabilities },
   softButtonCapabilities = hmiCapabilities.UI.softButtonCapabilities,
   displayCapabilities = common.buildDisplayCapForMobileExp(hmiCapabilities.UI.displayCapabilities),

--- a/test_scripts/Capabilities/PersistingHMICapabilities/031_Suspending_of_RAI_request_processing_in_case_cache_file_does_not_exist_no_cap_response.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/031_Suspending_of_RAI_request_processing_in_case_cache_file_does_not_exist_no_cap_response.lua
@@ -31,28 +31,13 @@ local delayRaiResponse = 10000
 local hmiCapabilities = common.getHMICapabilitiesFromFile()
 
 --[[ Local Functions ]]
-local function changeInternalNameRate(pCapabilities)
-  local capTable = common.cloneTable(pCapabilities)
-    capTable.bitsPerSample = string.gsub(capTable.bitsPerSample, "RATE_", "")
-    capTable.samplingRate = string.gsub(capTable.samplingRate, "RATE_", "")
-  return capTable
-end
-
-local function changeInternalNameRateArray(pCapabilities)
-  local capTableArray = common.cloneTable(pCapabilities)
-  for key, value in ipairs(capTableArray) do
-    capTableArray[key] = changeInternalNameRate(value)
-  end
-  return capTableArray
-end
-
 local capRaiResponse = {
   buttonCapabilities = hmiCapabilities.Buttons.capabilities,
   vehicleType = hmiCapabilities.VehicleInfo.vehicleType,
-  audioPassThruCapabilities = changeInternalNameRateArray(hmiCapabilities.UI.audioPassThruCapabilities),
+  audioPassThruCapabilities = hmiCapabilities.UI.audioPassThruCapabilities,
   hmiDisplayLanguage =  hmiCapabilities.UI.language,
   language = hmiCapabilities.VR.language, -- or TTS.language
-  pcmStreamCapabilities = changeInternalNameRate(hmiCapabilities.UI.pcmStreamCapabilities),
+  pcmStreamCapabilities = hmiCapabilities.UI.pcmStreamCapabilities,
   hmiZoneCapabilities = { hmiCapabilities.UI.hmiZoneCapabilities },
   softButtonCapabilities = hmiCapabilities.UI.softButtonCapabilities,
   displayCapabilities = common.buildDisplayCapForMobileExp(hmiCapabilities.UI.displayCapabilities),

--- a/test_scripts/Capabilities/PersistingHMICapabilities/033_Suspending_of_RAI_request_processing_during_OnReady_in_case_no_cap_response.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/033_Suspending_of_RAI_request_processing_during_OnReady_in_case_no_cap_response.lua
@@ -25,28 +25,13 @@ local hmiCapabilities = common.getHMICapabilitiesFromFile()
 local delayRaiResponse = 10000
 
 --[[ Local Functions ]]
-local function changeInternalNameRate(pCapabilities)
-  local capTable = common.cloneTable(pCapabilities)
-    capTable.bitsPerSample = string.gsub(capTable.bitsPerSample, "RATE_", "")
-    capTable.samplingRate = string.gsub(capTable.samplingRate, "RATE_", "")
-  return capTable
-end
-
-local function changeInternalNameRateArray(pCapabilities)
-  local capTableArray = common.cloneTable(pCapabilities)
-  for key, value in ipairs(capTableArray) do
-    capTableArray[key] = changeInternalNameRate(value)
-  end
-  return capTableArray
-end
-
 local capRaiResponse = {
   buttonCapabilities = hmiCapabilities.Buttons.capabilities,
   vehicleType = hmiCapabilities.VehicleInfo.vehicleType,
-  audioPassThruCapabilities = changeInternalNameRateArray(hmiCapabilities.UI.audioPassThruCapabilities),
+  audioPassThruCapabilities = hmiCapabilities.UI.audioPassThruCapabilities,
   hmiDisplayLanguage =  hmiCapabilities.UI.language,
   language = hmiCapabilities.VR.language, -- or TTS.language
-  pcmStreamCapabilities = changeInternalNameRate(hmiCapabilities.UI.pcmStreamCapabilities),
+  pcmStreamCapabilities = hmiCapabilities.UI.pcmStreamCapabilities,
   hmiZoneCapabilities = { hmiCapabilities.UI.hmiZoneCapabilities },
   softButtonCapabilities = hmiCapabilities.UI.softButtonCapabilities,
   displayCapabilities = common.buildDisplayCapForMobileExp(hmiCapabilities.UI.displayCapabilities),

--- a/test_scripts/Capabilities/PersistingHMICapabilities/034_Suspending_of_RAI_request_processing_during_OnReady_in_case_cache_file_does_not_exist_no_cap_response.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/034_Suspending_of_RAI_request_processing_during_OnReady_in_case_cache_file_does_not_exist_no_cap_response.lua
@@ -30,28 +30,13 @@ local delayRaiResponse = 10000
 local hmiCapabilities = common.getHMICapabilitiesFromFile()
 
 --[[ Local Functions ]]
-local function changeInternalNameRate(pCapabilities)
-  local capTable = common.cloneTable(pCapabilities)
-    capTable.bitsPerSample = string.gsub(capTable.bitsPerSample, "RATE_", "")
-    capTable.samplingRate = string.gsub(capTable.samplingRate, "RATE_", "")
-  return capTable
-end
-
-local function changeInternalNameRateArray(pCapabilities)
-  local capTableArray = common.cloneTable(pCapabilities)
-  for key, value in ipairs(capTableArray) do
-    capTableArray[key] = changeInternalNameRate(value)
-  end
-  return capTableArray
-end
-
 local capRaiResponse = {
   buttonCapabilities = hmiCapabilities.Buttons.capabilities,
   vehicleType = hmiCapabilities.VehicleInfo.vehicleType,
-  audioPassThruCapabilities = changeInternalNameRateArray(hmiCapabilities.UI.audioPassThruCapabilities),
+  audioPassThruCapabilities = hmiCapabilities.UI.audioPassThruCapabilities,
   hmiDisplayLanguage =  hmiCapabilities.UI.language,
   language = hmiCapabilities.VR.language, -- or TTS.language
-  pcmStreamCapabilities = changeInternalNameRate(hmiCapabilities.UI.pcmStreamCapabilities),
+  pcmStreamCapabilities = hmiCapabilities.UI.pcmStreamCapabilities,
   hmiZoneCapabilities = { hmiCapabilities.UI.hmiZoneCapabilities },
   softButtonCapabilities = hmiCapabilities.UI.softButtonCapabilities,
   displayCapabilities = common.buildDisplayCapForMobileExp(hmiCapabilities.UI.displayCapabilities),

--- a/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
@@ -263,8 +263,8 @@ function m.updateHMICapabilitiesTable(isRemainData)
     table.remove(hmiCapTbl.UI.displayCapabilities.textFields, 1)
     hmiCapTbl.UI.hmiZoneCapabilities = "BACK"
     hmiCapTbl.UI.softButtonCapabilities.imageSupported = false
-    hmiCapTbl.UI.audioPassThruCapabilities[1].samplingRate = "RATE_8KHZ"
-    hmiCapTbl.UI.pcmStreamCapabilities.samplingRate = "RATE_8KHZ"
+    hmiCapTbl.UI.audioPassThruCapabilities[1].samplingRate = "8KHZ"
+    hmiCapTbl.UI.pcmStreamCapabilities.samplingRate = "8KHZ"
     hmiCapTbl.UI.systemCapabilities.navigationCapability.sendLocationEnabled = false
     hmiCapTbl.UI.systemCapabilities.phoneCapability.dialNumberEnabled = false
     hmiCapTbl.UI.systemCapabilities.videoStreamingCapability.maxBitrate = 50000

--- a/test_scripts/Capabilities/pcmStreamCapabilities/commonPcmStreamCapabilities.lua
+++ b/test_scripts/Capabilities/pcmStreamCapabilities/commonPcmStreamCapabilities.lua
@@ -30,9 +30,6 @@ m.hmiDefaultCapabilities = hmi_values.getDefaultHMITable()
 
 local defaultSDLcapabilities = SDL.HMICap.get()
 m.defaultPcmStreamCapabilities = defaultSDLcapabilities.UI.pcmStreamCapabilities
-for k, value in pairs(m.defaultPcmStreamCapabilities) do
-  m.defaultPcmStreamCapabilities[k] = value:gsub("RATE_", "")
-end
 
 local pcmStreamCapabilitiesValues = {
   samplingRate = { "8KHZ", "16KHZ", "22KHZ", "44KHZ" },


### PR DESCRIPTION
Updates in scripts due to changes introduced by [pull/3510](https://github.com/smartdevicelink/sdl_core/pull/3510)

This PR is **[ready]** for review.

### Summary
Update for existing scripts.

### ATF version
develop

### Changelog
 - Removed `RATE_` prefix for `bitsPerSample` and  `samplingRate` parameters
 - Removed conversion logic for internal names

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
