### PR TITLE
SDL 0274: add preferredFPS to VideoStreamingCapability

### DIFF
--- a/test_scripts/API/ATF_GetSystemCapability.lua
+++ b/test_scripts/API/ATF_GetSystemCapability.lua
@@ -97,7 +97,8 @@ function Test:TestStep_GetVideoCapability()
           protocol="RAW",
           codec="H264"
         }},
-        hapticSpatialDataSupported= false
+        hapticSpatialDataSupported= false,
+        preferredFPS=20
       },
       systemCapabilityType="VIDEO_STREAMING"
     }

--- a/test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
+++ b/test_scripts/Smoke/API/048_GetSystemCapabilityRequest_SUCCESS.lua
@@ -54,7 +54,8 @@ local videoCapabilities = {
       protocol="RAW",
       codec="H264"
     }},
-    hapticSpatialDataSupported= false
+    hapticSpatialDataSupported= false,
+    preferredFPS=20
   },
   systemCapabilityType="VIDEO_STREAMING"
 }

--- a/user_modules/hmi_values.lua
+++ b/user_modules/hmi_values.lua
@@ -405,7 +405,8 @@ function module.getDefaultHMITable()
           hapticSpatialDataSupported = false,
           diagonalScreenSize = 10,
           pixelPerInch = 150,
-          scale = 2.5
+          scale = 2.5,
+          preferredFPS = 20
         },
         driverDistractionCapability = {
             subMenuDepth = 3,


### PR DESCRIPTION
ATF Test Scripts to check #3243 (SDL core PR at https://github.com/smartdevicelink/sdl_core/pull/3437)

This PR is **ready** for review.

### Summary
This change addresses required atf_test_script changes for SDL 0274: add preferredFPS to VideoStreamingCapability.

### ATF version
7.0.0

### Changelog

##### Enhancements
* SDL 0274: add preferredFPS to VideoStreamingCapability

##### Bug Fixes
* n/a

### Dependencies:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
