### PR TITLE
Correct number of onHMIStatusNotifications

### DIFF
--- a/test_scripts/CloudAppRPCs/012_Same_app_name_mobile_app_Disallowed.lua
+++ b/test_scripts/CloudAppRPCs/012_Same_app_name_mobile_app_Disallowed.lua
@@ -79,12 +79,19 @@ end
 local function registerApp(pAppId, pConId, pAppNameCode, pResultCode, pActivateCloudApp)
   local success
   local occurences
+  local hmiStatusOccurences
   if pResultCode == "SUCCESS" then
     success = true
     occurences = 1
+    if pActivateCloudApp then
+      hmiStatusOccurences = 2
+    else
+      hmiStatusOccurences = 1
+    end
   elseif pResultCode == "USER_DISALLOWED" then
     success = false
     occurences = 0
+    hmiStatusOccurences = 0
   end
   if (pActivateCloudApp) then
     common.getHMIConnection():SendRequest("SDL.ActivateApp", {appID = hmiAppIDMap[pAppId]})
@@ -99,7 +106,7 @@ local function registerApp(pAppId, pConId, pAppNameCode, pResultCode, pActivateC
     local cid = session:SendRPC("RegisterAppInterface", params)
     session:ExpectResponse(cid, { success = success, resultCode = pResultCode })
     session:ExpectNotification("OnPermissionsChange"):Times(occurences)
-    session:ExpectNotification("OnHMIStatus"):Times(occurences)
+    session:ExpectNotification("OnHMIStatus"):Times(hmiStatusOccurences)
     common.getHMIConnection():ExpectNotification("BasicCommunication.OnAppRegistered"):Times(occurences)
   end)
 end

--- a/test_scripts/CloudAppRPCs/013_Same_app_name_mobile_app_Unregistered.lua
+++ b/test_scripts/CloudAppRPCs/013_Same_app_name_mobile_app_Unregistered.lua
@@ -81,7 +81,9 @@ local function deleteMobDevices()
 end
 
 local function registerApp(pAppId, pConId, pAppNameCode, pActivateCloudApp, pUnregAppId)
+  local hmiStatusOccurences = 1
   if (pActivateCloudApp) then
+    hmiStatusOccurences = 2
     common.getHMIConnection():SendRequest("SDL.ActivateApp", {appID = hmiAppIDMap[pAppId]})
   end
   local session = common.getMobileSession(pAppId, pConId)
@@ -94,7 +96,7 @@ local function registerApp(pAppId, pConId, pAppNameCode, pActivateCloudApp, pUnr
     local cid = session:SendRPC("RegisterAppInterface", params)
     session:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
     session:ExpectNotification("OnPermissionsChange")
-    session:ExpectNotification("OnHMIStatus")
+    session:ExpectNotification("OnHMIStatus"):Times(hmiStatusOccurences)
     common.getHMIConnection():ExpectNotification("BasicCommunication.OnAppRegistered")
     :Do(function(_, d)
         common.setHMIAppId(d.params.application.appID, pAppId)


### PR DESCRIPTION
Tests for #[3559](https://github.com/smartdevicelink/sdl_core/pull/3559)

This PR is **ready** for review.

### Summary
Incorrect number of onhmistatus were counted for cloud apps. This corrects the expectation since upon connection a cloud app should receive the default hmi level, then FULL.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
