### PR TITLE
add test for 3783 crash issue

### DIFF
--- a/test_scripts/Defects/8_0/3783_Change_VR_During_Activation.lua
+++ b/test_scripts/Defects/8_0/3783_Change_VR_During_Activation.lua
@@ -1,0 +1,39 @@
+---------------------------------------------------------------------------------------------------
+--  Issue: https://github.com/smartdevicelink/sdl_core/issues/3783
+--
+--  Steps:
+--  1) Register and activate 5 apps
+--  2) Change VR Language
+--
+--  Expected:
+--  1) Core does not crash
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/AppServices/commonAppServices')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+
+--[[ Local functions ]]
+function changeLanguage(pLanguage)
+  common.getHMIConnection():SendNotification("VR.OnLanguageChange", { language = pLanguage })
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+for i = 1, 5 do
+  runner.Step("RAI App", common.registerAppWOPTU, { i })
+end
+
+for j = 1, 5 do
+  runner.Step("Activate App", common.activateApp, { j })
+end
+
+runner.Title("Test")
+runner.Step("Change VR Language", changeLanguage, { "FR-CA" })
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_sets/Defects/Defects_release_8_0.txt
+++ b/test_sets/Defects/Defects_release_8_0.txt
@@ -33,3 +33,4 @@
 ./test_scripts/Defects/8_0/3788_1_allow_RC_permission_in_case_App_is_registered_with_MEDIA_appHMIType.lua
 ./test_scripts/Defects/8_0/3788_2_allow_RC_permission_for_App_after_PTU_with_REMOTE_CONTROL_appHMIType.lua
 ./test_scripts/Defects/8_0/3788_3_revoke_RC_permission_for_App_after_PTU_with_MEDIA_appHMIType.lua
+./test_scripts/Defects/8_0/3783_Change_VR_During_Activation.lua


### PR DESCRIPTION
ATF Test Scripts to check https://github.com/smartdevicelink/sdl_core/issues/3783

This PR is **ready** for review.

### Summary
Add a simple script to test for crash by changing language during app activation

### ATF version
latest

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
