### PR TITLE
[Issue-1582] Adding of appId check to AlertManeuver and Speak requests in smoke tests

### DIFF
--- a/test_scripts/Smoke/API/028_AlertManeuver_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/028_AlertManeuver_PositiveCase_SUCCESS.lua
@@ -111,6 +111,7 @@ local allParams = {
 --[[ Local Functions ]]
 local function alertManeuver(pParams)
   local cid = common.getMobileSession():SendRPC("AlertManeuver", pParams.requestParams)
+  pParams.responseNaviParams.appID = common.getHMIAppId()
   common.getHMIConnection():ExpectRequest("Navigation.AlertManeuver", pParams.responseNaviParams)
   :Do(function(_, data)
       local function alertResp()
@@ -118,6 +119,7 @@ local function alertManeuver(pParams)
       end
       common.runAfter(alertResp, 2000)
     end)
+  pParams.responseTtsParams.appID = common.getHMIAppId()
   common.getHMIConnection():ExpectRequest("TTS.Speak", pParams.responseTtsParams)
   :Do(function(_, data)
       common.getHMIConnection():SendNotification("TTS.Started")

--- a/test_scripts/Smoke/API/044_AlertManeuver_Non_Media_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/044_AlertManeuver_Non_Media_PositiveCase_SUCCESS.lua
@@ -113,6 +113,7 @@ local allParams = {
 --[[ Local Functions ]]
 local function alertManeuver(pParams)
   local cid = common.getMobileSession():SendRPC("AlertManeuver", pParams.requestParams)
+  pParams.responseNaviParams.appID = common.getHMIAppId()
   common.getHMIConnection():ExpectRequest("Navigation.AlertManeuver", pParams.responseNaviParams)
   :Do(function(_, data)
     local function alertResp()
@@ -120,6 +121,7 @@ local function alertManeuver(pParams)
     end
     common.runAfter(alertResp, 2000)
   end)
+  pParams.responseTtsParams.appID = common.getHMIAppId()
   common.getHMIConnection():ExpectRequest("TTS.Speak", pParams.responseTtsParams)
   :Do(function(_, data)
     common.getHMIConnection():SendNotification("TTS.Started")


### PR DESCRIPTION
ATF Test Scripts to check #[1582](https://github.com/smartdevicelink/sdl_core/issues/1582)

This PR is **ready** for review.

### Summary
Adding of appId check to AlertManeuver and Speak requests in smoke tests

### ATF version
[ATF version to use]

### Changelog
* Update with adding of appId check in existed smoke scripts for AlertManeuver RPC

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
