### PR TITLE
[SDL-0236] Update mismatch in TireStatus structure

### DIFF
--- a/test_scripts/API/VehicleData/TireStatusMismatch/001_GetVD_TireStatus_default_values_for_old_app.lua
+++ b/test_scripts/API/VehicleData/TireStatusMismatch/001_GetVD_TireStatus_default_values_for_old_app.lua
@@ -1,0 +1,68 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0236-TireStatus-Mismatch.md
+---------------------------------------------------------------------------------------------------
+-- Description: Check that SDL applies default values for 'tirePressure' parameters within 'GetVehicleData' response
+--  for old Apps (syncMsgVersion<=7.1) in case HMI responds without tirePressure parameters
+--
+-- Preconditions:
+-- 1) SDL and HMI are started
+-- 2) GetVehicleData RPC and 'tirePressure' parameter are allowed by policies
+-- 3) App is registered with syncMsgVersion=7.1
+--
+-- In case:
+-- 1) App sends 'GetVehicleData' request with tirePressure=true to SDL
+-- SDL does:
+-- - a) transfer this request to HMI
+-- 2) HMI sends VI.GetVehicleData response with <tirePressure> data to SDL
+--   without <sub_vd_param> sub-parameter
+-- SDL does:
+-- - a) send GetVehicleData response with <tirePressure> data received from HMI and with default value
+--     for missing <sub_vd_param> sub-parameter (success = true, resultCode = "SUCCESS",
+--       <tirePressure> = <<data received from HMI, <sub_vd_param> = <default data>>) to App
+-- 3) App sends 'GetVehicleData' request with tirePressure=true to SDL
+-- SDL does:
+-- - a) transfer this request to HMI
+-- 4) HMI sends VI.GetVehicleData response with empty <tirePressure> array to SDL
+-- SDL does:
+-- - a) send GetVehicleData response with <tirePressure> data with default value
+--     for all missing <sub_vd_param> sub-parameters (success = true, resultCode = "SUCCESS",
+--       <tirePressure> = <default data>) to App
+-- 5) App sends 'GetVehicleData' request with tirePressure=true to SDL
+-- SDL does:
+-- - a) transfer this request to HMI
+-- 6) HMI sends VI.GetVehicleData response with <tirePressure> data and to SDL
+--   with all <sub_vd_param> sub-parameters
+-- SDL does:
+-- - a) send GetVehicleData response with <tirePressure> data received from HMI (success = true, resultCode = "SUCCESS",
+--     <tirePressure> = <data received from HMI>) to App
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/API/VehicleData/TireStatusMismatch/common')
+
+--[[ Test Configuration ]]
+config.application1.registerAppInterfaceParams.syncMsgVersion.majorVersion = 7
+config.application1.registerAppInterfaceParams.syncMsgVersion.minorVersion = 1
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerApp)
+common.Step("PolicyTableUpdate", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App", common.activateApp)
+
+common.Title("Test")
+for _, p in common.spairs(common.tirePressureParams) do
+  local hmiValue = common.getTirePressureNonDefaultValue()
+  hmiValue[p] = nil
+  local appValue = common.getTirePressureNonDefaultValue()
+  appValue[p] = common.getDefaultValue(p)
+  common.Step("Send GetVehicleData param " .. p .. " missing", common.sendGetVehicleData, { hmiValue, appValue })
+end
+common.Step("Send GetVehicleData all params missing", common.sendGetVehicleData,
+  { {}, common.getTirePressureDefaultValue() })
+common.Step("Send GetVehicleData all params present", common.sendGetVehicleData,
+  { common.getTirePressureNonDefaultValue(), common.getTirePressureNonDefaultValue() })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/TireStatusMismatch/002_OnVD_TireStatus_default_values_for_old_app.lua
+++ b/test_scripts/API/VehicleData/TireStatusMismatch/002_OnVD_TireStatus_default_values_for_old_app.lua
@@ -1,0 +1,64 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0236-TireStatus-Mismatch.md
+---------------------------------------------------------------------------------------------------
+-- Description: Check that SDL applies default values for 'tirePressure' parameters within 'OnVehicleData' notification
+--  for old Apps (syncMsgVersion<=7.1) in case HMI sends 'OnVehicleData' notification without tirePressure parameters
+--
+-- Preconditions:
+-- 1) SDL and HMI are started
+-- 2) SubscribeVehicleData, OnVehicleData RPCs and tirePressure' parameter are allowed by policies
+-- 3) App is registered with syncMsgVersion=7.1
+-- 4) App is subscribed to receive updates on 'tirePressure' vehicle data
+--
+-- In case:
+-- 1. HMI sends 'OnVehicleData' notification with 'tirePressure' data to SDL
+--   without <sub_vd_param> sub-parameter
+-- SDL does:
+--  - a) transfer 'OnVehicleData' notification with <tirePressure> data received from HMI to App
+--      with default value for missing <sub_vd_param> sub-parameter
+-- 2. HMI sends 'OnVehicleData' notification with empty <tirePressure> array to SDL
+-- SDL does:
+--  - a) transfer 'OnVehicleData' notification with default value to App
+--      for all missing <sub_vd_param> sub-parameter
+-- 3. HMI sends 'OnVehicleData' notification with 'tirePressure' data to SDL
+--   with all <sub_vd_param> sub-parameters
+-- SDL does:
+--  - a) transfer 'OnVehicleData' notification with <tirePressure> data received from HMI to App
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/API/VehicleData/TireStatusMismatch/common')
+
+--[[ Test Configuration ]]
+config.application1.registerAppInterfaceParams.syncMsgVersion.majorVersion = 7
+config.application1.registerAppInterfaceParams.syncMsgVersion.minorVersion = 1
+
+--[[ Local Functions ]]
+local function sendOnVehicleData(pHmiNotification, pAppNotification)
+  common.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", { tirePressure = pHmiNotification })
+  common.getMobileSession():ExpectNotification("OnVehicleData", { tirePressure = pAppNotification })
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App", common.registerApp)
+common.Step("PolicyTableUpdate", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App", common.activateApp)
+common.Step("Subscribe VehicleData tirePressure", common.subscribeVehicleData)
+
+common.Title("Test")
+for _, p in common.spairs(common.tirePressureParams) do
+  local hmiValue = common.getTirePressureNonDefaultValue()
+  hmiValue[p] = nil
+  local appValue = common.getTirePressureNonDefaultValue()
+  appValue[p] = common.getDefaultValue(p)
+  common.Step("Send OnVehicleData param " .. p .. " missing", sendOnVehicleData, { hmiValue, appValue })
+end
+common.Step("Send OnVehicleData all params missing", sendOnVehicleData,
+  { {}, common.getTirePressureDefaultValue() })
+common.Step("Send OnVehicleData all params present", sendOnVehicleData,
+  { common.getTirePressureNonDefaultValue(), common.getTirePressureNonDefaultValue() })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/TireStatusMismatch/003_OnVD_TireStatus_default_values_for_different_apps_version.lua
+++ b/test_scripts/API/VehicleData/TireStatusMismatch/003_OnVD_TireStatus_default_values_for_different_apps_version.lua
@@ -1,0 +1,99 @@
+---------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0236-TireStatus-Mismatch.md
+---------------------------------------------------------------------------------------------------
+-- Description: Check that SDL processes OnVehicleData notification with 'tirePressure' parameter
+--  for different Apps versions (syncMsgVersion=7.1 and syncMsgVersion=8.0)
+--
+-- Preconditions:
+-- 1) SDL and HMI are started
+-- 2) SubscribeVehicleData, OnVehicleData RPCs and tirePressure' parameter are allowed by policies
+-- 3) App_1 is registered with syncMsgVersion=7.1
+-- 4) App_2 is registered with syncMsgVersion=8.0
+-- 5) Apps are subscribed to receive updates on 'tirePressure' vehicle data
+--
+-- In case:
+-- 1. HMI sends 'OnVehicleData' notification with 'tirePressure' data to SDL
+--   without <sub_vd_param> sub-parameter
+-- SDL does:
+--  - a) transfer 'OnVehicleData' notification with <tirePressure> data received from HMI to App_1
+--      with default value for missing <sub_vd_param> sub-parameter
+--  - b) transfer 'OnVehicleData' notification with <tirePressure> data received from HMI to App_2
+-- 2. HMI sends 'OnVehicleData' notification with empty <tirePressure> array to SDL
+-- SDL does:
+--  - a) transfer 'OnVehicleData' notification with default value to App
+--      for all missing <sub_vd_param> sub-parameter
+--  - b) transfer 'OnVehicleData' notification with <tirePressure> data received from HMI to App_2
+-- 3. HMI sends 'OnVehicleData' notification with 'tirePressure' data to SDL
+--   with all <sub_vd_param> sub-parameters
+-- SDL does:
+--  - a) transfer 'OnVehicleData' notification with <tirePressure> data received from HMI to both Apps
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/API/VehicleData/TireStatusMismatch/common')
+
+--[[ Test Configuration ]]
+config.application1.registerAppInterfaceParams.syncMsgVersion.majorVersion = 7
+config.application1.registerAppInterfaceParams.syncMsgVersion.minorVersion = 1
+config.application2.registerAppInterfaceParams.syncMsgVersion.majorVersion = 8
+config.application2.registerAppInterfaceParams.syncMsgVersion.minorVersion = 0
+
+--[[ Local Variables ]]
+local isExpectedSubscription = true
+local isNotExpectedSubscription = false
+local appSessionId1 = 1
+local appSessionId2 = 2
+local tirePressureNonDefaultValue = common.getTirePressureNonDefaultValue()
+
+--[[ Local Functions ]]
+local function validation(actualData, expectedData, pMessage)
+  if actualData == nil then return false, "Actual table: nil" end
+  if true ~= common.isTableEqual(actualData, expectedData) then
+      return false, pMessage .. " contains unexpected parameters.\n" ..
+      "Expected table: " .. common.tableToString(expectedData) .. "\n" ..
+      "Actual table: " .. common.tableToString(actualData) .. "\n"
+  end
+  return true
+end
+
+local function sendOnVehicleDataTwoApps(pHmiNotification, pAppNotification1, pAppNotification2)
+  common.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", { tirePressure = pHmiNotification })
+  common.getMobileSession(appSessionId1):ExpectNotification("OnVehicleData")
+  :ValidIf(function(_,data)
+    return validation(data.payload, { tirePressure = pAppNotification1 }, "OnVehicleData notification for App_1")
+  end)
+  common.getMobileSession(appSessionId2):ExpectNotification("OnVehicleData")
+  :ValidIf(function(_,data)
+    return validation(data.payload, { tirePressure = pAppNotification2 }, "OnVehicleData notification for App_2")
+  end)
+end
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+common.Step("Register App_1", common.registerAppWOPTU, { appSessionId1 })
+common.Step("Register App_2", common.registerApp, { appSessionId2 })
+common.Step("PolicyTableUpdate", common.policyTableUpdate, { common.ptUpdate })
+common.Step("Activate App_1", common.activateApp, { appSessionId1 })
+common.Step("Subscribe VehicleData tirePressure for App_1", common.subscribeVehicleData,
+  { appSessionId1, isExpectedSubscription })
+common.Step("Activate App_2", common.activateApp, { appSessionId2 })
+common.Step("Subscribe VehicleData tirePressure for App_2", common.subscribeVehicleData,
+  { appSessionId2, isNotExpectedSubscription })
+
+common.Title("Test")
+for _, p in common.spairs(common.tirePressureParams) do
+  local hmiValue = common.getTirePressureNonDefaultValue()
+  hmiValue[p] = nil
+  local appValue = common.getTirePressureNonDefaultValue()
+  appValue[p] = common.getDefaultValue(p)
+  common.Step("Send OnVehicleData param " .. p .. " missing", sendOnVehicleDataTwoApps,
+    { hmiValue, appValue, hmiValue })
+end
+common.Step("Send OnVehicleData all params missing", sendOnVehicleDataTwoApps ,
+  { {}, common.getTirePressureDefaultValue(), {} })
+common.Step("Send OnVehicleData all params present", sendOnVehicleDataTwoApps,
+  { tirePressureNonDefaultValue, tirePressureNonDefaultValue, tirePressureNonDefaultValue })
+
+common.Title("Postconditions")
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/API/VehicleData/TireStatusMismatch/common.lua
+++ b/test_scripts/API/VehicleData/TireStatusMismatch/common.lua
@@ -1,0 +1,108 @@
+---------------------------------------------------------------------------------------------------
+-- Common module
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local actions = require("user_modules/sequences/actions")
+local runner = require('user_modules/script_runner')
+local utils = require("user_modules/utils")
+
+--[[ General configuration parameters ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local Variables ]]
+local m = {}
+
+--[[ Common Proxy Functions ]]
+m.Title = runner.Title
+m.Step = runner.Step
+m.preconditions = actions.preconditions
+m.postconditions = actions.postconditions
+m.start = actions.start
+m.registerApp = actions.app.register
+m.registerAppWOPTU = actions.app.registerNoPTU
+m.activateApp = actions.app.activate
+m.getMobileSession = actions.getMobileSession
+m.getHMIConnection = actions.hmi.getConnection
+m.policyTableUpdate = actions.policyTableUpdate
+m.cloneTable = utils.cloneTable
+m.spairs = utils.spairs
+m.isTableEqual = utils.isTableEqual
+m.tableToString = utils.tableToString
+
+--[[ Common Variables ]]
+m.tirePressureParams = {
+  "pressureTelltale", "leftFront", "rightFront", "leftRear", "rightRear", "innerLeftRear", "innerRightRear"
+}
+
+--[[ Common Functions ]]
+function m.ptUpdate(pTbl)
+  local grp = pTbl.policy_table.functional_groupings["Location-1"]
+  grp.user_consent_prompt = nil
+  for _, rpc in pairs(grp.rpcs) do
+    table.insert(rpc.parameters, "tirePressure")
+  end
+end
+
+function m.getDefaultValue(pParam)
+  if pParam == "pressureTelltale" then return "NOT_USED" end
+  return {
+    status = "UNKNOWN"
+  }
+end
+
+function m.getTirePressureDefaultValue()
+  local out = {}
+  for _, p in pairs(m.tirePressureParams) do
+    out[p] = m.getDefaultValue(p)
+  end
+  return out
+end
+
+function m.getNonDefaultValue(pParam)
+  if pParam == "pressureTelltale" then return "ON" end
+  return {
+    status = "NORMAL",
+    tpms = "TRAIN",
+    pressure = 1.1
+  }
+end
+
+function m.getTirePressureNonDefaultValue()
+  local out = {}
+  for _, p in pairs(m.tirePressureParams) do
+    out[p] = m.getNonDefaultValue(p)
+  end
+  return out
+end
+
+function m.sendGetVehicleData(pHmiResponse, pAppResponse)
+  local cid = actions.getMobileSession():SendRPC("GetVehicleData", { tirePressure = true })
+  actions.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { tirePressure = true })
+  :Do(function(_, data)
+      actions.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { tirePressure = pHmiResponse })
+    end)
+  actions.getMobileSession():ExpectResponse(cid, { success = true, resultCode = "SUCCESS", tirePressure = pAppResponse })
+end
+
+function m.subscribeVehicleData(pAppId, isRequestOnHMIExpected)
+  if pAppId == nil then pAppId = 1 end
+  if isRequestOnHMIExpected == nil then isRequestOnHMIExpected = true end
+  local tirePressureResponseData = {
+    dataType = "VEHICLEDATA_TIREPRESSURE",
+    resultCode = "SUCCESS"
+  }
+  local cid = actions.getMobileSession(pAppId):SendRPC("SubscribeVehicleData", { tirePressure = true })
+  if isRequestOnHMIExpected == true then
+    actions.getHMIConnection():ExpectRequest("VehicleInfo.SubscribeVehicleData", { tirePressure = true })
+    :Do(function(_,data)
+      actions.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS",
+        { tirePressure = tirePressureResponseData })
+    end)
+  else
+    actions.getHMIConnection():ExpectRequest("VehicleInfo.SubscribeVehicleData", { tirePressure = true }):Times(0)
+  end
+  actions.getMobileSession(pAppId):ExpectResponse(cid,
+    { success = true, resultCode = "SUCCESS", tirePressure = tirePressureResponseData })
+end
+
+return m

--- a/test_sets/tireStatus_mismatch.txt
+++ b/test_sets/tireStatus_mismatch.txt
@@ -1,0 +1,3 @@
+./test_scripts/API/VehicleData/TireStatusMismatch/001_GetVD_TireStatus_default_values_for_old_app.lua
+./test_scripts/API/VehicleData/TireStatusMismatch/002_OnVD_TireStatus_default_values_for_old_app.lua
+./test_scripts/API/VehicleData/TireStatusMismatch/003_OnVD_TireStatus_default_values_for_different_apps_version.lua


### PR DESCRIPTION
ATF Test Scripts to check  [#2940](https://github.com/smartdevicelink/sdl_core/issues/2940)

This PR is **[ready]** for review.

### Summary
ATF scripts to cover SDL behavior with old applications for the 'Update mismatch in TireStatus structure' feature

### ATF version
[8.0.0_version_bump](https://github.com/smartdevicelink/sdl_atf/tree/feature/8.0.0_version_bump)

### Changelog
 - Add scripts to check default values for the old app

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
