### PR TITLE
Extended coverage for GetSystemCapability and SubtleAlert parameters

### DIFF
--- a/test_scripts/WidgetSupport/Capabilities/008_GetSCs_no_app_specific_capabilities.lua
+++ b/test_scripts/WidgetSupport/Capabilities/008_GetSCs_no_app_specific_capabilities.lua
@@ -1,0 +1,108 @@
+---------------------------------------------------------------------------------------------------
+-- Proposals:
+--  - https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0216-widget-support.md
+--  - https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0242-alert-style-subtle.md
+
+-- Description:
+-- Mobile application sends valid GetSystemCapability request with DISPLAYS systemCapabilityType
+-- and gets SUCCESS resultCode only if SDL received OnSystemCapabilityUpdated notification from HMI
+-- with the displayCapabilities for specific appID
+
+-- Preconditions:
+-- 1) SDL and HMI are started
+-- 2) App is registered
+-- Steps:
+-- 1) App requests GetSystemCapability with DISPLAYS systemCapabilityType
+-- SDL does:
+--  - validates parameters of the request
+--  - checks if displayCapabilities is available for specified appID
+--  - responds with (resultCode: DATA_NOT_AVAILABLE, success:false) to mobile application
+-- 2) HMI sends OnSystemCapabilityUpdated with the displayCapabilities for specific appID
+-- 3) App requests GetSystemCapability with DISPLAYS systemCapabilityType one more time
+-- SDL does:
+--  - respond with (resultCode: SUCCESS, success:true) and transfers the displayCapabilities to mobile application
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/WidgetSupport/common')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+-- [[ Local Variables ]]
+local sysCaps = common.getOnSystemCapabilityParams()
+
+sysCaps.systemCapability.displayCapabilities[1].windowCapabilities[1].textFields = {
+  {
+    name = "subtleAlertText1",
+    characterSet = "UTF_8",
+    width = 500,
+    rows = 1
+  },
+  {
+    name = "subtleAlertText2",
+    characterSet = "UTF_8",
+    width = 500,
+    rows = 1
+  },
+  {
+    name = "subtleAlertSoftButtonText",
+    characterSet = "UTF_8",
+    width = 500,
+    rows = 1
+  }
+}
+sysCaps.systemCapability.displayCapabilities[1].windowCapabilities[1].imageFields = {
+  {
+    name = "subtleAlertIcon",
+    imageTypeSupported = {
+      "GRAPHIC_BMP",
+      "GRAPHIC_JPEG",
+      "GRAPHIC_PNG"
+    },
+    imageResolution = {
+      resolutionWidth = 64,
+      resolutionHeight = 64
+    }
+  }
+}
+
+-- [[ Local Functions ]]
+local function sendOnSCU()
+  local paramsToSDL = common.cloneTable(sysCaps)
+  paramsToSDL.appID = common.getHMIAppId()
+  common.getHMIConnection():SendNotification("BasicCommunication.OnSystemCapabilityUpdated", paramsToSDL)
+  common.getMobileSession():ExpectNotification("OnSystemCapabilityUpdated", sysCaps)
+end
+
+local function sendGetSC(pSuccess, pResultCode)
+  local cid = common.getMobileSession():SendRPC("GetSystemCapability", { systemCapabilityType = "DISPLAYS" })
+  local exp = nil
+  if pResultCode == "SUCCESS" then exp = sysCaps.systemCapability end
+  common.getMobileSession():ExpectResponse(cid, {
+    success = pSuccess,
+    resultCode = pResultCode,
+    systemCapability = exp
+  })
+  :ValidIf(function(_, data)
+      if data.payload.success == false and data.payload.systemCapability ~= nil then
+        return false, "Struct 'systemCapability' is populated in erroneous response"
+      end
+      return true
+    end)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+common.Step("Clean environment and Back-up/update PPT", common.precondition)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("Register App", common.registerApp)
+
+runner.Title("Test")
+runner.Step("GetSystemCapability DATA_NOT_AVAILABLE", sendGetSC, { false, "DATA_NOT_AVAILABLE" })
+runner.Step("Send OnSystemCapabilityUpdated", sendOnSCU)
+runner.Step("GetSystemCapability SUCCESS", sendGetSC, { true, "SUCCESS" })
+
+runner.Title("Postconditions")
+common.Step("Stop SDL, restore SDL settings and PPT", common.postcondition)

--- a/test_sets/widget_support.txt
+++ b/test_sets/widget_support.txt
@@ -5,6 +5,7 @@
 ./test_scripts/WidgetSupport/Capabilities/005_OnSCU_not_transferred_for_non_display_capabilities.lua
 ./test_scripts/WidgetSupport/Capabilities/006_GetSC_subscription_ignored.lua
 ./test_scripts/WidgetSupport/Capabilities/007_GetSC_2_apps_different_data.lua
+./test_scripts/WidgetSupport/Capabilities/008_GetSCs_no_app_specific_capabilities.lua
 ./test_scripts/WidgetSupport/CreateWindow/001_Create_widget_success.lua
 ./test_scripts/WidgetSupport/CreateWindow/002_Two_apps_create_widgets_with_the_same_names.lua
 ./test_scripts/WidgetSupport/CreateWindow/003_Two_apps_create_widgets_with_the_same_id.lua

--- a/user_modules/hmi_values.lua
+++ b/user_modules/hmi_values.lua
@@ -321,7 +321,8 @@ function module.getDefaultHMITable()
             "navigationText1", "navigationText2", "ETA", "totalDistance", "navigationText", "audioPassThruDisplayText1",
             "audioPassThruDisplayText2", "sliderHeader", "sliderFooter", "notificationText", "menuName",
             "secondaryText", "tertiaryText", "timeToDestination", "menuTitle", "locationName",
-            "locationDescription", "addressLines", "phoneNumber"
+            "locationDescription", "addressLines", "phoneNumber", "subtleAlertText1", "subtleAlertText2",
+            "subtleAlertSoftButtonText"
           }
           local out = { }
           for _, field in pairs(fields) do
@@ -332,7 +333,7 @@ function module.getDefaultHMITable()
         imageFields = (function()
           local fields = {
             "softButtonImage", "choiceImage", "choiceSecondaryImage", "vrHelpItem", "turnIcon", "menuIcon", "cmdIcon",
-            "showConstantTBTIcon", "locationImage"
+            "showConstantTBTIcon", "locationImage", "subtleAlertIcon"
           }
           local out = { }
           for _, field in pairs(fields) do


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Extended coverage for `GetSystemCapability(DISPLAYS)` and `SubtleAlert` parameters

### ATF version
develop

### Changelog
 - Added new script
 - Updated test set for `widget_support`


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
