### PR TITLE
Add clean up for AppIcons folder

### DIFF
--- a/user_modules/sequences/actions.lua
+++ b/user_modules/sequences/actions.lua
@@ -1240,6 +1240,7 @@ function m.preconditions()
   SDL.AppInfo.clean()
   m.sdl.deletePTS()
   SDL.AppStorage.clean()
+  SDL.AppIcons.clean()
 end
 
 --[[ @postconditions: postcondition steps


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Within https://github.com/smartdevicelink/sdl_core/pull/2202 folder for icons had changed from `storage` to a `icons`
Appropriate clean up is required for a new folder.

### ATF version
https://github.com/smartdevicelink/sdl_atf/pull/227

### Changelog
  - Added call of `SDL.AppIcons.clean()` function into `preconditions()`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
