### PR TITLE
[SDL-0308] Extending coverage for `Add a Reason Parameter to All Protocol NAKs`, scripts for issue #3539

### DIFF
--- a/test_scripts/Protocol/NACKReason/005_Wrong_app_type_Video_Audio_Services_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/005_Wrong_app_type_Video_Audio_Services_NACK.lua
@@ -1,0 +1,61 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because of wrong HMI type of mobile application
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'DEFAULT' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of Video/Audio service
+-- SDL does:
+-- - respond with NACK to StartService request because Video/Audio service can be opened
+-- only if app is registered with PROJECTION or NAVIGATION HMI types
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Test Configuration ]]
+common.app.getParams().appHMIType = { "DEFAULT" }
+
+--[[ Local Variables ]]
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Service type: 11 disallowed with current HMI type" }
+  }
+}
+
+local audioServiceParams = {
+  reqParams = {
+    mtu = { type = common.bsonType.INT64,  value = 131072 }
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Service type: 10 disallowed with current HMI type" }
+  }
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start Video Service with wrong HMI type, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams })
+common.Step("Start Audio Service with wrong HMI type, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.PCM, audioServiceParams.reqParams, audioServiceParams.nackParams })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/006_Wrong_HMI_level_Video_Audio_Services_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/006_Wrong_HMI_level_Video_Audio_Services_NACK.lua
@@ -1,0 +1,57 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because of wrong HMI level of mobile application
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is in NONE HMI level
+--
+-- Steps:
+-- 1. Mobile app requests the opening of Video/Audio service
+-- SDL does:
+-- - respond with NACK to StartService request because Video/Audio service can be opened
+-- only if app is in FULL or LIMITED HMI levels
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Service type: 11 disallowed with current HMI level" }
+  }
+}
+
+local audioServiceParams = {
+  reqParams = {
+    mtu = { type = common.bsonType.INT64,  value = 131072 }
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Service type: 10 disallowed with current HMI level" }
+  }
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion)
+
+common.Title("Test")
+common.Step("Start Video Service in wrong HMI level, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams })
+common.Step("Start Audio Service in wrong HMI level, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.PCM, audioServiceParams.reqParams, audioServiceParams.nackParams })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/007_Force_protected_Video_Audio_Services_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/007_Force_protected_Video_Audio_Services_NACK.lua
@@ -1,0 +1,66 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because of force protected settings for Video and Audio services
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of unprotected Video/Audio service
+-- SDL does:
+-- - respond with NACK to StartService request because unprotected service is requested
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = {
+      type = common.bsonType.STRING,
+      value = "Service type: 11 disallowed by settings. Allowed only in protected mode"
+    }
+  }
+}
+
+local audioServiceParams = {
+  reqParams = {
+    mtu = { type = common.bsonType.INT64,  value = 131072 }
+  },
+  nackParams = {
+    reason = {
+      type = common.bsonType.STRING,
+      value = "Service type: 10 disallowed by settings. Allowed only in protected mode"
+    }
+  }
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Init SDL certificates", common.initSDLCertificates, { "./files/Security/client_credential.pem"})
+common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
+  { "ForceProtectedService", "0x0A, 0x0B" })
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start unprotected Video Service, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams })
+common.Step("Start unprotected Audio Service, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.PCM, audioServiceParams.reqParams, audioServiceParams.nackParams })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/008_Force_not_protected_Video_Audio_Services_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/008_Force_not_protected_Video_Audio_Services_NACK.lua
@@ -1,0 +1,66 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because of force unprotected settings for Video and Audio services
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of protected Video/Audio service
+-- SDL does:
+-- - respond with NACK to StartService request because protected service is requested
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = {
+      type = common.bsonType.STRING,
+      value = "Service type: 11 disallowed by settings. Allowed only in unprotected mode"
+    }
+  }
+}
+
+local audioServiceParams = {
+  reqParams = {
+    mtu = { type = common.bsonType.INT64,  value = 131072 }
+  },
+  nackParams = {
+    reason = {
+      type = common.bsonType.STRING,
+      value = "Service type: 10 disallowed by settings. Allowed only in unprotected mode"
+    }
+  }
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Init SDL certificates", common.initSDLCertificates, { "./files/Security/client_credential.pem"})
+common.Step("ForceUnprotectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
+  { "ForceUnprotectedService", "0x0A, 0x0B" })
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start protected Video Service, NACK", common.startServiceProtectedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams })
+common.Step("Start protected Audio Service, NACK", common.startServiceProtectedNACK,
+  { 1, common.serviceType.PCM, audioServiceParams.reqParams, audioServiceParams.nackParams })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/009_PTU_failed_Video_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/009_PTU_failed_Video_Service_NACK.lua
@@ -1,0 +1,60 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because PTU is failed during service starting
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of protected Video service
+-- 2. PTU is triggered to get actual certificate
+-- 3. Mobile app provides invalid update in SystemRequest
+-- SDL does:
+-- - respond with NACK to StartService request because PTU is failed
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local isPTUtriggered = true
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Policy Table Update failed" }
+  }
+}
+
+--[[ Local Functions ]]
+local function setVideoConfig()
+  common.getHMIConnection():ExpectRequest("Navigation.SetVideoConfig")
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
+  { "ForceProtectedService", "0x0A, 0x0B" })
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion, { isPTUtriggered })
+common.Step("PTU", common.policyTableUpdate)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start Video Service, PTU failed, NACK", common.ptuFailedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams, setVideoConfig })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/010_PTU_failed_Audio_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/010_PTU_failed_Audio_Service_NACK.lua
@@ -1,0 +1,49 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because PTU is failed during service starting
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of protected Audio service
+-- 2. PTU is triggered to get actual certificate
+-- 3. Mobile app provides invalid update in SystemRequest
+-- SDL does:
+-- - respond with NACK to StartService request because PTU is failed
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local isPTUtriggered = true
+local audioServiceParams = {
+  reqParams = {
+    mtu = { type = common.bsonType.INT64,  value = 131072 }
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Policy Table Update failed" }
+  }
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
+  { "ForceProtectedService", "0x0A, 0x0B" })
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion, { isPTUtriggered })
+common.Step("PTU", common.policyTableUpdate)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start Audio Service, PTU failed, NACK", common.ptuFailedNACK,
+  { 1, common.serviceType.PCM, audioServiceParams.reqParams, audioServiceParams.nackParams })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/011_PTU_failed_RPC_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/011_PTU_failed_RPC_Service_NACK.lua
@@ -34,8 +34,6 @@ local rpcServiceParams = {
 --[[ Scenario ]]
 common.Title("Preconditions")
 common.Step("Clean environment", common.preconditions)
-common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
-  { "ForceProtectedService", "0x0A, 0x0B" })
 common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 common.Step("Register App", common.registerAppUpdatedProtocolVersion, { isPTUtriggered })
 common.Step("PTU", common.policyTableUpdate)

--- a/test_scripts/Protocol/NACKReason/011_PTU_failed_RPC_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/011_PTU_failed_RPC_Service_NACK.lua
@@ -1,0 +1,49 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because PTU is failed during service starting
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of protected RPC service
+-- 2. PTU is triggered to get actual certificate
+-- 3. Mobile app provides invalid update in SystemRequest
+-- SDL does:
+-- - respond with NACK to StartService request because PTU is failed
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local isPTUtriggered = true
+local rpcServiceParams = {
+  reqParams = {
+    protocolVersion = { type = common.bsonType.STRING, value = "5.3.0" }
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Policy Table Update failed" }
+  }
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
+  { "ForceProtectedService", "0x0A, 0x0B" })
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion, { isPTUtriggered })
+common.Step("PTU", common.policyTableUpdate)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start RPC Service, PTU failed, NACK", common.ptuFailedNACK,
+  { 1, common.serviceType.RPC, rpcServiceParams.reqParams, rpcServiceParams.nackParams })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/012_Invalid_time_Video_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/012_Invalid_time_Video_Service_NACK.lua
@@ -1,0 +1,65 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because system time is not provided during service starting
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of protected Video service
+-- 2. SDL requests system time via BC.GetSystemTime request
+-- 3. HMI responds with DATA_NOT_AVAILABLE resultCode
+-- SDL does:
+-- - respond with NACK to StartService request because system time is not provided
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local isPTUtriggered = true
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Failed to get system time" }
+  }
+}
+
+--[[ Local Functions ]]
+local function startStreamRequests()
+  common.getHMIConnection():ExpectRequest("Navigation.SetVideoConfig")
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+
+  common.getHMIConnection():ExpectRequest("Navigation.StartStream")
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
+  { "ForceProtectedService", "0x0A, 0x0B" })
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion, { isPTUtriggered })
+common.Step("PTU", common.policyTableUpdate)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start Video Service, system time is not provided, NACK", common.startSecureServiceTimeNotProvided,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams, startStreamRequests })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/013_Invalid_time_Audio_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/013_Invalid_time_Audio_Service_NACK.lua
@@ -1,0 +1,57 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because system time is not provided during service starting
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of protected Audio service
+-- 2. SDL requests system time via BC.GetSystemTime request
+-- 3. HMI responds with DATA_NOT_AVAILABLE resultCode
+-- SDL does:
+-- - respond with NACK to StartService request because system time is not provided
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local isPTUtriggered = true
+local audioServiceParams = {
+  reqParams = {
+    mtu = { type = common.bsonType.INT64,  value = 131072 }
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Failed to get system time" }
+  }
+}
+
+--[[ Local Functions ]]
+local function startStreamRequests()
+  common.getHMIConnection():ExpectRequest("Navigation.StartAudioStream")
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
+  { "ForceProtectedService", "0x0A, 0x0B" })
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion, { isPTUtriggered })
+common.Step("PTU", common.policyTableUpdate)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start Audio Service, system time is not provided, NACK", common.startSecureServiceTimeNotProvided,
+  { 1, common.serviceType.PCM, audioServiceParams.reqParams, audioServiceParams.nackParams, startStreamRequests })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/014_Invalid_time_RPC_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/014_Invalid_time_RPC_Service_NACK.lua
@@ -34,8 +34,6 @@ local rpcServiceParams = {
 --[[ Scenario ]]
 common.Title("Preconditions")
 common.Step("Clean environment", common.preconditions)
-common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
-  { "ForceProtectedService", "0x0A, 0x0B" })
 common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
 common.Step("Register App", common.registerAppUpdatedProtocolVersion, { isPTUtriggered })
 common.Step("PTU", common.policyTableUpdate)

--- a/test_scripts/Protocol/NACKReason/014_Invalid_time_RPC_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/014_Invalid_time_RPC_Service_NACK.lua
@@ -1,0 +1,49 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because system time is not provided during service starting
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of protected RPC service
+-- 2. SDL requests system time via BC.GetSystemTime request
+-- 3. HMI responds with DATA_NOT_AVAILABLE resultCode
+-- SDL does:
+-- - respond with NACK to StartService request because system time is not provided
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local isPTUtriggered = true
+local rpcServiceParams = {
+  reqParams = {
+    protocolVersion = { type = common.bsonType.STRING, value = "5.3.0" }
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Failed to get system time" }
+  }
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("ForceProtectedService = 0x0A, 0x0B", common.sdl.setSDLIniParameter,
+  { "ForceProtectedService", "0x0A, 0x0B" })
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion, { isPTUtriggered })
+common.Step("PTU", common.policyTableUpdate)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start RPC Service, system time is not provided, NACK", common.startSecureServiceTimeNotProvided,
+  { 1, common.serviceType.RPC, rpcServiceParams.reqParams, rpcServiceParams.nackParams })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/015_Second_unprotected_Video_Audio_RPC_Services_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/015_Second_unprotected_Video_Audio_RPC_Services_NACK.lua
@@ -1,0 +1,95 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because of second opening of unprotected Video and Audio services
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+-- 4. Unprotected RPC, Video and Audio services are opened
+--
+-- Steps:
+-- 1. Mobile app requests the opening of unprotected Video/Audio/RPC service
+-- SDL does:
+-- - respond with NACK to StartService request because unprotected service is opened
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local function reasonMessage(pService)
+  return "Cannot start an unprotected service of type " .. pService ..
+    ". Session 1 already has an unprotected service of type " .. pService
+end
+
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = {
+      type = common.bsonType.STRING,
+      value = reasonMessage(common.serviceType.VIDEO)
+    }
+  }
+}
+
+local audioServiceParams = {
+  reqParams = {
+    mtu = { type = common.bsonType.INT64,  value = 131072 }
+  },
+  nackParams = {
+    reason = {
+      type = common.bsonType.STRING,
+      value =  reasonMessage(common.serviceType.PCM)
+    }
+  }
+}
+
+local rpcServiceParams = {
+  reqParams = {
+    protocolVersion = { type = common.bsonType.STRING, value = "5.3.0" }
+  },
+  nackParams = {
+    reason = {
+      type = common.bsonType.STRING,
+      value = reasonMessage(common.serviceType.RPC)
+    }
+  }
+}
+
+--[[ Local Functions ]]
+local function setVideoConfig()
+  common.getHMIConnection():ExpectRequest("Navigation.SetVideoConfig")
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
+    end)
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion)
+common.Step("Activate App", common.activateApp)
+common.Step("Start unprotected Video Service, ACK", common.startServiceUnprotectedACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.reqParams, setVideoConfig })
+common.Step("Start unprotected Audio Service, ACK", common.startServiceUnprotectedACK,
+  { 1, common.serviceType.PCM, audioServiceParams.reqParams, audioServiceParams.reqParams })
+
+common.Title("Test")
+common.Step("Start unprotected Video Service, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams })
+common.Step("Start unprotected Audio Service, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.PCM, audioServiceParams.reqParams, audioServiceParams.nackParams })
+common.Step("Start unprotected RPC Service, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.RPC, rpcServiceParams.reqParams, rpcServiceParams.nackParams })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/016_SetVideoConfig_no_response_Video_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/016_SetVideoConfig_no_response_Video_Service_NACK.lua
@@ -1,0 +1,57 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because HMI does not respond to Navigation.SetVideoConfig request
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of Video service
+-- SDL does:
+-- - send Navigation.SetVideoConfig request to HMI
+-- 2. HMI does not respond to Navigation.SetVideoConfig request during default timeout
+-- SDL does:
+-- - respond with NACK to StartService request because HMI does not respond to Navigation.SetVideoConfig request
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Timed out while waiting for SetVideoConfig response" }
+  }
+}
+
+--[[ Local Functions ]]
+local function setVideoConfig()
+  common.getHMIConnection():ExpectRequest("Navigation.SetVideoConfig")
+  :Do(function()
+      -- do nothing
+    end)
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start Video Service, no SetVideoConfig response, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams, setVideoConfig })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/017_SetVideoConfig_error_response_Video_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/017_SetVideoConfig_error_response_Video_Service_NACK.lua
@@ -1,0 +1,58 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message
+-- in case NACK received because HMI responds with erroneous result code to Navigation.SetVideoConfig request
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of Video service
+-- SDL does:
+-- - send Navigation.SetVideoConfig request to HMI
+-- 2. HMI responds with erroneous result code to Navigation.SetVideoConfig request
+-- SDL does:
+-- - respond with NACK to StartService request because HMI responds with erroneous result code
+--    to Navigation.SetVideoConfig request
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Received SetVideoConfig failure response" }
+  }
+}
+
+--[[ Local Functions ]]
+local function setVideoConfig()
+  common.getHMIConnection():ExpectRequest("Navigation.SetVideoConfig")
+  :Do(function(_, data)
+      common.getHMIConnection():SendError(data.id, data.method, "REJECTED", "Request is rejected" )
+    end)
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start Video Service, erroneous SetVideoConfig response, NACK", common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams, setVideoConfig })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/NACKReason/018_SetVideoConfig_error_response_with_rejected_params_Video_Service_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/018_SetVideoConfig_error_response_with_rejected_params_Video_Service_NACK.lua
@@ -1,0 +1,63 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0308-protocol-nak-reason.md
+--
+-- Description: SDL provides reason information in NACK message in case NACK received because HMI responds with
+--  erroneous result code and rejectedParams to Navigation.SetVideoConfig request
+--
+-- Precondition:
+-- 1. SDL and HMI are started
+-- 2. Mobile app is registered with 'NAVIGATION' HMI type and with 5 protocol
+-- 3. Mobile app is activated
+--
+-- Steps:
+-- 1. Mobile app requests the opening of Video service
+-- SDL does:
+-- - send Navigation.SetVideoConfig request to HMI
+-- 2. HMI responds with erroneous result code and rejectedParams to Navigation.SetVideoConfig request
+-- SDL does:
+-- - respond with NACK to StartService request because HMI responds with erroneous result code
+--    to Navigation.SetVideoConfig request
+-- - provide reason information in NACK message
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require("test_scripts/Protocol/commonProtocol")
+
+--[[ Local Variables ]]
+local videoServiceParams = {
+  reqParams = {
+    height        = { type = common.bsonType.INT32,  value = 350 },
+    width         = { type = common.bsonType.INT32,  value = 800 },
+    videoProtocol = { type = common.bsonType.STRING, value = "RAW" },
+    videoCodec    = { type = common.bsonType.STRING, value = "H264" },
+  },
+  nackParams = {
+    reason = { type = common.bsonType.STRING, value = "Received SetVideoConfig failure response" },
+    rejectedParams = {
+      type = common.bsonType.ARRAY,
+      value = {{ type = common.bsonType.STRING, value = "videoProtocol" }}
+    }
+  }
+}
+
+--[[ Local Functions ]]
+local function setVideoConfig()
+  common.getHMIConnection():ExpectRequest("Navigation.SetVideoConfig")
+  :Do(function(_, data)
+      common.getHMIConnection():SendResponse(data.id, data.method, "REJECTED", { rejectedParams = { "protocol" }})
+    end)
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerAppUpdatedProtocolVersion)
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+common.Step("Start Video Service, erroneous SetVideoConfig response with rejectedParams, NACK",
+  common.startServiceUnprotectedNACK,
+  { 1, common.serviceType.VIDEO, videoServiceParams.reqParams, videoServiceParams.nackParams, setVideoConfig })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Protocol/commonProtocol.lua
+++ b/test_scripts/Protocol/commonProtocol.lua
@@ -99,7 +99,8 @@ function common.startServiceUnprotectedACK(pAppId, pServiceId, pRequestPayload, 
     end)
 end
 
-function common.startServiceUnprotectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
+function common.startServiceUnprotectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtentionFunc)
+    if pExtentionFunc then pExtentionFunc() end
     local mobSession = common.getMobileSession(pAppId)
     local msg = {
         serviceType = pServiceId,

--- a/test_scripts/Protocol/commonProtocol.lua
+++ b/test_scripts/Protocol/commonProtocol.lua
@@ -193,4 +193,8 @@ function common.startSecureServiceTimeNotProvided(pAppId, pServiceId, pRequestPa
     common.startServiceProtectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
 end
 
+function common.setProtectedServicesInIni()
+  common.sdl.setSDLIniParameter("ForceProtectedService", "0x0A, 0x0B")
+end
+
 return common

--- a/test_scripts/Protocol/commonProtocol.lua
+++ b/test_scripts/Protocol/commonProtocol.lua
@@ -77,8 +77,8 @@ function common.startServiceProtectedNACK(pAppId, pServiceId, pRequestPayload, p
     end)
 end
 
-function common.startServiceUnprotectedACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtentionFunc)
-    if pExtentionFunc then pExtentionFunc() end
+function common.startServiceUnprotectedACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtensionFunc)
+    if pExtensionFunc then pExtensionFunc() end
     local mobSession = common.getMobileSession(pAppId)
     local msg = {
         serviceType = pServiceId,
@@ -99,8 +99,8 @@ function common.startServiceUnprotectedACK(pAppId, pServiceId, pRequestPayload, 
     end)
 end
 
-function common.startServiceUnprotectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtentionFunc)
-    if pExtentionFunc then pExtentionFunc() end
+function common.startServiceUnprotectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtensionFunc)
+    if pExtensionFunc then pExtensionFunc() end
     local mobSession = common.getMobileSession(pAppId)
     local msg = {
         serviceType = pServiceId,
@@ -159,8 +159,8 @@ function common.registerAppUpdatedProtocolVersion(hasPTU)
     end)
 end
 
-function common.ptuFailedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtentionFunc)
-    if pExtentionFunc then pExtentionFunc() end
+function common.ptuFailedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtensionFunc)
+    if pExtensionFunc then pExtensionFunc() end
     common.startServiceProtectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
     common.getMobileSession():ExpectHandshakeMessage()
     :Times(0)
@@ -178,8 +178,8 @@ function common.ptuFailedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayl
     end)
 end
 
-function common.startSecureServiceTimeNotProvided(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtentionFunc)
-    if pExtentionFunc then pExtentionFunc() end
+function common.startSecureServiceTimeNotProvided(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtensionFunc)
+    if pExtensionFunc then pExtensionFunc() end
 
     local event = events.Event()
     event.level = 3

--- a/test_scripts/Protocol/commonProtocol.lua
+++ b/test_scripts/Protocol/commonProtocol.lua
@@ -5,11 +5,13 @@
 local actions = require("user_modules/sequences/actions")
 local ssl = require("test_scripts/Security/SSLHandshakeFlow/common")
 local constants = require("protocol_handler/ford_protocol_constants")
+local runner = require('user_modules/script_runner')
 local utils = require('user_modules/utils')
 local events = require("events")
 local bson = require('bson4lua')
-  
+
 --[[ General configuration parameters ]]
+config.defaultProtocolVersion = 5
 
 --[[ Variables ]]
 local common = ssl
@@ -20,6 +22,11 @@ common.frameType   = constants.FRAME_TYPE
 common.serviceType = constants.SERVICE_TYPE
 common.getDeviceName = utils.getDeviceName
 common.getDeviceMAC = utils.getDeviceMAC
+common.isFileExist = utils.isFileExist
+common.cloneTable = utils.cloneTable
+common.testSettings = runner.testSettings
+common.Title = runner.Title
+common.Step = runner.Step
 
 common.bsonType = {
     DOUBLE   = 0x01,
@@ -30,6 +37,9 @@ common.bsonType = {
     INT32    = 0x10,
     INT64    = 0x12
 }
+
+--[[ Tests Configuration ]]
+runner.testSettings.isSelfIncluded = false
 
 --[[ Functions ]]
 function common.startServiceProtectedACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
@@ -43,7 +53,7 @@ function common.startServiceProtectedACK(pAppId, pServiceId, pRequestPayload, pR
         local actPayload = bson.to_table(data.binaryData)
         return compareValues(pResponsePayload, actPayload, "binaryData")
     end)
-    
+
     if pServiceId == 7 then
         mobSession:ExpectHandshakeMessage()
     elseif pServiceId == 11 then
@@ -52,19 +62,6 @@ function common.startServiceProtectedACK(pAppId, pServiceId, pRequestPayload, pR
             common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
         end)
     end
-end
-  
-function common.startServiceUnprotectedACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
-    local mobSession = common.getMobileSession(pAppId)
-    mobSession:StartService(pServiceId, bson.to_bytes(pRequestPayload))
-    mobSession:ExpectControlMessage(pServiceId, {
-      frameInfo = common.frameInfo.START_SERVICE_ACK,
-      encryption = false
-    })
-    :ValidIf(function(_, data)
-        local actPayload = bson.to_table(data.binaryData)
-        return compareValues(pResponsePayload, actPayload, "binaryData")
-    end)
 end
 
 function common.startServiceProtectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
@@ -80,10 +77,39 @@ function common.startServiceProtectedNACK(pAppId, pServiceId, pRequestPayload, p
     end)
 end
 
+function common.startServiceUnprotectedACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtentionFunc)
+    if pExtentionFunc then pExtentionFunc() end
+    local mobSession = common.getMobileSession(pAppId)
+    local msg = {
+        serviceType = pServiceId,
+        frameType = constants.FRAME_TYPE.CONTROL_FRAME,
+        frameInfo = constants.FRAME_INFO.START_SERVICE,
+        sessionId = mobSession,
+        encryption = false,
+        binaryData = bson.to_bytes(pRequestPayload)
+    }
+    mobSession:Send(msg)
+    mobSession:ExpectControlMessage(pServiceId, {
+        frameInfo = common.frameInfo.START_SERVICE_ACK,
+        encryption = false
+    })
+    :ValidIf(function(_, data)
+        local actPayload = bson.to_table(data.binaryData)
+        return compareValues(pResponsePayload, actPayload, "binaryData")
+    end)
+end
 
 function common.startServiceUnprotectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
     local mobSession = common.getMobileSession(pAppId)
-    mobSession:StartService(pServiceId, bson.to_bytes(pRequestPayload))
+    local msg = {
+        serviceType = pServiceId,
+        frameType = constants.FRAME_TYPE.CONTROL_FRAME,
+        frameInfo = constants.FRAME_INFO.START_SERVICE,
+        sessionId = mobSession,
+        encryption = false,
+        binaryData = bson.to_bytes(pRequestPayload)
+    }
+    mobSession:Send(msg)
     mobSession:ExpectControlMessage(pServiceId, {
         frameInfo = common.frameInfo.START_SERVICE_NACK,
         encryption = false
@@ -92,6 +118,79 @@ function common.startServiceUnprotectedNACK(pAppId, pServiceId, pRequestPayload,
         local actPayload = bson.to_table(data.binaryData)
         return compareValues(pResponsePayload, actPayload, "binaryData")
     end)
+end
+
+function common.registerAppUpdatedProtocolVersion(hasPTU)
+    local appId = 1
+    local session = common.getMobileSession()
+    local msg = {
+        serviceType = common.serviceType.RPC,
+        frameType = constants.FRAME_TYPE.CONTROL_FRAME,
+        frameInfo = constants.FRAME_INFO.START_SERVICE,
+        sessionId = session.sessionId,
+        encryption = false,
+        binaryData = bson.to_bytes({ protocolVersion = { type = common.bsonType.STRING, value = "5.3.0" }})
+    }
+    session:Send(msg)
+
+    session:ExpectControlMessage(common.serviceType.RPC, {
+        frameInfo = common.frameInfo.START_SERVICE_ACK,
+        encryption = false
+    })
+    :Do(function()
+        session.sessionId = appId
+        local corId = session:SendRPC("RegisterAppInterface", common.app.getParams(appId))
+
+        common.hmi.getConnection():ExpectNotification("BasicCommunication.OnAppRegistered",
+            { application = { appName = common.app.getParams(appId).appName } })
+        :Do(function(_, d1)
+            common.app.setHMIId(d1.params.application.appID, appId)
+            if hasPTU then
+                common.ptu.expectStart()
+            end
+        end)
+
+        session:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
+        :Do(function()
+            session:ExpectNotification("OnHMIStatus",
+                { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+        end)
+    end)
+end
+
+function common.ptuFailedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtentionFunc)
+    if pExtentionFunc then pExtentionFunc() end
+    common.startServiceProtectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
+    common.getMobileSession():ExpectHandshakeMessage()
+    :Times(0)
+    local function ptUpdate(pTbl)
+        -- notifications_per_minute_by_priority parameter is mandatory and PTU would fail if it's removed
+        pTbl.policy_table.module_config.notifications_per_minute_by_priority = nil
+    end
+    local expNotificationFunc = function()
+        common.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData")
+        :Times(0)
+    end
+    common.isPTUStarted()
+    :Do(function()
+        common.policyTableUpdate(ptUpdate, expNotificationFunc)
+    end)
+end
+
+function common.startSecureServiceTimeNotProvided(pAppId, pServiceId, pRequestPayload, pResponsePayload, pExtentionFunc)
+    if pExtentionFunc then pExtentionFunc() end
+
+    local event = events.Event()
+    event.level = 3
+    event.matches = function(_, data)
+        return data.method == "BasicCommunication.GetSystemTime"
+    end
+    common.getHMIConnection():ExpectEvent(event, "Expect GetSystemTime")
+    :Do(function(_, data)
+        common.getHMIConnection():SendError(data.id, data.method, "DATA_NOT_AVAILABLE", "Time is not provided")
+    end)
+
+    common.startServiceProtectedNACK(pAppId, pServiceId, pRequestPayload, pResponsePayload)
 end
 
 return common

--- a/test_sets/protocol_nak_reason_param.txt
+++ b/test_sets/protocol_nak_reason_param.txt
@@ -13,3 +13,6 @@
 ./test_scripts/Protocol/NACKReason/013_Invalid_time_Audio_Service_NACK.lua
 ./test_scripts/Protocol/NACKReason/014_Invalid_time_RPC_Service_NACK.lua
 ./test_scripts/Protocol/NACKReason/015_Second_unprotected_Video_Audio_RPC_Services_NACK.lua
+./test_scripts/Protocol/NACKReason/016_SetVideoConfig_no_response_Video_Service_NACK.lua
+./test_scripts/Protocol/NACKReason/017_SetVideoConfig_error_response_Video_Service_NACK.lua
+./test_scripts/Protocol/NACKReason/018_SetVideoConfig_error_response_with_rejected_params_Video_Service_NACK.lua

--- a/test_sets/protocol_nak_reason_param.txt
+++ b/test_sets/protocol_nak_reason_param.txt
@@ -2,3 +2,14 @@
 ./test_scripts/Protocol/NACKReason/002_Second_Protected_Audio_Service_NACK.lua
 ./test_scripts/Protocol/NACKReason/003_Second_Protected_RPC_Service_NACK.lua
 ./test_scripts/Protocol/NACKReason/004_Invalid_Certificate_NACK.lua
+./test_scripts/Protocol/NACKReason/005_Wrong_app_type_Video_Audio_Services_NACK.lua
+./test_scripts/Protocol/NACKReason/006_Wrong_HMI_level_Video_Audio_Services_NACK.lua
+./test_scripts/Protocol/NACKReason/007_Force_protected_Video_Audio_Services_NACK.lua
+./test_scripts/Protocol/NACKReason/008_Force_not_protected_Video_Audio_Services_NACK.lua
+./test_scripts/Protocol/NACKReason/009_PTU_failed_Video_Service_NACK.lua
+./test_scripts/Protocol/NACKReason/010_PTU_failed_Audio_Service_NACK.lua
+./test_scripts/Protocol/NACKReason/011_PTU_failed_RPC_Service_NACK.lua
+./test_scripts/Protocol/NACKReason/012_Invalid_time_Video_Service_NACK.lua
+./test_scripts/Protocol/NACKReason/013_Invalid_time_Audio_Service_NACK.lua
+./test_scripts/Protocol/NACKReason/014_Invalid_time_RPC_Service_NACK.lua
+./test_scripts/Protocol/NACKReason/015_Second_unprotected_Video_Audio_RPC_Services_NACK.lua


### PR DESCRIPTION
ATF Test Scripts to check #[3539](https://github.com/smartdevicelink/sdl_core/issues/3539)
ATF Test Scripts to Extending coverage for [Add a Reason Parameter to All Protocol NAKs](https://github.com/smartdevicelink/sdl_core/issues/3434)

This PR is **ready** for review.

### Summary
Extending coverage for `Add a Reason Parameter to All Protocol NAKs`, scripts for issue #3539

### ATF version
develop

### Changelog
New test script to check the next reasons
- Invalid time
- Failed PTU
- Repeated start of second unprotected service
- Wrong HMI level
- Wrong HMI type
- Service start not according to settings in .ini file

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
