### PR TITLE
Add tests for Security Query error handling

### DIFF
--- a/test_scripts/Security/SecurityQueryErrorHandling/001_Invalid_query_size.lua
+++ b/test_scripts/Security/SecurityQueryErrorHandling/001_Invalid_query_size.lua
@@ -1,0 +1,57 @@
+---------------------------------------------------------------------------------------------------
+-- Case: Trigger SendInternalError with INVALID_QUERY_SIZE by responding to SendHandshakeData with
+--       an empty payload
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require("test_scripts/Security/SecurityQueryErrorHandling/common")
+local constants = require("protocol_handler/ford_protocol_constants")
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+config.application1.registerAppInterfaceParams.appHMIType = { "NAVIGATION" }
+
+--[[ Local Functions ]]
+local function startHandshake()
+  local serviceId = 7
+  common.getMobileSession():StartSecureService(serviceId)
+  common.getMobileSession():ExpectControlMessage(serviceId, {
+    frameInfo = constants.FRAME_INFO.START_SERVICE_ACK,
+    encryption = true
+  }):Times(0)
+
+  local response = {
+    frameInfo = 0,
+    serviceType = constants.SERVICE_TYPE.CONTROL,
+    encryption = false,
+    rpcType = constants.BINARY_RPC_TYPE.RESPONSE,
+    rpcFunctionId = constants.BINARY_RPC_FUNCTION_ID.HANDSHAKE,
+    binaryData = ""
+  }
+
+  local expParams = {
+    frameInfo = 0,
+    encryption = false,
+    rpcType = constants.BINARY_RPC_TYPE.NOTIFICATION,
+    rpcFunctionId = constants.BINARY_RPC_FUNCTION_ID.INTERNAL_ERROR,
+    payload = {
+      id = constants.QUERY_ERROR_CODE.INVALID_QUERY_SIZE
+    },
+    binaryData = string.char(constants.QUERY_ERROR_CODE.INVALID_QUERY_SIZE)
+  }
+
+  common.HandshakeMessageError(response, expParams)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Init SDL certificates", common.initSDLCertificates, { "./files/Security/client_credential.pem" })
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+
+runner.Title("Test")
+runner.Step("Register App", common.registerApp)
+runner.Step("Send invalid handshake data response", startHandshake)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL, clean-up certificates", common.postconditions)

--- a/test_scripts/Security/SecurityQueryErrorHandling/002_Invalid_query_id.lua
+++ b/test_scripts/Security/SecurityQueryErrorHandling/002_Invalid_query_id.lua
@@ -1,0 +1,56 @@
+---------------------------------------------------------------------------------------------------
+-- Case: Trigger SendInternalError with INVALID_QUERY_ID by responding to SendHandshakeData with
+--       a correct payload, but an invalid query ID (0x10)
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require("test_scripts/Security/SecurityQueryErrorHandling/common")
+local constants = require("protocol_handler/ford_protocol_constants")
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+config.application1.registerAppInterfaceParams.appHMIType = { "NAVIGATION" }
+
+--[[ Local Functions ]]
+local function startHandshake()
+  local serviceId = 7
+  common.getMobileSession():StartSecureService(serviceId)
+  common.getMobileSession():ExpectControlMessage(serviceId, {
+    frameInfo = constants.FRAME_INFO.START_SERVICE_ACK,
+    encryption = true
+  }):Times(0)
+
+  local response = {
+    frameInfo = 0,
+    serviceType = constants.SERVICE_TYPE.CONTROL,
+    encryption = false,
+    rpcType = constants.BINARY_RPC_TYPE.RESPONSE,
+    rpcFunctionId = 0x10
+  }
+
+  local expParams = {
+    frameInfo = 0,
+    encryption = false,
+    rpcType = constants.BINARY_RPC_TYPE.NOTIFICATION,
+    rpcFunctionId = constants.BINARY_RPC_FUNCTION_ID.INTERNAL_ERROR,
+    payload = {
+      id = constants.QUERY_ERROR_CODE.INVALID_QUERY_ID
+    },
+    binaryData = string.char(constants.QUERY_ERROR_CODE.INVALID_QUERY_ID)
+  }
+
+  common.HandshakeMessageError(response, expParams)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Init SDL certificates", common.initSDLCertificates, { "./files/Security/client_credential.pem" })
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+
+runner.Title("Test")
+runner.Step("Register App", common.registerApp)
+runner.Step("Send invalid handshake data response", startHandshake)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL, clean-up certificates", common.postconditions)

--- a/test_scripts/Security/SecurityQueryErrorHandling/003_Service_not_protected.lua
+++ b/test_scripts/Security/SecurityQueryErrorHandling/003_Service_not_protected.lua
@@ -1,0 +1,67 @@
+---------------------------------------------------------------------------------------------------
+-- Case: Trigger SendInternalError with INVALID_QUERY_ID by establising a secure audio service, 
+--       then attempting to send an encrypted RPC
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require("test_scripts/Security/SecurityQueryErrorHandling/common")
+local constants = require("protocol_handler/ford_protocol_constants")
+local securityConstants = require('security/security_constants')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+config.application1.registerAppInterfaceParams.appHMIType = { "NAVIGATION" }
+
+--[[ Local Functions ]]
+local function startHandshake()
+  local serviceId = 10
+  common.getMobileSession():StartSecureService(serviceId)
+  common.getMobileSession():ExpectControlMessage(serviceId, {
+    frameInfo = constants.FRAME_INFO.START_SERVICE_ACK,
+    encryption = true
+  })
+
+  common.getMobileSession():ExpectHandshakeMessage()
+  :Times(1)
+end
+
+local function sendEncryptedRequest()
+  local params = {
+    cmdID = 1,
+    menuParams = {
+      position = 1,
+      menuName = "Command_1"
+    }
+  }
+  local cid = common.getMobileSession().mobile_session_impl.rpc_services:SendRPC("AddCommand", params, nil, securityConstants.ENCRYPTION.ON)
+  common.getHMIConnection():ExpectRequest("UI.AddCommand", params):Times(0)
+  common.getMobileSession():ExpectNotification("OnHashChange"):Times(0)
+
+  local expParams = {
+    frameInfo = 0,
+    encryption = false,
+    rpcType = constants.BINARY_RPC_TYPE.NOTIFICATION,
+    rpcFunctionId = constants.BINARY_RPC_FUNCTION_ID.INTERNAL_ERROR,
+    payload = {
+      id = constants.QUERY_ERROR_CODE.SERVICE_NOT_PROTECTED
+    },
+    binaryData = string.char(constants.QUERY_ERROR_CODE.SERVICE_NOT_PROTECTED)
+  }
+
+  common.expectSecurityQuery(expParams)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Init SDL certificates", common.initSDLCertificates, { "./files/Security/client_credential.pem" })
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+
+runner.Title("Test")
+runner.Step("Register App", common.registerApp)
+runner.Step("Activate App", common.activateApp)
+runner.Step("Send handshake for audio service", startHandshake)
+runner.Step("Send encrypted request for unprotected service", sendEncryptedRequest)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL, clean-up certificates", common.postconditions)

--- a/test_scripts/Security/SecurityQueryErrorHandling/common.lua
+++ b/test_scripts/Security/SecurityQueryErrorHandling/common.lua
@@ -1,0 +1,228 @@
+---------------------------------------------------------------------------------------------------
+-- Common module
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local actions = require("user_modules/sequences/actions")
+local security = require("user_modules/sequences/security")
+local utils = require("user_modules/utils")
+local test = require("user_modules/dummy_connecttest")
+local SDL = require("SDL")
+local constants = require("protocol_handler/ford_protocol_constants")
+local events = require("events")
+local json = require("modules/json")
+
+--[[ General configuration parameters ]]
+config.SecurityProtocol = "DTLS"
+config.application1.registerAppInterfaceParams.appName = "server"
+config.application1.registerAppInterfaceParams.fullAppID = "SPT"
+
+--[[ Module ]]
+local common = actions
+
+common.readFile = utils.readFile
+
+--[[ Functions ]]
+local function getSystemTimeValue()
+  local dd = os.date("*t")
+  return {
+    millisecond = 0,
+    second = dd.sec,
+    minute = dd.min,
+    hour = dd.hour,
+    day = dd.day,
+    month = dd.month,
+    year = dd.year,
+    tz_hour = 2,
+    tz_minute = 0
+  }
+end
+
+function common.HandshakeMessageError(handshakeResponse, expErrorNotification)
+  local session = common.getMobileSession().mobile_session_impl.control_services.session
+  local handshakeEvent = events.Event()
+  handshakeEvent.matches = function(_, data)
+      return data.frameType ~= constants.FRAME_TYPE.CONTROL_FRAME
+        and data.serviceType == constants.SERVICE_TYPE.CONTROL
+        and data.sessionId == session.sessionId.get()
+        and data.rpcFunctionId == constants.BINARY_RPC_FUNCTION_ID.HANDSHAKE
+    end
+  session:ExpectEvent(handshakeEvent, "Handshake internal")
+  :Do(function(_, data)
+      if not handshakeResponse.rpcCorrelationId then
+        handshakeResponse.rpcCorrelationId = data.rpcCorrelationId
+      end
+      if not handshakeResponse.binaryData then
+        local binData = data.binaryData
+        local dataToSend = session.security:performHandshake(binData)
+        handshakeResponse.binaryData = dataToSend
+      end
+
+      session:Send(handshakeResponse)
+    end)
+  :Times(AnyNumber())
+
+  if expErrorNotification then
+    expectSecurityQuery(expErrorNotification)
+  end
+end
+
+function common.expectSecurityQuery(params)
+  local session = common.getMobileSession().mobile_session_impl.control_services.session
+  local queryEvent = events.Event()
+  queryEvent.matches = function(_, data)
+      return data.frameType ~= constants.FRAME_TYPE.CONTROL_FRAME
+        and (not data.rpcType or data.rpcType == params.rpcType)
+        and data.serviceType == constants.SERVICE_TYPE.CONTROL
+        and data.sessionId == session.sessionId.get()
+        and data.rpcFunctionId == params.rpcFunctionId
+    end
+  session:ExpectEvent(queryEvent, "Error internal")
+  :ValidIf(function(exp, data)
+      return compareValues(params, data, "data")
+    end)
+end
+
+local function registerGetSystemTimeResponse()
+  actions.getHMIConnection():ExpectRequest("BasicCommunication.GetSystemTime")
+  :Do(function(_, data)
+      actions.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { systemTime = getSystemTimeValue() })
+    end)
+  :Pin()
+  :Times(AnyNumber())
+end
+
+function common.allowSDL()
+  local event = events.Event()
+  event.matches = function(e1, e2) return e1 == e2 end
+  common.getHMIConnection():SendNotification("SDL.OnAllowSDLFunctionality", {
+    allowed = true,
+    source = "GUI",
+    device = {
+      id = utils.getDeviceMAC(),
+      name = utils.getDeviceName()
+    }
+  })
+  RUN_AFTER(function() common.getHMIConnection():RaiseEvent(event, "Allow SDL event") end, 500)
+  return common.getHMIConnection():ExpectEvent(event, "Allow SDL event")
+end
+
+function common.start(pHMIParams, isCacheUsed)
+  test:runSDL()
+  SDL.WaitForSDLStart(test)
+  :Do(function()
+      test:initHMI()
+      :Do(function()
+          local rid = actions.getHMIConnection():SendRequest("MB.subscribeTo", {
+            propertyName = "BasicCommunication.OnSystemTimeReady" })
+          actions.getHMIConnection():ExpectResponse(rid)
+          :Do(function()
+              utils.cprint(35, "HMI initialized")
+              test:initHMI_onReady(pHMIParams, isCacheUsed)
+              :Do(function()
+                  utils.cprint(35, "HMI is ready")
+                  actions.getHMIConnection():SendNotification("BasicCommunication.OnSystemTimeReady")
+                  registerGetSystemTimeResponse()
+                  test:connectMobile()
+                  :Do(function()
+                      utils.cprint(35, "Mobile connected")
+                      common.allowSDL()
+                    end)
+                end)
+            end)
+        end)
+    end)
+end
+
+function common.initSDLCertificates(pCrtsFileName, pIsModuleCrtDefined)
+  SDL.CRT.set(pCrtsFileName, pIsModuleCrtDefined)
+end
+
+function common.cleanUpCertificates()
+  SDL.CRT.clean()
+end
+
+local preconditionsOrig = common.preconditions
+local postconditionsOrig = common.postconditions
+
+function common.preloadedPTUpdate(pPTUpdateFunc)
+  local pt = actions.sdl.getPreloadedPT()
+  pt.policy_table.functional_groupings["DataConsent-2"].rpcs = json.null
+  if pPTUpdateFunc then pPTUpdateFunc(pt) end
+  actions.sdl.setPreloadedPT(pt)
+end
+
+function common.preconditions(pPTUpdateFunc)
+  preconditionsOrig()
+  common.setSDLIniParameter("Protocol", "DTLSv1.0")
+  common.cleanUpCertificates()
+  if pPTUpdateFunc == nil then
+    pPTUpdateFunc = function(pPT)
+      pPT.policy_table.app_policies["default"].encryption_required = true
+    end
+  end
+  common.preloadedPTUpdate(pPTUpdateFunc)
+end
+
+function common.postconditions()
+  postconditionsOrig()
+  common.cleanUpCertificates()
+end
+
+function common.defaultExpNotificationFunc()
+  common.getHMIConnection():ExpectRequest("BasicCommunication.DecryptCertificate")
+  :Do(function(_, d)
+      common.getHMIConnection():SendResponse(d.id, d.method, "SUCCESS", { })
+    utils.wait(1000) -- time for SDL to save certificates
+    end)
+  :Times(AnyNumber())
+  common.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { odometer = true })
+end
+
+local policyTableUpdateOrig = common.policyTableUpdate
+function common.policyTableUpdate(pPTUpdateFunc, pExpNotificationFunc)
+  local func = common.defaultExpNotificationFunc
+  if pExpNotificationFunc then func = pExpNotificationFunc end
+  policyTableUpdateOrig(pPTUpdateFunc, func)
+end
+
+function common.policyTableUpdateSuccess(pPTUpdateFunc)  
+  common.isPTUStarted()  
+  :Do(function()  
+      common.policyTableUpdate(pPTUpdateFunc)  
+    end)  
+end
+
+local function registerStartSecureServiceFunc(pMobSession)
+  function pMobSession.mobile_session_impl.control_services:StartSecureService(pServiceId, pPayload)
+    local msg = {
+      serviceType = pServiceId,
+      frameInfo = constants.FRAME_INFO.START_SERVICE,
+      sessionId = self.session.sessionId.get(),
+      encryption = true,
+      binaryData = pPayload
+    }
+    self:Send(msg)
+  end
+  function pMobSession.mobile_session_impl:StartSecureService(pServiceId, pPayload)
+    if not self.isSecuredSession then
+      self.security:registerSessionSecurity()
+      self.security:prepareToHandshake()
+    end
+    return self.control_services:StartSecureService(pServiceId, pPayload)
+  end
+  function pMobSession:StartSecureService(pServiceId, pPayload)
+    return self.mobile_session_impl:StartSecureService(pServiceId, pPayload)
+  end
+end
+
+local origGetMobileSession = actions.getMobileSession
+function actions.getMobileSession(pAppId)
+  if not pAppId then pAppId = 1 end
+  if not test.mobileSession[pAppId] then
+    local session = origGetMobileSession(pAppId)
+    registerStartSecureServiceFunc(session)
+  end
+  return origGetMobileSession(pAppId)
+end
+
+return common

--- a/test_sets/security.txt
+++ b/test_sets/security.txt
@@ -30,6 +30,9 @@
 ./test_scripts/Security/GetSystemTime/023_GetSystemTime_without_response_from_HMI.lua
 ./test_scripts/Security/GetSystemTime/024_GetSystemTime_with_response_from_HMI_in_9_sec.lua
 ./test_scripts/Security/GetSystemTime/025_GetSystemTime_is_sent_later.lua
+./test_scripts/Security/SecurityQueryErrorHandling/001_Invalid_query_size.lua
+./test_scripts/Security/SecurityQueryErrorHandling/002_Invalid_query_id.lua
+./test_scripts/Security/SecurityQueryErrorHandling/003_Service_not_protected.lua
 ./test_scripts/Security/SSLHandshakeFlow/001_Navi_Predefined_cert_valid_SUCCESS.lua
 ./test_scripts/Security/SSLHandshakeFlow/002_Navi_Predefined_cert_expired_PTU_cert_valid_SUCCESS.lua
 ./test_scripts/Security/SSLHandshakeFlow/003_Navi_Predefined_cert_expired_PTU_cert_missing_NACK.lua

--- a/user_modules/sequences/security.lua
+++ b/user_modules/sequences/security.lua
@@ -107,7 +107,7 @@ local function registerExpectServiceEventFunc(pMobSession)
       end
     session:ExpectEvent(handshakeEvent, "Handshake internal")
     :Do(function(_, data)
-      local binData = data.binaryData
+        local binData = data.binaryData
         local dataToSend = session.security:performHandshake(binData)
         if dataToSend then
           local handshakeMessage = {


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/protocol_spec/issues/40

This PR is **ready** for review.

### Summary
Adds tests for error handling in the security manager, depends on https://github.com/smartdevicelink/sdl_atf/pull/238

### ATF version
https://github.com/smartdevicelink/sdl_atf/pull/238

### Changelog

##### Enhancements
* Adds tests for "Send Internal Error" security query

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
