### PR TITLE
Add SendHapticData RPC to the smoke

### DIFF
--- a/test_scripts/Smoke/API/056_SendHapticData_PositiveCase_SUCCESS.lua
+++ b/test_scripts/Smoke/API/056_SendHapticData_PositiveCase_SUCCESS.lua
@@ -1,0 +1,65 @@
+---------------------------------------------------------------------------------------------------
+-- User story: Smoke
+-- Use case: SendHapticData
+-- Item: Happy path
+--
+-- Requirement summary:
+-- [SendHapticData] SUCCESS: getting SUCCESS:UI.SendHapticData()
+--
+-- Description:
+-- Mobile application sends valid SendHapticData request with valid parameters to SDL
+
+-- Pre-conditions:
+-- a. HMI and SDL are started
+-- b. Mobile app is registered and activated on SDL
+-- c. Mobile app is currently Full HMI level
+
+-- Steps:
+-- 1. Mobile app requests SendHapticData with valid parameters
+-- 2. HMI receives UI.SendHapticData request and responds with SUCCESS
+
+-- Expected:
+-- SDL responds with (resultCode: SUCCESS, success:true) to mobile application
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/Smoke/commonSmoke')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local hapticData = {
+  hapticRectData = {
+    { id = 1, rect = { x = 1, y = 1.5, width = 1, height = 1.5 } }
+  }
+}
+
+--[[ Local Functions ]]
+local function sendHapticData()
+  local mobSession = common.getMobileSession()
+  local hmi = common.getHMIConnection()
+  local cid = mobSession:SendRPC("SendHapticData", hapticData)
+  local hmiData = common.cloneTable(hapticData)
+  hmiData.appID = common.getHMIAppId()
+  hmi:ExpectRequest("UI.SendHapticData", hmiData)
+  :Do(function(_, data)
+      hmi:SendResponse(data.id, data.method, "SUCCESS")
+    end)
+  mobSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS" })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Update Preloaded PT", common.updatePreloadedPT)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("RAI", common.registerApp)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("SendHapticData Positive Case", sendHapticData)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Smoke/commonSmoke.lua
+++ b/test_scripts/Smoke/commonSmoke.lua
@@ -77,8 +77,8 @@ function common.updatePreloadedPT()
   pt.policy_table.functional_groupings["DataConsent-2"].rpcs = json.null
   local additionalRPCs = {
     "SendLocation", "SubscribeVehicleData", "UnsubscribeVehicleData", "GetVehicleData", "UpdateTurnList",
-    "AlertManeuver", "DialNumber", "ReadDID", "GetDTCs", "ShowConstantTBT", "Alert", "SubtleAlert", 
-    "OnSubtleAlertPressed"
+    "AlertManeuver", "DialNumber", "ReadDID", "GetDTCs", "ShowConstantTBT", "Alert", "SubtleAlert",
+    "OnSubtleAlertPressed", "SendHapticData"
   }
   pt.policy_table.functional_groupings.NewTestCaseGroup = { rpcs = { } }
   for _, v in pairs(additionalRPCs) do

--- a/test_sets/smoke_tests.txt
+++ b/test_sets/smoke_tests.txt
@@ -54,6 +54,7 @@
 ./test_scripts/Smoke/API/053_GetInteriorVehicleDataConsent_PositiveCase_SUCCESS.lua
 ./test_scripts/Smoke/API/054_ReleaseInteriorVehicleDataModule_PositiveCase_SUCCESS.lua
 ./test_scripts/Smoke/API/055_GetInteriorVehicleData_PositiveCase_SUCCESS.lua
+./test_scripts/Smoke/API/056_SendHapticData_PositiveCase_SUCCESS.lua
 ./test_scripts/API/SubtleAlertStyle/SubtleAlert/001_PositiveCase_With_SoftButtons_SUCCESS.lua
 ./test_scripts/AppServices/PublishAppService/001_Mobile_success_flow.lua
 ./test_scripts/AppServices/PublishAppService/002_HMI_success_flow.lua


### PR DESCRIPTION
ATF Test Scripts to check #[3645](https://github.com/smartdevicelink/sdl_core/issues/3645)

This PR is **ready** for review.

### Summary
Script with a check of successful processing of SendHapticData RPC  

### ATF version
develop

### Changelog
 * Added new script with SendHapticData RPC 
 * Updated smoke test set with new script
 * Added permissions for SendHapticData RPC in common smoke file

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
