### PR TITLE
Remove query type from SendHandshakeData event matcher

### DIFF
--- a/user_modules/sequences/security.lua
+++ b/user_modules/sequences/security.lua
@@ -103,7 +103,6 @@ local function registerExpectServiceEventFunc(pMobSession)
         return data.frameType ~= constants.FRAME_TYPE.CONTROL_FRAME
           and data.serviceType == constants.SERVICE_TYPE.CONTROL
           and data.sessionId == session.sessionId.get()
-          and data.rpcType == constants.BINARY_RPC_TYPE.NOTIFICATION
           and data.rpcFunctionId == constants.BINARY_RPC_FUNCTION_ID.HANDSHAKE
       end
     session:ExpectEvent(handshakeEvent, "Handshake internal")
@@ -115,7 +114,7 @@ local function registerExpectServiceEventFunc(pMobSession)
             frameInfo = 0,
             serviceType = constants.SERVICE_TYPE.CONTROL,
             encryption = false,
-            rpcType = constants.BINARY_RPC_TYPE.NOTIFICATION,
+            rpcType = constants.BINARY_RPC_TYPE.RESPONSE,
             rpcFunctionId = constants.BINARY_RPC_FUNCTION_ID.HANDSHAKE,
             rpcCorrelationId = data.rpcCorrelationId,
             binaryData = dataToSend


### PR DESCRIPTION

ATF Test Scripts to check https://github.com/smartdevicelink/sdl_core/issues/3755

This PR is **ready** for review.

### Summary
Remove query type from event matcher for SendHandshakeData, use RESPONSE type in SendHandshakeData response.

### ATF version
https://github.com/smartdevicelink/sdl_atf/pull/237

### Changelog

##### Bug Fixes
* Remove query type from event matcher for SendHandshakeData
* Use RESPONSE type in SendHandshakeData response instead of NOTIFICATION

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
