### PR TITLE
Add clean up of AppStorage and AppIcons folders into postconditions

### DIFF
--- a/user_modules/sequences/actions.lua
+++ b/user_modules/sequences/actions.lua
@@ -1249,6 +1249,8 @@ end
 --]]
 function m.postconditions()
   StopSDL()
+  SDL.AppStorage.clean()
+  SDL.AppIcons.clean()
   m.sdl.restoreSDLIniFile()
   m.sdl.restorePreloadedPT()
   m.sdl.restoreHMICapabilitiesFile()


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Scripts are failing if run consecutively:
```
./test_scripts/API/RemoveUrlParameterMaxLength/002_StartStream.lua
./test_scripts/API/RemoveUrlParameterMaxLength/003_StartAudioStream.lua
```

### ATF version
develop

### Changelog
 - Added clean up of `AppStorage` and `AppIcons` folders into `postconditions()` function


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
