### PR TITLE
Update 1893 script

### DIFF
--- a/test_scripts/Defects/4_5/1893_ATF_HeartBeat_App_does_not_send_HB_and_does_not_respond.lua
+++ b/test_scripts/Defects/4_5/1893_ATF_HeartBeat_App_does_not_send_HB_and_does_not_respond.lua
@@ -62,7 +62,7 @@ local function Register_App(appId, answerHeartbeatFromSDL, self)
   -- create mobile session
   mobileSession[appId] = mobile_session.MobileSession(self, self.mobileConnection)
   -- set parameters for heartbeat
-  mobileSession[appId].activateHeartbeat = false
+  mobileSession[appId].activateHeartbeat = true
   mobileSession[appId].sendHeartbeatToSDL = false
   mobileSession[appId].answerHeartbeatFromSDL = answerHeartbeatFromSDL
   mobileSession[appId].ignoreSDLHeartBeatACK = false


### PR DESCRIPTION
ATF Test Scripts update related to [#1892](https://github.com/smartdevicelink/sdl_core/issues/1892)

This PR is **[ready]** for review.

### Summary
Along with the changes made in https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2476 script `1893` also needs to be updated.

### ATF version
develop

### Changelog
 - switch on HB in ATF: in this way 1st HB message would be sent to SDL and hence SDL starts it's HB monitor

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
