### PR TITLE
Update AppInfo path to account for Core changes

### DIFF
--- a/test_scripts/Policies/Policy_Table_Update/148_ATF_HMILvl_on_PTU_affected_in_BACKGROUND_or_NONE.lua
+++ b/test_scripts/Policies/Policy_Table_Update/148_ATF_HMILvl_on_PTU_affected_in_BACKGROUND_or_NONE.lua
@@ -29,6 +29,7 @@ local mobileSession = require("mobile_session")
 local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
 local commonSteps = require("user_modules/shared_testcases/commonSteps")
 local json = require("modules/json")
+local SDL = require("SDL")
 local utils = require ('user_modules/utils')
 
 --[[ Local Variables ]]
@@ -209,7 +210,7 @@ end
 
 function Test.Precondition_Clean()
   commonSteps:DeleteLogsFileAndPolicyTable()
-  os.remove(config.pathToSDL .. "/app_info.dat") -- in order to skip resumption
+  SDL.AppInfo.clean() -- in order to skip resumption
   os.remove(policy_file_path .. "/sdl_snapshot.json")
   if not check_file_exists(policy_file_path .. "/sdl_snapshot.json") then
     print("PTS is removed")

--- a/test_scripts/Policies/Validation_of_PolicyTables/230_ATF_usage_and_error_counts_update_minutes_in_hmi_none.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/230_ATF_usage_and_error_counts_update_minutes_in_hmi_none.lua
@@ -42,6 +42,7 @@ local json = require("modules/json")
 local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
 local commonSteps = require ('user_modules/shared_testcases/commonSteps')
 local mobile_session = require('mobile_session')
+local SDL = require("SDL")
 local utils = require ('user_modules/utils')
 require('cardinalities')
 require('user_modules/AppTypes')
@@ -398,7 +399,7 @@ end
 function Test:StopSDL()
   StopSDL(self)
   TestData:store("Store first LocalPT ", constructPathToDatabase(), "first_policy.sqlite" )
-  os.remove(config.pathToSDL .. "app_info.dat")
+  SDL.AppInfo.clean() -- in order to skip resumption
 end
 
 function Test:StartSDL()

--- a/test_scripts/Policies/Validation_of_PolicyTables/231_ATF_usage_and_error_counts_update_minutes_in_hmi_limited.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/231_ATF_usage_and_error_counts_update_minutes_in_hmi_limited.lua
@@ -35,6 +35,7 @@ local json = require("modules/json")
 local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
 local commonSteps = require ('user_modules/shared_testcases/commonSteps')
 local mobile_session = require('mobile_session')
+local SDL = require("SDL")
 local utils = require ('user_modules/utils')
 
 commonSteps:DeleteLogsFiles()
@@ -409,7 +410,7 @@ end
 function Test:StopSDL()
   StopSDL(self)
   TestData:store("Store first LocalPT ", constructPathToDatabase(), "first_policy.sqlite" )
-  os.remove(config.pathToSDL .. "app_info.dat")
+  SDL.AppInfo.clean()
 end
 
 function Test:StartSDL()

--- a/test_scripts/Policies/Validation_of_PolicyTables/232_ATF_usage_and_error_counts_update_minutes_in_hmi_full.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/232_ATF_usage_and_error_counts_update_minutes_in_hmi_full.lua
@@ -36,6 +36,7 @@ local json = require("modules/json")
 local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
 local commonSteps = require ('user_modules/shared_testcases/commonSteps')
 local mobile_session = require('mobile_session')
+local SDL = require("SDL")
 local utils = require ('user_modules/utils')
 require('cardinalities')
 require('user_modules/AppTypes')
@@ -395,7 +396,7 @@ end
 function Test:StopSDL()
   StopSDL(self)
   TestData:store("Store first LocalPT ", constructPathToDatabase(), "first_policy.sqlite" )
-  os.remove(config.pathToSDL .. "app_info.dat")
+  SDL.AppInfo.clean()
 end
 
 function Test:StartSDL()

--- a/test_scripts/Policies/Validation_of_PolicyTables/233_ATF_usage_and_error_counts_update_minutes_in_hmi_background.lua
+++ b/test_scripts/Policies/Validation_of_PolicyTables/233_ATF_usage_and_error_counts_update_minutes_in_hmi_background.lua
@@ -36,6 +36,7 @@ local json = require("modules/json")
 local commonFunctions = require ('user_modules/shared_testcases/commonFunctions')
 local commonSteps = require ('user_modules/shared_testcases/commonSteps')
 local mobile_session = require('mobile_session')
+local SDL = require("SDL")
 local utils = require ('user_modules/utils')
 require('cardinalities')
 require('user_modules/AppTypes')
@@ -398,7 +399,7 @@ end
 function Test:StopSDL()
   StopSDL(self)
   TestData:store("Store first LocalPT ", constructPathToDatabase(), "first_policy.sqlite" )
-  os.remove(config.pathToSDL .. "app_info.dat")
+  SDL.AppInfo.clean()
 end
 
 function Test:StartSDL()

--- a/test_scripts/Policies/build_options/079_ATF_PTU_HMI_Level_Affected_Apps_NONE_BACKGROUND_HTTP.lua
+++ b/test_scripts/Policies/build_options/079_ATF_PTU_HMI_Level_Affected_Apps_NONE_BACKGROUND_HTTP.lua
@@ -31,6 +31,7 @@ local mobileSession = require("mobile_session")
 local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
 local commonSteps = require("user_modules/shared_testcases/commonSteps")
 local commonTestCases = require("user_modules/shared_testcases/commonTestCases")
+local SDL = require("SDL")
 local json = require("modules/json")
 
 --[[ Local Variables ]]
@@ -167,7 +168,7 @@ end
 
 function Test.Precondition_Clean()
   commonSteps:DeleteLogsFileAndPolicyTable()
-  os.remove(config.pathToSDL .. "/app_info.dat") -- in order to skip resumption
+  SDL.AppInfo.clean() -- in order to skip resumption
   os.remove(policy_file_path .. "/sdl_snapshot.json")
   if not check_file_exists(policy_file_path .. "/sdl_snapshot.json") then
     print("PTS is removed")

--- a/test_scripts/SDL5_0/LowVoltage/common.lua
+++ b/test_scripts/SDL5_0/LowVoltage/common.lua
@@ -291,8 +291,7 @@ end
 function m.waitUntilResumptionDataIsStored()
   utils.cprint(35, "Wait ...")
   local timeoutToSafe = commonFunctions:read_parameter_from_smart_device_link_ini("AppSavePersistentDataTimeout")
-  local fileName = commonPreconditions:GetPathToSDL()
-    .. commonFunctions:read_parameter_from_smart_device_link_ini("AppInfoStorage")
+  local fileName = SDL.AppInfo.file()
   local function isFileExist()
     local f = io.open(fileName, "r")
     if f ~= nil then

--- a/user_modules/all_common_modules.lua
+++ b/user_modules/all_common_modules.lua
@@ -32,9 +32,7 @@ if common_functions:IsFileExist("sdl.pid") then
 end
 os.execute("kill -9 $(ps aux | grep -e smartDeviceLinkCore | awk '{print$2}')")
 -- Remove app_info.dat to avoid resumption.
-if common_functions:IsFileExist(config.pathToSDL  .. "app_info.dat") then
-  os.execute("rm -rf " .. config.pathToSDL  .. "app_info.dat")
-end
+sdl.AppInfo.clean()
 local path_to_sdl_without_bin = string.gsub(config.pathToSDL, "bin/", "")
 local sdl_bin_bk = path_to_sdl_without_bin .. "sdl_bin_bk/"
 if common_functions:IsDirectoryExist(sdl_bin_bk) == false then

--- a/user_modules/common_functions.lua
+++ b/user_modules/common_functions.lua
@@ -28,8 +28,8 @@ end
 
 function CommonFunctions:DeleteLogsFiles()
   CommonFunctions:CheckSdlPath()
-  if self:IsFileExist(config.pathToSDL .. "app_info.dat") then
-    os.remove(config.pathToSDL .. "app_info.dat")
+  if self:IsFileExist(config.pathToSDL .. SDLConfig:GetValue("AppStorageFolder") .. "/" .. SDLConfig:GetValue("AppInfoStorage")) then
+    os.remove(config.pathToSDL .. SDLConfig:GetValue("AppStorageFolder") .. "/" .. SDLConfig:GetValue("AppInfoStorage"))
   end
   os.execute("rm -f " .. config.pathToSDL .. "*.log")
 end

--- a/user_modules/common_functions.lua
+++ b/user_modules/common_functions.lua
@@ -1,6 +1,7 @@
 -- This script contains common functions that are used in many script.
 -- How to use: common_functions:IsFileExist(path to file)
 --------------------------------------------------------------------------------
+local SDLConfig = require('user_modules/shared_testcases/SmartDeviceLinkConfigurations')
 local CommonFunctions = {}
 -- COMMON FUNCTIONS FOR FILE AND FOLDER
 --------------------------------------------------------------------------------

--- a/user_modules/shared_testcases/commonSteps.lua
+++ b/user_modules/shared_testcases/commonSteps.lua
@@ -380,8 +380,8 @@ function commonSteps:DeleteLogsFiles()
 	self:CheckSDLPath()
 
 	--Delete app_info.dat and log files
-	if self:file_exists(config.pathToSDL .. "app_info.dat") == true then
-		os.remove(config.pathToSDL .. "app_info.dat")
+	if self:file_exists(config.pathToSDL .. SDLConfig:GetValue("AppStorageFolder") .. "/" .. SDLConfig:GetValue("AppInfoStorage")) == true then
+		os.remove(config.pathToSDL .. SDLConfig:GetValue("AppStorageFolder") .. "/" .. SDLConfig:GetValue("AppInfoStorage"))
 	end
 
 	if self:file_exists(config.pathToSDL .. "SmartDeviceLinkCore.log") == true then

--- a/user_modules/shared_testcases/testCasesForExternalUCS.lua
+++ b/user_modules/shared_testcases/testCasesForExternalUCS.lua
@@ -59,12 +59,9 @@ local m = { }
 --! @parameters: NO
 --]]
   function m.removeLPT()
-    local data = { "AppStorageFolder" }
-    for i, v in pairs(data) do
-      assert(os.execute("rm -rf " .. commonPreconditions:GetPathToSDL()
-        .. commonFunctions:read_parameter_from_smart_device_link_ini(v)
-        .. (i == 1 and "/*" or "")))
-    end
+    assert(os.execute("rm -rf " .. commonPreconditions:GetPathToSDL()
+      .. commonFunctions:read_parameter_from_smart_device_link_ini("AppStorageFolder")
+      .. "/*"))
   end
 
 --[[@removePTS: Delete Policy Table Snapshot

--- a/user_modules/shared_testcases/testCasesForExternalUCS.lua
+++ b/user_modules/shared_testcases/testCasesForExternalUCS.lua
@@ -59,7 +59,7 @@ local m = { }
 --! @parameters: NO
 --]]
   function m.removeLPT()
-    local data = { "AppStorageFolder", "AppInfoStorage" }
+    local data = { "AppStorageFolder" }
     for i, v in pairs(data) do
       assert(os.execute("rm -rf " .. commonPreconditions:GetPathToSDL()
         .. commonFunctions:read_parameter_from_smart_device_link_ini(v)

--- a/user_modules/shared_testcases_custom/commonSteps.lua
+++ b/user_modules/shared_testcases_custom/commonSteps.lua
@@ -413,8 +413,8 @@ function commonSteps:DeleteLogsFiles()
 	self:CheckSDLPath()
 
 	--Delete app_info.dat and log files
-	if self:file_exists(config.pathToSDL .. "app_info.dat") == true then
-		os.remove(config.pathToSDL .. "app_info.dat")
+	if self:file_exists(config.pathToSDL .. SDLConfig:GetValue("AppStorageFolder") .. "/" .. SDLConfig:GetValue("AppInfoStorage")) == true then
+		os.remove(config.pathToSDL .. SDLConfig:GetValue("AppStorageFolder") .. "/" .. SDLConfig:GetValue("AppInfoStorage"))
 	end
 
 	if self:file_exists(config.pathToSDL .. "SmartDeviceLinkCore.log") == true then


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/sdl_core/pull/3686

This PR is **ready** for review.

### Summary
Update `app_info.dat` path to account for it being stored in the `storage` folder.

### ATF version
https://github.com/smartdevicelink/sdl_atf/pull/226

### Changelog

##### Enhancements
* Update `app_info.dat` path to account for it being stored in the `storage` folder.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
