### PR TITLE
Feature/sdl 0264 separating the change of audible status and the change of hmi status

### DIFF
--- a/test_scripts/API/SubtleAlertStyle/commonSubtleAlert.lua
+++ b/test_scripts/API/SubtleAlertStyle/commonSubtleAlert.lua
@@ -126,7 +126,7 @@ function commonSubtleAlert.subtleAlertRejectedPhoneCall(pParams, prepareFunc)
     end)
 
   common.getMobileSession():ExpectNotification("OnHMIStatus",
-    { systemContext = "MAIN", hmiLevel = "LIMITED", audioStreamingState = "NOT_AUDIBLE" },
+    { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "NOT_AUDIBLE" },
     { systemContext = "MAIN", hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
   :Times(2)
 

--- a/test_scripts/MobileProjection/Phase2/020_different_types_apps_interactions.lua
+++ b/test_scripts/MobileProjection/Phase2/020_different_types_apps_interactions.lua
@@ -162,10 +162,10 @@ local testCases = {
         action = { event = actions.phoneCallStart, appId = "none" },
         checks = {
           ohs = {
-            [1] = { hLvl = "BACKGROUND", aSS = "NOT_AUDIBLE", vSS = "NOT_STREAMABLE" },
+            [1] = { hLvl = "LIMITED", aSS = "NOT_AUDIBLE", vSS = "NOT_STREAMABLE" },
             [2] = { }, -- hLvl = "BACKGROUND", aSS = "NOT_AUDIBLE", vSS = "NOT_STREAMABLE"
             [3] = { }, -- hLvl = "BACKGROUND", aSS = "NOT_AUDIBLE", vSS = "NOT_STREAMABLE"
-            [4] = { hLvl = "LIMITED", aSS = "NOT_AUDIBLE", vSS = "STREAMABLE" }
+            [4] = { hLvl = "FULL", aSS = "NOT_AUDIBLE", vSS = "STREAMABLE" }
           }
         }
       },

--- a/test_scripts/MobileProjection/Phase2/smoke/020_different_types_apps_interactions.lua
+++ b/test_scripts/MobileProjection/Phase2/smoke/020_different_types_apps_interactions.lua
@@ -162,10 +162,10 @@ local testCases = {
         action = { event = actions.phoneCallStart, appId = "none" },
         checks = {
           ohs = {
-            [1] = { hLvl = "BACKGROUND", aSS = "NOT_AUDIBLE", vSS = "NOT_STREAMABLE" },
+            [1] = { hLvl = "LIMITED", aSS = "NOT_AUDIBLE", vSS = "NOT_STREAMABLE" },
             [2] = { }, -- hLvl = "BACKGROUND", aSS = "NOT_AUDIBLE", vSS = "NOT_STREAMABLE"
             [3] = { }, -- hLvl = "BACKGROUND", aSS = "NOT_AUDIBLE", vSS = "NOT_STREAMABLE"
-            [4] = { hLvl = "LIMITED", aSS = "NOT_AUDIBLE", vSS = "STREAMABLE" }
+            [4] = { hLvl = "FULL", aSS = "NOT_AUDIBLE", vSS = "STREAMABLE" }
           }
         }
       },

--- a/test_scripts/WebEngine/WebEngineProjection/014_HMI_status_transitions_different_applications_interactions.lua
+++ b/test_scripts/WebEngine/WebEngineProjection/014_HMI_status_transitions_different_applications_interactions.lua
@@ -97,10 +97,10 @@ local testCase = {
       action = { event = common.userActions.phoneCallStart, appId = "none" },
       checks = {
         onHmiStatus = {
-          [1] = { hmiLvl = "BACKGROUND", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE" },
+          [1] = { hmiLvl = "LIMITED", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE" },
           [2] = { }, -- hmiLvl = "BACKGROUND", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE"
           [3] = { }, -- hmiLvl = "BACKGROUND", audio = "NOT_AUDIBLE", video = "NOT_STREAMABLE"
-          [4] = { hmiLvl = "LIMITED", audio = "NOT_AUDIBLE", video = "STREAMABLE" }
+          [4] = { hmiLvl = "FULL", audio = "NOT_AUDIBLE", video = "STREAMABLE" }
         }
       }
     },


### PR DESCRIPTION
ATF Test Scripts to check #3227

This PR is **ready** for review.

### Summary
modified for sdl 0264 separating the change of audible status and the change of hmi status

### ATF version
develop

### Changelog
Updated test_script/MobileProjection/020_different_types_apps_interactions.lua
Updated test_script/MobileProjection/smoke/020_different_types_apps_interactions.lua
Updated test_script/API/SubtleAlertStyle/commonSubtleAlert.lua
Updated test_script/WebEngine/WebEngineProjection/014_HMI_status_transitions_different_applications_interactions.lua

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
