### PR TITLE
get AppIconsFolder value from ini config

### DIFF
--- a/test_scripts/API/SetAppIcon/commonIconResumed.lua
+++ b/test_scripts/API/SetAppIcon/commonIconResumed.lua
@@ -11,7 +11,6 @@ local utils = require("user_modules/utils")
 local test = require("user_modules/dummy_connecttest")
 local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
 local mobile_session = require('mobile_session')
-local SDLConfig = require('user_modules/shared_testcases/SmartDeviceLinkConfigurations')
 
 --[[ Module ]]
 local m = actions
@@ -38,7 +37,7 @@ end
 --]]
 function m.getIconValueForResumption(pAppId)
   if not pAppId then pAppId = 1 end
-  return commonPreconditions:GetPathToSDL() .. SDLConfig:GetValue("AppIconsFolder") .. "/" .. m.getConfigAppParams(pAppId).fullAppID
+  return commonPreconditions:GetPathToSDL() .. m.sdl.getSDLIniParameter("AppIconsFolder") .. "/" .. m.getConfigAppParams(pAppId).fullAppID
 end
 
 --[[ @registerAppWOPTU: register mobile application

--- a/test_scripts/API/SetAppIcon/commonIconResumed.lua
+++ b/test_scripts/API/SetAppIcon/commonIconResumed.lua
@@ -11,6 +11,7 @@ local utils = require("user_modules/utils")
 local test = require("user_modules/dummy_connecttest")
 local commonPreconditions = require('user_modules/shared_testcases/commonPreconditions')
 local mobile_session = require('mobile_session')
+local SDLConfig = require('user_modules/shared_testcases/SmartDeviceLinkConfigurations')
 
 --[[ Module ]]
 local m = actions
@@ -37,7 +38,7 @@ end
 --]]
 function m.getIconValueForResumption(pAppId)
   if not pAppId then pAppId = 1 end
-  return commonPreconditions:GetPathToSDL() .. "storage/" .. m.getConfigAppParams(pAppId).fullAppID
+  return commonPreconditions:GetPathToSDL() .. SDLConfig:GetValue("AppIconsFolder") .. "/" .. m.getConfigAppParams(pAppId).fullAppID
 end
 
 --[[ @registerAppWOPTU: register mobile application


### PR DESCRIPTION
ATF Test Scripts to check #[issue number in sdl_core repository]

This PR is **ready** for review.

### Summary
get `AppIconsFolder` from ini instead of assuming it is `storage`

tests `test_scripts/API/SetAppIcon` 2-6 and 10-11 were failing on a fresh build before these changes

### ATF version
latest

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
