### PR TITLE
Update keyboard property reset and cache expectations

### DIFF
--- a/test_scripts/API/KeyboardEnhancements/ResetGlobalProperties/001_App_resets_KeyboardProperties.lua
+++ b/test_scripts/API/KeyboardEnhancements/ResetGlobalProperties/001_App_resets_KeyboardProperties.lua
@@ -36,7 +36,8 @@ local function sendResetGP()
     keyboardProperties = {
       language = "EN-US",
       keyboardLayout = "QWERTY",
-      autoCompleteList = common.json.EMPTY_ARRAY
+      autoCompleteList = common.json.EMPTY_ARRAY,
+      maskInputCharacters = "DISABLE_INPUT_KEY_MASK"
     },
     appID = common.getHMIAppId()
   }
@@ -46,9 +47,6 @@ local function sendResetGP()
       common.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", {})
     end)
   :ValidIf(function(_, data)
-      if data.params.keyboardProperties.maskInputCharacters then
-        return false, "Unexpected 'maskInputCharacters' parameter received"
-      end
       if data.params.keyboardProperties.customKeys then
         return false, "Unexpected 'customKeys' parameter received"
       end

--- a/test_scripts/API/KeyboardEnhancements/Resumption/002_SDL_resumes_cached_KeyboardProperties.lua
+++ b/test_scripts/API/KeyboardEnhancements/Resumption/002_SDL_resumes_cached_KeyboardProperties.lua
@@ -45,7 +45,8 @@ local sgpParams_resumption = {
   keyboardProperties = {
     language = sgpParams_1.keyboardProperties.language,
     keyboardLayout = sgpParams_1.keyboardProperties.keyboardLayout,
-    autoCompleteList = sgpParams_1.keyboardProperties.autoCompleteList
+    autoCompleteList = sgpParams_1.keyboardProperties.autoCompleteList,
+    maskInputCharacters = sgpParams_1.keyboardProperties.maskInputCharacters
   }
 }
 

--- a/test_scripts/API/KeyboardEnhancements/Resumption/003_SDL_resumes_cached_KeyboardProperties_with_removed_autoCompleteList.lua
+++ b/test_scripts/API/KeyboardEnhancements/Resumption/003_SDL_resumes_cached_KeyboardProperties_with_removed_autoCompleteList.lua
@@ -32,7 +32,7 @@ local sgpParams_1 = {
     keypressMode = "SINGLE_KEYPRESS",
     limitedCharacterList = { "a" },
     autoCompleteList = { "Daemon, Freedom" },
-    maskInputCharacters = "DISABLE_INPUT_KEY_MASK",
+    maskInputCharacters = "USER_CHOICE_INPUT_KEY_MASK",
     customKeys = { "#", "$" }
   }
 }
@@ -46,7 +46,8 @@ local sgpParams_2 = {
 local sgpParams_resumption = {
   keyboardProperties = {
     language = sgpParams_1.keyboardProperties.language,
-    keyboardLayout = sgpParams_1.keyboardProperties.keyboardLayout
+    keyboardLayout = sgpParams_1.keyboardProperties.keyboardLayout,
+    maskInputCharacters = sgpParams_1.keyboardProperties.maskInputCharacters
   }
 }
 

--- a/test_scripts/API/KeyboardEnhancements/Resumption/004_SDL_resumes_cached_KeyboardProperties_single_parameter.lua
+++ b/test_scripts/API/KeyboardEnhancements/Resumption/004_SDL_resumes_cached_KeyboardProperties_single_parameter.lua
@@ -63,7 +63,8 @@ local function getResumptionParams(pReqParams)
     keyboardProperties = {
       language = sgpParams.keyboardProperties.language,
       keyboardLayout = sgpParams.keyboardProperties.keyboardLayout,
-      autoCompleteList = sgpParams.keyboardProperties.autoCompleteList
+      autoCompleteList = sgpParams.keyboardProperties.autoCompleteList,
+      maskInputCharacters = sgpParams.keyboardProperties.maskInputCharacters
     }
   }
   local k, v = next(pReqParams.keyboardProperties)


### PR DESCRIPTION

ATF Test Scripts to check https://github.com/smartdevicelink/sdl_core/pull/3635

This PR is **ready** for review.

### Summary
Add expectation for maskInputCharacters in ResetGlobalProperties and in resumption cache

### ATF version
develop

### Changelog
##### Bug Fixes
* Add expectation for maskInputCharacters in ResetGlobalProperties and in resumption cache to match Core fix

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
