### PR TITLE
update testing for resumption status codes

### DIFF
--- a/test_scripts/Resumption/Handling_errors_from_HMI/002_successful_resumption_other_successful_result_codes.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/002_successful_resumption_other_successful_result_codes.lua
@@ -13,7 +13,7 @@
 --  - start resumption process
 --  - send set of <Rpc_n> requests to HMI
 -- 4. HMI responds with any <successful> resultCode to each <Rpc_n> request:
---   "WARNINGS", "RETRY", "SAVED", "WRONG_LANGUAGE", "UNSUPPORTED_RESOURCE"
+--   "WARNINGS", "RETRY", "SAVED", "WRONG_LANGUAGE", "UNSUPPORTED_RESOURCE", "TRUNCATED_DATA"
 -- SDL does:
 --  - process responses from HMI
 --  - restore all persistent data
@@ -29,7 +29,7 @@ runner.testSettings.isSelfIncluded = false
 
 -- [[ Local Variables ]]
 local successCodes = {
-  "WARNINGS", "RETRY", "SAVED", "WRONG_LANGUAGE", "UNSUPPORTED_RESOURCE"
+  "WARNINGS", "RETRY", "SAVED", "WRONG_LANGUAGE", "UNSUPPORTED_RESOURCE", "TRUNCATED_DATA"
 }
 -- [[ Local Function ]]
 local function setResponseCode(pCode)

--- a/test_scripts/Resumption/Handling_errors_from_HMI/027_resume_all_data_with_one_error_rpc_unexpected_disconnect_different_resultCodes.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/027_resume_all_data_with_one_error_rpc_unexpected_disconnect_different_resultCodes.lua
@@ -44,7 +44,6 @@ local resultCodes = {
   "NO_APPS_REGISTERED",
   "NO_DEVICES_CONNECTED",
   "USER_DISALLOWED",
-  "TRUNCATED_DATA",
   "READ_ONLY"
 }
 
@@ -66,7 +65,7 @@ local function reRegisterApp(pAppId, pErrorCode)
     end)
   common.getHMIConnection():ExpectRequest("UI.AddSubMenu",common.resumptionData[pAppId].addSubMenu.UI)
   :Do(function(_, data)
-      common.getHMIConnection():SendError(data.id, data.method, pErrorCode, "info message")
+      common.getHMIConnection():SendError(data.id, data.method, pErrorCode)
     end)
 
   common.resumptionFullHMILevel(pAppId)


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/sdl_core/issues/3660

This PR is **ready** for review.

### Summary
Modify tests for IsResponseSuccessful updates that will now consider result_code instead of info message

### ATF version
latest

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
