### PR TITLE
Make stable scripts for issue 3620

### DIFF
--- a/test_scripts/Defects/7_1/3620/common.lua
+++ b/test_scripts/Defects/7_1/3620/common.lua
@@ -57,6 +57,10 @@ function common.startUnprotectedRPCservice()
     frameInfo = common.frameInfo.START_SERVICE_ACK,
     encryption = false
   })
+  common.hmi.getConnection():ExpectNotification("BasicCommunication.OnServiceUpdate",
+    { serviceEvent = "REQUEST_RECEIVED", serviceType = "RPC" },
+    { serviceEvent = "REQUEST_ACCEPTED", serviceType = "RPC" })
+  :Times(2)
 end
 
 function common.startProtectedServiceWithOnServiceUpdate(pServiceParams)


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
There is an instability of scripts for issue 3620:
https://github.com/smartdevicelink/sdl_atf_test_scripts/tree/develop/test_scripts/Defects/7_1/3620

Some scripts randomly failed with message:
```
 HMI notification BasicCommunication.OnServiceUpdate: ValidIf: 
params.serviceEvent: expected: REQUEST_RECEIVED, actual value: REQUEST_ACCEPTED
params.serviceEvent: expected: REQUEST_REJECTED, actual value: REQUEST_RECEIVED
 HMI notification BasicCommunication.OnServiceUpdate: Times: The most allowed occurences boundary exceed
```

### ATF version
develop

### Changelog
  - Added expectation on `BC.OnServiceUpdate` into `startUnprotectedRPCservice()` function

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
