### PR TITLE
Add expectations for HMI PTU in EXTERNAL_PROPRIETARY policy tests

### DIFF
--- a/test_scripts/Policies/External_UCS/003_ATF_P_TC_LPT_Creation_PreloadedPT_without_disallowed_by_external_consent_entities_off_struct.lua
+++ b/test_scripts/Policies/External_UCS/003_ATF_P_TC_LPT_Creation_PreloadedPT_without_disallowed_by_external_consent_entities_off_struct.lua
@@ -99,7 +99,7 @@ function Test:InitHMI()
 end
 
 function Test:InitHMI_onReady()
-  self:initHMI_onReady()
+  testCasesForExternalUCS.initHMI_onReady(self)
 end
 
 function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/004_ATF_P_TC_LPT_Creation_PreloadedPT_with_disallowed_by_external_consent_entities_off_struct.lua
+++ b/test_scripts/Policies/External_UCS/004_ATF_P_TC_LPT_Creation_PreloadedPT_with_disallowed_by_external_consent_entities_off_struct.lua
@@ -102,7 +102,7 @@ function Test:InitHMI()
 end
 
 function Test:InitHMI_onReady()
-  self:initHMI_onReady()
+  testCasesForExternalUCS.initHMI_onReady(self)
 end
 
 function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/005_ATF_P_TC_LPT_Creation_PreloadedPT_without_disallowed_by_external_consent_entities_on_struct.lua
+++ b/test_scripts/Policies/External_UCS/005_ATF_P_TC_LPT_Creation_PreloadedPT_without_disallowed_by_external_consent_entities_on_struct.lua
@@ -97,7 +97,7 @@ function Test:InitHMI()
 end
 
 function Test:InitHMI_onReady()
-  self:initHMI_onReady()
+  testCasesForExternalUCS.initHMI_onReady(self)
 end
 
 function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/006_ATF_P_TC_LPT_Creation_PreloadedPT_with_disallowed_by_external_consent_entities_on_struct.lua
+++ b/test_scripts/Policies/External_UCS/006_ATF_P_TC_LPT_Creation_PreloadedPT_with_disallowed_by_external_consent_entities_on_struct.lua
@@ -102,7 +102,7 @@ function Test:InitHMI()
 end
 
 function Test:InitHMI_onReady()
-  self:initHMI_onReady()
+  testCasesForExternalUCS.initHMI_onReady(self)
 end
 
 function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/021_ATF_N_TC_PTU_with_disallowed_by_external_consent_entities_off_struct_with_invalid_type_of_params.lua
+++ b/test_scripts/Policies/External_UCS/021_ATF_N_TC_PTU_with_disallowed_by_external_consent_entities_off_struct_with_invalid_type_of_params.lua
@@ -109,7 +109,7 @@ local function sequence(desc, updateFunc)
   end
 
   function Test:InitHMI_onReady()
-    self:initHMI_onReady()
+    testCasesForExternalUCS.initHMI_onReady(self)
   end
 
   function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/022_ATF_N_TC_PTU_with_disallowed_by_external_consent_entities_on_struct_with_invalid_type_of_params.lua
+++ b/test_scripts/Policies/External_UCS/022_ATF_N_TC_PTU_with_disallowed_by_external_consent_entities_on_struct_with_invalid_type_of_params.lua
@@ -109,7 +109,7 @@ local function sequence(desc, updateFunc)
   end
 
   function Test:InitHMI_onReady()
-    self:initHMI_onReady()
+    testCasesForExternalUCS.initHMI_onReady(self)
   end
 
   function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/025_ATF_P_TC_LPT_Update_PreloadedPT_without_disallowed_by_external_consent_entities_off_struct.lua
+++ b/test_scripts/Policies/External_UCS/025_ATF_P_TC_LPT_Update_PreloadedPT_without_disallowed_by_external_consent_entities_off_struct.lua
@@ -105,7 +105,7 @@ function Test:InitHMI()
 end
 
 function Test:InitHMI_onReady()
-  self:initHMI_onReady()
+  testCasesForExternalUCS.initHMI_onReady(self)
 end
 
 function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/026_ATF_P_TC_LPT_Update_PreloadedPT_with_disallowed_by_external_consent_entities_off_struct.lua
+++ b/test_scripts/Policies/External_UCS/026_ATF_P_TC_LPT_Update_PreloadedPT_with_disallowed_by_external_consent_entities_off_struct.lua
@@ -119,7 +119,7 @@ function Test:InitHMI()
 end
 
 function Test:InitHMI_onReady()
-  self:initHMI_onReady()
+  testCasesForExternalUCS.initHMI_onReady(self)
 end
 
 function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/027_ATF_P_TC_LPT_Update_PreloadedPT_without_disallowed_by_external_consent_entities_on_struct.lua
+++ b/test_scripts/Policies/External_UCS/027_ATF_P_TC_LPT_Update_PreloadedPT_without_disallowed_by_external_consent_entities_on_struct.lua
@@ -105,7 +105,7 @@ function Test:InitHMI()
 end
 
 function Test:InitHMI_onReady()
-  self:initHMI_onReady()
+  testCasesForExternalUCS.initHMI_onReady(self)
 end
 
 function Test:ConnectMobile()

--- a/test_scripts/Policies/External_UCS/028_ATF_P_TC_LPT_Update_PreloadedPT_with_disallowed_by_external_consent_entities_on_struct.lua
+++ b/test_scripts/Policies/External_UCS/028_ATF_P_TC_LPT_Update_PreloadedPT_with_disallowed_by_external_consent_entities_on_struct.lua
@@ -119,7 +119,7 @@ function Test:InitHMI()
 end
 
 function Test:InitHMI_onReady()
-  self:initHMI_onReady()
+  testCasesForExternalUCS.initHMI_onReady(self)
 end
 
 function Test:ConnectMobile()

--- a/test_scripts/Policies/Policy_Table_Update/149_ATF_Policy_Table_Update_Trigger_After_N_Days.lua
+++ b/test_scripts/Policies/Policy_Table_Update/149_ATF_Policy_Table_Update_Trigger_After_N_Days.lua
@@ -143,6 +143,7 @@ function Test:Precondition_InitOnready()
   EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
   :Do(function(exp, d)
     if(exp.occurences == 1) then
+      EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATING" })
       self.hmiConnection:SendResponse(d.id, d.method, "SUCCESS", { })
       ptuInProgress = true
     end

--- a/test_scripts/Policies/Policy_Table_Update/172_ATF_PTU_request_after_N_ignition_cycles.lua
+++ b/test_scripts/Policies/Policy_Table_Update/172_ATF_PTU_request_after_N_ignition_cycles.lua
@@ -157,6 +157,7 @@ function Test:TestStep_InitOnready()
   EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
   :Do(function(exp, d)
     if(exp.occurences == 1) then
+      EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATING" })
       self.hmiConnection:SendResponse(d.id, d.method, "SUCCESS", { })
       ptuInProgress = true
     end

--- a/test_scripts/Policies/Validation_of_PolicyTables/280_ATF_Reset_ignition_cycles_since_last_exchange_in_PT.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/280_ATF_Reset_ignition_cycles_since_last_exchange_in_PT.lua
@@ -96,6 +96,7 @@ function Test:Precondition_InitOnready()
     end
   end)
   :Times(AnyNumber())
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }):Times(2)
 end
 
 function Test:Precondition_StartNewSession()

--- a/test_scripts/Policies/Validation_of_PolicyTables/308_ATF_Check_app_registration_language_gui.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/308_ATF_Check_app_registration_language_gui.lua
@@ -124,6 +124,7 @@ function Test:Precondition_InitOnready()
     end
   end)
   :Times(AnyNumber())
+  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }):Times(2)
 end
 
 function Test:Precondition_ConnectMobile()

--- a/test_scripts/Policies/Validation_of_PolicyTables/308_ATF_Check_app_registration_language_gui.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/308_ATF_Check_app_registration_language_gui.lua
@@ -119,12 +119,12 @@ function Test:Precondition_InitOnready()
   EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
   :Do(function(exp, d)
     if(exp.occurences == 1) then
+      EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATING" })
       self.hmiConnection:SendResponse(d.id, d.method, "SUCCESS", { })
       ptuInProgress = true
     end
   end)
   :Times(AnyNumber())
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }):Times(2)
 end
 
 function Test:Precondition_ConnectMobile()

--- a/test_scripts/Policies/Validation_of_PolicyTables/308_ATF_Check_app_registration_language_gui.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/308_ATF_Check_app_registration_language_gui.lua
@@ -50,6 +50,7 @@ local basic_ptu_file = "files/ptu.json"
 local ptu_first_app_registered = "files/ptu1app.json"
 local HMIAppID
 local language_desired = "EN-US"
+local ptuInProgress
 -- Basic applications. Using in Register tests
 local application1 =
 {
@@ -113,8 +114,16 @@ function Test:Precondition_initHMI()
   self:initHMI()
 end
 
-function Test:Precondition_initHMI_onReady()
+function Test:Precondition_InitOnready()
   self:initHMI_onReady()
+  EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
+  :Do(function(exp, d)
+    if(exp.occurences == 1) then
+      self.hmiConnection:SendResponse(d.id, d.method, "SUCCESS", { })
+      ptuInProgress = true
+    end
+  end)
+  :Times(AnyNumber())
 end
 
 function Test:Precondition_ConnectMobile()
@@ -141,11 +150,15 @@ function Test:RegisterFirstApp()
       EXPECT_RESPONSE(correlationId, { success = true })
       EXPECT_NOTIFICATION("OnPermissionsChange")
     end)
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }):Times(2)
-  EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
-  :Do(function(_,data)
+  if ptuInProgress then
+    self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+  else
+    EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATE_NEEDED" }, { status = "UPDATING" }):Times(2)
+    EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
+    :Do(function(_,data)
       self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
     end)
+  end
 end
 
 function Test:CheckDB_app_registration_language_gui()

--- a/test_scripts/Policies/user_consent_of_Policies/221_ATF_Factory_reset.lua
+++ b/test_scripts/Policies/user_consent_of_Policies/221_ATF_Factory_reset.lua
@@ -30,6 +30,9 @@ local sdl = require('SDL')
 local utils = require ('user_modules/utils')
 local commonTestCases = require ('user_modules/shared_testcases/commonTestCases')
 
+--[[ Local Variables ]]
+local ptuInProgress = false
+
 --[[ Local Functions ]]
 
 local function ReplacePreloadedFile()
@@ -139,8 +142,16 @@ function Test:Precondition_InitHMI()
   self:initHMI()
 end
 
-function Test:Precondition_InitHMI_onReady()
+function Test:Precondition_InitOnready()
   self:initHMI_onReady()
+  EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
+  :Do(function(exp, d)
+    if(exp.occurences == 1) then
+      self.hmiConnection:SendResponse(d.id, d.method, "SUCCESS", { })
+      ptuInProgress = true
+    end
+  end)
+  :Times(AnyNumber())
 end
 
 function Test:Precondition_ConnectMobile()
@@ -195,10 +206,12 @@ function Test:Precondition_Activate_app_To_Trigger_PTU_after_reset()
         end)
     end)
 
-  EXPECT_HMICALL("BasicCommunication.PolicyUpdate", {file = "/tmp/fs/mp/images/ivsu_cache/sdl_snapshot.json"})
-  :Do(function(_,data)
-      self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
-    end)
+  if not ptuInProgress then
+    EXPECT_HMICALL("BasicCommunication.PolicyUpdate", {file = "/tmp/fs/mp/images/ivsu_cache/sdl_snapshot.json"})
+    :Do(function(_,data)
+        self.hmiConnection:SendResponse(data.id, data.method, "SUCCESS", {})
+      end)      
+  end
 
   EXPECT_HMICALL("BasicCommunication.ActivateApp")
   :Do(function(_,data) self.hmiConnection:SendResponse(data.id,"BasicCommunication.ActivateApp", "SUCCESS", {}) end)

--- a/test_scripts/Policies/user_consent_of_Policies/221_ATF_Factory_reset.lua
+++ b/test_scripts/Policies/user_consent_of_Policies/221_ATF_Factory_reset.lua
@@ -147,6 +147,7 @@ function Test:Precondition_InitOnready()
   EXPECT_HMICALL("BasicCommunication.PolicyUpdate")
   :Do(function(exp, d)
     if(exp.occurences == 1) then
+      EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", { status = "UPDATING" })
       self.hmiConnection:SendResponse(d.id, d.method, "SUCCESS", { })
       ptuInProgress = true
     end


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/sdl_core/pull/3649

This PR is **ready** for review.

### Summary
Add expectation for BC.PolicyUpdate during InitHMI_OnReady in External Proprietary tests. 

### ATF version
develop

### Changelog

##### Bug Fixes
* Add expectation for BC.PolicyUpdate during InitHMI_OnReady in External UCS tests
* Add expectation for BC.PolicyUpdate during InitHMI_OnReady in Policy Table validation tests
* Add expectation for BC.PolicyUpdate during InitHMI_OnReady in Policy Table Update tests
* Add expectation for BC.PolicyUpdate during InitHMI_OnReady in user consent tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
