### PR TITLE
Add hard-coded odometer value in VD script

### DIFF
--- a/test_scripts/API/VehicleData/OnVehicleData/003_OnVD_disallowed_after_PTU.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/003_OnVD_disallowed_after_PTU.lua
@@ -49,6 +49,11 @@ local function policyTableUpdate(pDisallowedParam)
   common.policyTableUpdate(ptUpdate)
 end
 
+local function getValue(pParam)
+  if pParam == "odometer" then return 1 end
+  return nil
+end
+
 --[[ Scenario ]]
 for param in common.spairs(common.getVDParams(true)) do
   common.Title("VD parameter: " .. param)
@@ -57,11 +62,13 @@ for param in common.spairs(common.getVDParams(true)) do
   common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
   common.Step("Register App", common.registerApp)
   common.Step("RPC " .. common.rpc.sub .. " SUCCESS", common.processSubscriptionRPC, { common.rpc.sub, param })
-  common.Step("RPC " .. common.rpc.on .. " transferred", common.sendOnVehicleData, { param, common.isExpected })
+  common.Step("RPC " .. common.rpc.on .. " transferred", common.sendOnVehicleData,
+    { param, common.isExpected, getValue(param) })
 
   common.Title("Test")
   common.Step("PTU with disabling permissions for VD parameter", policyTableUpdate, { param })
-  common.Step("RPC " .. common.rpc.on .. " ignored", common.sendOnVehicleData, { param, common.isNotExpected })
+  common.Step("RPC " .. common.rpc.on .. " ignored", common.sendOnVehicleData,
+    { param, common.isNotExpected, getValue(param) })
 
   common.Title("Postconditions")
   common.Step("Stop SDL", common.postconditions)


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Sometimes script:
```
./test_scripts/API/VehicleData/OnVehicleData/003_OnVD_disallowed_after_PTU.lua
```
may fail on PTU step with message:
```
expected: UP_TO_DATE, actual value: UPDATE_NEEDED
```

The reason of that is `odometer` trigger. 
In case if the difference between current odometer value and the one received on a previous PTU update exceeds `exchange_after_x_kilometers` parameter SDL triggers new PTU update.

### ATF version
develop

### Changelog
 - replace random generated value for `odometer` in `OnVehicleData` by a hard-coded one (e.g. `1`). This would make `odometer` trigger is never happen.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
