### PR TITLE
Fix list of parameters in VD Subscribe/Unsubscribe scripts

### DIFF
--- a/test_scripts/API/VehicleData/SubscribeVehicleData/003_SubscribeVD_disallowed_after_PTU.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/003_SubscribeVD_disallowed_after_PTU.lua
@@ -63,7 +63,8 @@ for param in common.spairs(common.getVDParams(true)) do
 
   common.runner.Title("Test")
   common.runner.Step("PTU with disabling permissions for VD parameter", policyTableUpdate, { param })
-  common.runner.Step("RPC " .. common.rpc.sub .. " DISALLOWED after PTU", common.processRPCFailure, { common.rpc.sub, result })
+  common.runner.Step("RPC " .. common.rpc.sub .. " DISALLOWED after PTU", common.processRPCFailure,
+    { common.rpc.sub, param, result })
 
   common.runner.Title("Postconditions")
   common.runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/003_UnsubscribeVD_disallowed_after_PTU.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/003_UnsubscribeVD_disallowed_after_PTU.lua
@@ -77,7 +77,7 @@ for param in common.spairs(common.getVDParams(true)) do
   common.runner.Step("RPC " .. common.rpc.sub .. " SUCCESS", common.processSubscriptionRPC,
     { common.rpc.sub, param })
   common.runner.Step("RPC " .. common.rpc.unsub .. " DISALLOWED after PTU", common.processRPCFailure,
-    { common.rpc.unsub, result })
+    { common.rpc.unsub, param, result })
 
   common.runner.Title("Postconditions")
   common.runner.Step("Stop SDL", common.postconditions)


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Currently 2 scripts on VD below has incorrect list of parameters for `common.processRPCFailure()` function:
```
./test_scripts/API/VehicleData/SubscribeVehicleData/003_SubscribeVD_disallowed_after_PTU.lua
./test_scripts/API/VehicleData/UnsubscribeVehicleData/003_UnsubscribeVD_disallowed_after_PTU.lua
```
It leads to an issue that appropriate check doesn't work.

### ATF version
develop

### Changelog
 - Fix list of parameters for `common.processRPCFailure()` function

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
