### PR TITLE
change GetPolicyConfigurationData field to check

### DIFF
--- a/test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua
+++ b/test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua
@@ -84,10 +84,10 @@ local dataReqRes = {
     end
   },
   hugeJson = {
-    request = { policyType = "consumer_friendly_messages", property = "messages" },
+    request = { policyType = "vehicle_data", property = "schema_items" },
     response = { result = { code = 0 } },
     validIf = function(data)
-    return validation(data, "consumer_friendly_messages", "messages", CHECK_TYPES.OBJECT)
+    return validation(data, "vehicle_data", "schema_items", CHECK_TYPES.ARRAY_OF_OBJECTS)
     end
   },
   arrayOfNumbers = {


### PR DESCRIPTION
This PR is **ready]** for review.

### Summary
consumer_friendly_messages.messages is not loaded in ext prop policy mode, so instead we will compare the vehicle_data.schema_items property as it is also a large json with custom objects

### ATF version
latest

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
