### PR TITLE
Extended coverage for disallowed parameters for vehicle data RPCs

### DIFF
--- a/test_scripts/API/VehicleData/GetVehicleData/011_GetVD_allowed_and_disallowed_after_PTU.lua
+++ b/test_scripts/API/VehicleData/GetVehicleData/011_GetVD_allowed_and_disallowed_after_PTU.lua
@@ -1,0 +1,77 @@
+---------------------------------------------------------------------------------------------------
+-- Description: Check that SDL cuts off param from GetVehicleData request/response
+-- in case <vd_param> parameter is not allowed by policy after PTU
+--
+-- Preconditions:
+-- 1) SDL and HMI are started
+-- 2) GetVehicleData RPC and <vd_param> parameter is disallowed by policies
+-- 3) App is registered
+--
+-- In case:
+-- 1) App sends valid GetVehicleData request to SDL (with all VD params incl. <vd_param>)
+-- SDL does:
+-- - a) cut off <vd_param>
+-- - b) transfer request to HMI
+-- 2) HMI sends VI.GetVehicleData response data to SDL (with all VD params incl. <vd_param>)
+-- SDL does:
+-- - a) cut off <vd_param>
+-- - b) transfer response to App:
+--  (success = true, resultCode = "SUCCESS", <vd_param> = <data received from HMI>)
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/API/VehicleData/common')
+
+--[[ Conditions to skip test ]]
+if #common.restrictedVDParams == 1 then
+  common.runner.skipTest("Test is not applicable for one restricted VD parameter")
+end
+
+--[[ Local Variables ]]
+local all_params = {}
+for param in pairs(common.getVDParams(true)) do
+  table.insert(all_params, param)
+end
+if #all_params == 0 then all_params = common.json.EMPTY_ARRAY end
+
+--[[ Local Functions ]]
+local function getVDGroup(pDisallowedParam)
+  local params = {}
+  for param in pairs(common.getVDParams()) do
+    if param ~= pDisallowedParam then table.insert(params, param) end
+  end
+  if #params == 0 then params = common.json.EMPTY_ARRAY end
+  return {
+    rpcs = {
+      [common.rpc.get] = {
+        hmi_levels = { "NONE", "BACKGROUND", "LIMITED", "FULL" },
+        parameters = params
+      }
+    }
+  }
+end
+
+local function policyTableUpdate(pDisallowedParam)
+  local function ptUpdate(pt)
+    pt.policy_table.functional_groupings["NewTestCaseGroup"] = getVDGroup(pDisallowedParam)
+    pt.policy_table.app_policies[common.getAppParams().fullAppID].groups = { "Base-4", "NewTestCaseGroup" }
+  end
+  common.policyTableUpdate(ptUpdate)
+end
+
+--[[ Scenario ]]
+for param in common.spairs(common.getVDParams()) do
+  common.runner.Title("VD parameter: " .. param)
+  common.runner.Title("Preconditions")
+  common.runner.Step("Clean environment and update preloaded_pt file", common.preconditions)
+  common.runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+  common.runner.Step("Register App", common.registerApp)
+  common.runner.Step("RPC GetVehicleData, SUCCESS", common.getVehicleDataMultipleParams, { all_params })
+
+  common.runner.Title("Test")
+  common.runner.Step("PTU with disabling permissions for VD parameter", policyTableUpdate, { param })
+  common.runner.Step("RPC " .. common.rpc.get .. " filtered after PTU", common.getVehicleDataMultipleParams,
+    { all_params, nil, param })
+
+  common.runner.Title("Postconditions")
+  common.runner.Step("Stop SDL", common.postconditions)
+end

--- a/test_scripts/API/VehicleData/OnVehicleData/010_OnVD_allowed_and_disallowed_after_PTU.lua
+++ b/test_scripts/API/VehicleData/OnVehicleData/010_OnVD_allowed_and_disallowed_after_PTU.lua
@@ -1,0 +1,80 @@
+---------------------------------------------------------------------------------------------------
+-- Description: Check that SDL cuts off param from OnVehicleData notification transferred to App
+-- in case <vd_param> parameter is not allowed by policy after PTU
+--
+-- Preconditions:
+-- 1) SDL and HMI are started
+-- 2) OnVehicleData RPCs and <vd_param> parameter is disallowed by policies
+-- 3) App is registered and subscribed to all VD params incl. <vd_param>
+--
+-- In case:
+-- 1) HMI sends OnVehicleData notification to SDL (with all VD params incl. <vd_param>)
+-- SDL does:
+-- - a) cut off <vd_param>
+-- - b) transfer this notification to App
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/API/VehicleData/common')
+
+--[[ Conditions to skip test ]]
+if #common.restrictedVDParams == 1 then
+  common.runner.skipTest("Test is not applicable for one restricted VD parameter")
+end
+
+--[[ Local Variables ]]
+local odometer = 1
+local all_params = {}
+for param in pairs(common.getVDParams(true)) do
+  table.insert(all_params, param)
+end
+if #all_params == 0 then all_params = common.json.EMPTY_ARRAY end
+
+--[[ Local Functions ]]
+local function getVDGroup(pDisallowedParam)
+  local params = {}
+  for param in pairs(common.getVDParams(true)) do
+    if param ~= pDisallowedParam then table.insert(params, param) end
+  end
+  if #params == 0 then params = common.json.EMPTY_ARRAY end
+  return {
+    rpcs = {
+      [common.rpc.sub] = {
+        hmi_levels = { "NONE", "BACKGROUND", "LIMITED", "FULL" },
+        parameters = all_params
+      },
+      [common.rpc.on] = {
+        hmi_levels = { "NONE", "BACKGROUND", "LIMITED", "FULL" },
+        parameters = params
+      }
+    }
+  }
+end
+
+local function policyTableUpdate(pDisallowedParam)
+  local function ptUpdate(pt)
+    pt.policy_table.functional_groupings["NewTestCaseGroup"] = getVDGroup(pDisallowedParam)
+    pt.policy_table.app_policies[common.getAppParams().fullAppID].groups = { "Base-4", "NewTestCaseGroup" }
+  end
+  common.policyTableUpdate(ptUpdate)
+end
+
+--[[ Scenario ]]
+for param in common.spairs(common.getVDParams(true)) do
+  common.runner.Title("VD parameter: " .. param)
+  common.runner.Title("Preconditions")
+  common.runner.Step("Clean environment and update preloaded_pt file", common.preconditions)
+  common.runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+  common.runner.Step("Register App", common.registerApp)
+  common.runner.Step("RPC " .. common.rpc.sub .. " SUCCESS", common.processSubscriptionRPCMultipleParams,
+    { common.rpc.sub, all_params })
+  common.runner.Step("RPC " .. common.rpc.on .. " transferred", common.sendOnVehicleDataMultipleParams,
+    { all_params, common.isExpected, {["odometer"] = odometer} })
+
+  common.runner.Title("Test")
+  common.runner.Step("PTU with disabling permissions for VD parameter", policyTableUpdate, { param })
+  common.runner.Step("RPC " .. common.rpc.on .. " filtered", common.sendOnVehicleDataMultipleParams,
+    { all_params, common.isExpected, {["odometer"] = odometer}, param })
+
+  common.runner.Title("Postconditions")
+  common.runner.Step("Stop SDL", common.postconditions)
+end

--- a/test_scripts/API/VehicleData/SubscribeVehicleData/015_SubscribeVD_allowed_and_disallowed_after_PTU.lua
+++ b/test_scripts/API/VehicleData/SubscribeVehicleData/015_SubscribeVD_allowed_and_disallowed_after_PTU.lua
@@ -1,0 +1,80 @@
+---------------------------------------------------------------------------------------------------
+-- Description: Check that SDL cuts off out param from SubscribeVehicleData request/response
+-- in case <vd_param> parameter is not allowed by policy after PTU
+--
+-- Preconditions:
+-- 1) SDL and HMI are started
+-- 2) SubscribeVehicleData RPC and <vd_param> parameter is disallowed by policies
+-- 3) App is registered
+--
+-- In case:
+-- 1) App sends valid SubscribeVehicleData request to SDL (with all VD params incl. <vd_param>)
+-- SDL does:
+-- - a) cut off <vd_param>
+-- - b) transfer this request to HMI
+-- 2) HMI sends SubscribeVehicleData response to SDL (with all VD params incl. <vd_param>)
+-- SDL does:
+-- - a) cut off <vd_param>
+-- - b) transfer SubscribeVehicleData response to App:
+--  (success = true, resultCode = SUCCESS", <vd_param> = <data received from HMI>)
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/API/VehicleData/common')
+
+--[[ Conditions to skip test ]]
+if #common.restrictedVDParams == 1 then
+  common.runner.skipTest("Test is not applicable for one restricted VD parameter")
+end
+
+--[[ Local Variables ]]
+local all_params = {}
+for param in pairs(common.getVDParams(true)) do
+  table.insert(all_params, param)
+end
+if #all_params == 0 then all_params = common.json.EMPTY_ARRAY end
+
+--[[ Local Functions ]]
+local function getVDGroup(pDisallowedParam)
+  local params = {}
+  for param in pairs(common.getVDParams(true)) do
+    if param ~= pDisallowedParam then table.insert(params, param) end
+  end
+  if #params == 0 then params = common.json.EMPTY_ARRAY end
+  return {
+    rpcs = {
+      [common.rpc.sub] = {
+        hmi_levels = { "NONE", "BACKGROUND", "LIMITED", "FULL" },
+        parameters = params
+      }
+    }
+  }
+end
+
+local function policyTableUpdate(pDisallowedParam)
+  local function ptUpdate(pt)
+    pt.policy_table.functional_groupings["NewTestCaseGroup"] = getVDGroup(pDisallowedParam)
+    pt.policy_table.app_policies[common.getAppParams().fullAppID].groups = { "Base-4", "NewTestCaseGroup" }
+  end
+  common.policyTableUpdate(ptUpdate)
+end
+
+--[[ Scenario ]]
+for param in common.spairs(common.getVDParams(true)) do
+  common.runner.Title("VD parameter: " .. param)
+  common.runner.Title("Preconditions")
+  common.runner.Step("Clean environment and update preloaded_pt file", common.preconditions)
+  common.runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+  common.runner.Step("Register App", common.registerApp)
+  common.runner.Step("RPC " .. common.rpc.sub, common.processSubscriptionRPCMultipleParams,
+    { common.rpc.sub, all_params })
+  common.runner.Step("RPC " .. common.rpc.unsub, common.processSubscriptionRPCMultipleParams,
+    { common.rpc.unsub, all_params })
+
+  common.runner.Title("Test")
+  common.runner.Step("PTU with disabling permissions for VD parameter", policyTableUpdate, { param })
+  common.runner.Step("RPC " .. common.rpc.sub .. " filtered after PTU", common.processSubscriptionRPCMultipleParams,
+    { common.rpc.sub, all_params, nil, nil, param })
+
+  common.runner.Title("Postconditions")
+  common.runner.Step("Stop SDL", common.postconditions)
+end

--- a/test_scripts/API/VehicleData/UnsubscribeVehicleData/012_UnsubscribeVD_allowed_and_disallowed_after_PTU.lua
+++ b/test_scripts/API/VehicleData/UnsubscribeVehicleData/012_UnsubscribeVD_allowed_and_disallowed_after_PTU.lua
@@ -1,0 +1,86 @@
+---------------------------------------------------------------------------------------------------
+-- Description: Check that SDL filters out param from UnsubscribeVehicleData request/response
+-- in case <vd_param> parameter is not allowed by policy after PTU
+--
+-- Preconditions:
+-- 1) SDL and HMI are started
+-- 2) UnsubscribeVehicleData RPCs and <vd_param> parameter is disallowed by policies
+-- 3) App is registered and subscribed to <vd_param> data
+--
+-- In case:
+-- 1) App sends valid UnsubscribeVehicleData request to SDL (with all VD params incl. <vd_param>)
+-- SDL does:
+-- - a) cut off <vd_param>
+-- - b) transfer this request to HMI
+-- 2) HMI sends VI.UnsubscribeVehicleData response to SDL (with all VD params incl. <vd_param>)
+-- SDL does:
+-- - a) cut off <vd_param>
+-- - b) transfer UnsubscribeVehicleData response to App:
+--  (success = true, resultCode = "SUCCESS", <vd_param> = <data received from HMI>)
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/API/VehicleData/common')
+
+--[[ Conditions to skip test ]]
+if #common.restrictedVDParams == 1 then
+  common.runner.skipTest("Test is not applicable for one restricted VD parameter")
+end
+
+--[[ Local Variables ]]
+local all_params = {}
+for param in pairs(common.getVDParams(true)) do
+  table.insert(all_params, param)
+end
+if #all_params == 0 then all_params = common.json.EMPTY_ARRAY end
+
+--[[ Local Functions ]]
+local function getVDGroup(pDisallowedParam)
+  local params = {}
+  for param in pairs(common.getVDParams(true)) do
+    if param ~= pDisallowedParam then table.insert(params, param) end
+  end
+  if #params == 0 then params = common.json.EMPTY_ARRAY end
+  return {
+    rpcs = {
+      [common.rpc.sub] = {
+        hmi_levels = { "NONE", "BACKGROUND", "LIMITED", "FULL" },
+        parameters = all_params
+      },
+      [common.rpc.unsub] = {
+        hmi_levels = { "NONE", "BACKGROUND", "LIMITED", "FULL" },
+        parameters = params
+      },
+    }
+  }
+end
+
+local function policyTableUpdate(pDisallowedParam)
+  local function ptUpdate(pt)
+    pt.policy_table.functional_groupings["NewTestCaseGroup"] = getVDGroup(pDisallowedParam)
+    pt.policy_table.app_policies[common.getAppParams().fullAppID].groups = { "Base-4", "NewTestCaseGroup" }
+  end
+  common.policyTableUpdate(ptUpdate)
+end
+
+--[[ Scenario ]]
+for param in common.spairs(common.getVDParams(true)) do
+  common.runner.Title("VD parameter: " .. param)
+  common.runner.Title("Preconditions")
+  common.runner.Step("Clean environment and update preloaded_pt file", common.preconditions)
+  common.runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+  common.runner.Step("Register App", common.registerApp)
+  common.runner.Step("RPC " .. common.rpc.sub .. " SUCCESS", common.processSubscriptionRPCMultipleParams,
+    { common.rpc.sub, all_params })
+  common.runner.Step("RPC " .. common.rpc.unsub .. " SUCCESS", common.processSubscriptionRPCMultipleParams,
+    { common.rpc.unsub, all_params })
+
+  common.runner.Title("Test")
+  common.runner.Step("PTU with disabling permissions for VD parameter", policyTableUpdate, { param })
+  common.runner.Step("RPC " .. common.rpc.sub .. " SUCCESS", common.processSubscriptionRPCMultipleParams,
+    { common.rpc.sub, all_params })
+  common.runner.Step("RPC " .. common.rpc.unsub .. " filtered after PTU", common.processSubscriptionRPCMultipleParams,
+    { common.rpc.unsub, all_params, nil, nil, param })
+
+  common.runner.Title("Postconditions")
+  common.runner.Step("Stop SDL", common.postconditions)
+end

--- a/test_scripts/API/VehicleData/common.lua
+++ b/test_scripts/API/VehicleData/common.lua
@@ -356,13 +356,52 @@ end
 --]]
 function m.getVehicleData(pParam, pValue)
   if pValue == nil then pValue = m.vdValues[pParam] end
-  local cid = m.getMobileSession():SendRPC("GetVehicleData", { [pParam] = true })
-  m.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", { [pParam] = true })
-  :Do(function(_, data)
-    m.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { [pParam] = pValue })
+  m.getVehicleDataMultipleParams({ pParam }, { pParam = pValue })
+end
+
+--[[ @getVehicleDataMultipleParams: Successful processing of GetVehicleData RPC for multiple params
+--! @parameters:
+--! pParamsArray: array of VD parameters
+--! pValueOverrides: table with data to override default test values
+--! pDisallowedParam: param which SDL is expected to exclude
+--! @return: none
+--]]
+function m.getVehicleDataMultipleParams(pParamsArray, pValueOverrides, pDisallowedParam)
+  if pValueOverrides == nil then pValueOverrides = {} end
+  local mobileRequestData = {}
+  local SDLRequestData = {}
+  local HMIResponseData = {}
+  local SDLResponseData = { success = true, resultCode = "SUCCESS" }
+  for _, param in pairs(pParamsArray) do
+    mobileRequestData[param] = true
+    if pValueOverrides[param] == nil then
+      HMIResponseData[param] = m.vdValues[param]
+    else
+      HMIResponseData[param] = pValueOverrides[param]
+    end
+    if param ~= pDisallowedParam then
+      SDLRequestData[param] = true
+      SDLResponseData[param] = HMIResponseData[param]
+    end
+  end
+  local cid = m.getMobileSession():SendRPC("GetVehicleData", mobileRequestData)
+  m.getHMIConnection():ExpectRequest("VehicleInfo.GetVehicleData", SDLRequestData)
+  :ValidIf(function(_, data)
+    if data.params[pDisallowedParam] ~= nil then
+      return false, "Disallowed param '" .. pDisallowedParam .. "' is received by HMI"
+    end
+    return true
   end)
-  m.getMobileSession():ExpectResponse(cid,
-    { success = true, resultCode = "SUCCESS", [pParam] = pValue })
+  :Do(function(_, data)
+    m.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", HMIResponseData)
+  end)
+  m.getMobileSession():ExpectResponse(cid, SDLResponseData)
+  :ValidIf(function(_, data)
+    if data.payload[pDisallowedParam] ~= nil then
+      return false, "Disallowed param '" .. pDisallowedParam .. "' is received by App"
+    end
+    return true
+  end)
 end
 
 --[[ @processRPCFailure: Processing VehicleData RPC with ERROR resultCode
@@ -375,7 +414,28 @@ end
 --]]
 function m.processRPCFailure(pRPC, pParam, pResult, pRequestValue)
   if pRequestValue == nil then pRequestValue = true end
-  local cid = m.getMobileSession():SendRPC(pRPC, { [pParam] = pRequestValue })
+  m.processRPCFailureMultipleParams(pRPC, { pParam }, pResult, { [pParam] = pRequestValue })
+end
+
+--[[ @processRPCFailureMultipleParams: Processing VehicleData RPC with ERROR resultCode for multiple params
+--! @parameters:
+--! pRPC: RPC for mobile request
+--! pParamsArray: array of names of VD parameters
+--! pResult: expected result code
+--! pRequestValueOverrides: table with data for App request to override default test value
+--! @return: none
+--]]
+function m.processRPCFailureMultipleParams(pRPC, pParamsArray, pResult, pRequestValueOverrides)
+  if pRequestValueOverrides == nil then pRequestValueOverrides = {} end
+  local HMIRequestData = {}
+  for _, param in pairs(pParamsArray) do
+    if pRequestValueOverrides[param] == nil then
+      HMIRequestData[param] = true
+    else
+      HMIRequestData[param] = pRequestValueOverrides[param]
+    end
+  end
+  local cid = m.getMobileSession():SendRPC(pRPC, HMIRequestData)
   m.getHMIConnection():ExpectRequest("VehicleInfo." .. pRPC):Times(0)
   m.getMobileSession():ExpectResponse(cid, { success = false, resultCode = pResult })
 end
@@ -406,25 +466,65 @@ end
 --! @return: none
 --]]
 function m.processSubscriptionRPC(pRPC, pParam, pAppId, isRequestOnHMIExpected)
+  return m.processSubscriptionRPCMultipleParams(pRPC, { pParam }, pAppId, isRequestOnHMIExpected)
+end
+
+--[[ @processSubscriptionRPCMultipleParams: Processing SubscribeVehicleData for multiple VD params
+--! @parameters:
+--! pRPC: RPC for mobile request
+--! pParamsArray: array of names of VD parameters
+--! pAppId: application number (1, 2, etc.)
+--! isRequestOnHMIExpected: if true or omitted VI.Sub/UnsubscribeVehicleData request is expected on HMI,
+--!   otherwise - not expected
+--! pDisallowedParam: param which SDL is expected to exclude
+--! @return: none
+--]]
+function m.processSubscriptionRPCMultipleParams(pRPC, pParamsArray, pAppId, isRequestOnHMIExpected, pDisallowedParam)
   if pAppId == nil then pAppId = 1 end
   if isRequestOnHMIExpected == nil then isRequestOnHMIExpected = true end
-  local response = {
-    dataType = m.vd[pParam],
-    resultCode = "SUCCESS"
-  }
-  local responseParam = pParam
-  if pParam == "clusterModeStatus" then responseParam = "clusterModes" end
-  local cid = m.getMobileSession(pAppId):SendRPC(pRPC, { [pParam] = true })
+  local mobileRequestData = {}
+  local SDLRequestData = {}
+  local HMIResponseData = {}
+  local SDLResponseData = { success = true, resultCode = "SUCCESS" }
+  for _, param in pairs(pParamsArray) do
+    mobileRequestData[param] = true
+    local response_param
+    if param == "clusterModeStatus" then
+      response_param = "clusterModes"
+    else
+      response_param = param
+    end
+    HMIResponseData[response_param] = {
+      dataType = m.vd[param],
+      resultCode = "SUCCESS"
+    }
+    if param ~= pDisallowedParam then
+      SDLRequestData[param] = true
+      SDLResponseData[param] = HMIResponseData[response_param]
+    end
+  end
+  local cid = m.getMobileSession(pAppId):SendRPC(pRPC, mobileRequestData)
   if isRequestOnHMIExpected == true then
-    m.getHMIConnection():ExpectRequest("VehicleInfo." .. pRPC, { [pParam] = true })
+    m.getHMIConnection():ExpectRequest("VehicleInfo." .. pRPC, SDLRequestData)
+    :ValidIf(function(_, data)
+        if data.params[pDisallowedParam] ~= nil then
+          return false, "Disallowed param '" .. pDisallowedParam .. "' is received by HMI"
+        end
+        return true
+      end)
     :Do(function(_,data)
-      m.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", { [responseParam] = response })
+      m.getHMIConnection():SendResponse(data.id, data.method, "SUCCESS", HMIResponseData)
     end)
   else
     m.getHMIConnection():ExpectRequest("VehicleInfo." .. pRPC):Times(0)
   end
-  m.getMobileSession(pAppId):ExpectResponse(cid,
-    { success = true, resultCode = "SUCCESS", [responseParam] = response })
+  m.getMobileSession(pAppId):ExpectResponse(cid, SDLResponseData)
+  :ValidIf(function(_, data)
+      if pDisallowedParam ~= nil and data.payload[pDisallowedParam].resultCode ~= "DISALLOWED" then
+        return false, "Disallowed param '" .. pDisallowedParam .. "' is received by App"
+      end
+      return true
+    end)
   local ret = m.getMobileSession(pAppId):ExpectNotification("OnHashChange")
   :Do(function(_, data)
     m.setHashId(data.payload.hashID, pAppId)
@@ -440,11 +540,41 @@ end
 --! @return: none
 --]]
 function m.sendOnVehicleData(pParam, pExpTime, pValue)
-  if pExpTime == nil then pExpTime = 1 end
-  if pValue == nil then pValue = m.vdValues[pParam] end
-  m.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", { [pParam] = pValue })
-  m.getMobileSession():ExpectNotification("OnVehicleData", { [pParam] = pValue })
-  :Times(pExpTime)
+  return m.sendOnVehicleDataMultipleParams({ pParam }, pExpTime, { [pParam] = pValue })
+end
+
+--[[ @sendOnVehicleDataMultipleParams: Processing OnVehicleData RPC for multiple params
+--! @parameters:
+--! pParamsArray: array of names of VD parameters
+--! pExpTimes: number of notifications (0, 1 or more)
+--! pValueOverrides: table with values of parameters to override default test values
+--! pDisallowedParam: param which SDL is expected to exclude when passing the notification to the app
+--! @return: none
+--]]
+function m.sendOnVehicleDataMultipleParams(pParamsArray, pExpTimes, pValueOverrides, pDisallowedParam)
+  if pExpTimes == nil then pExpTimes = 1 end
+  if pValueOverrides == nil then pValueOverrides = {} end
+  local HMINotificationData = {}
+  local SDLNotificationData = {}
+  for _, param in pairs(pParamsArray) do
+    if pValueOverrides[param] == nil then
+      HMINotificationData[param] = m.vdValues[param]
+    else
+      HMINotificationData[param] = pValueOverrides[param]
+    end
+    if param ~= pDisallowedParam then
+      SDLNotificationData[param] = HMINotificationData[param]
+    end
+  end
+  m.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", HMINotificationData)
+  m.getMobileSession():ExpectNotification("OnVehicleData", SDLNotificationData)
+  :Times(pExpTimes)
+  :ValidIf(function(_, data)
+      if data.payload[pDisallowedParam] ~= nil then
+        return false, "Disallowed param '" .. pDisallowedParam .. "' is received by App"
+      end
+      return true
+    end)
 end
 
 --[[ @sendOnVehicleDataTwoApps: Processing OnVehicleData RPC for two apps

--- a/test_scripts/API/VehicleData/common.lua
+++ b/test_scripts/API/VehicleData/common.lua
@@ -500,7 +500,7 @@ function m.processSubscriptionRPCMultipleParams(pRPC, pParamsArray, pAppId, isRe
     }
     if param ~= pDisallowedParam then
       SDLRequestData[param] = true
-      SDLResponseData[param] = HMIResponseData[response_param]
+      SDLResponseData[response_param] = HMIResponseData[response_param]
     end
   end
   local cid = m.getMobileSession(pAppId):SendRPC(pRPC, mobileRequestData)

--- a/test_sets/API/vehicle_data.txt
+++ b/test_sets/API/vehicle_data.txt
@@ -8,6 +8,7 @@
 ./test_scripts/API/VehicleData/GetVehicleData/008_GetVD_app_version_is_less_than_parameter_version.lua
 ./test_scripts/API/VehicleData/GetVehicleData/009_GetVD_min_max_boundary_values.lua
 ./test_scripts/API/VehicleData/GetVehicleData/010_GetVD_enum_and_bool_values.lua
+./test_scripts/API/VehicleData/GetVehicleData/011_GetVD_allowed_and_disallowed_after_PTU.lua
 ./test_scripts/API/VehicleData/OnVehicleData/001_OnVD_Success.lua
 ./test_scripts/API/VehicleData/OnVehicleData/002_OnVD_disallowed.lua
 ./test_scripts/API/VehicleData/OnVehicleData/003_OnVD_disallowed_after_PTU.lua
@@ -17,6 +18,7 @@
 ./test_scripts/API/VehicleData/OnVehicleData/007_OnVD_min_max_boundary_values.lua
 ./test_scripts/API/VehicleData/OnVehicleData/008_OnVD_enum_and_bool_values.lua
 ./test_scripts/API/VehicleData/OnVehicleData/009_OnVD_allowed_for_omitted_parameters_field.lua
+./test_scripts/API/VehicleData/OnVehicleData/010_OnVD_allowed_and_disallowed_after_PTU.lua
 ./test_scripts/API/VehicleData/SubscribeVehicleData/001_SubscribeVD_Success.lua
 ./test_scripts/API/VehicleData/SubscribeVehicleData/002_SubscribeVD_disallowed.lua
 ./test_scripts/API/VehicleData/SubscribeVehicleData/003_SubscribeVD_disallowed_after_PTU.lua
@@ -31,6 +33,7 @@
 ./test_scripts/API/VehicleData/SubscribeVehicleData/012_SubscribeVD_Resumption_of_subscription_for_2_apps_Ignition_Cycle.lua
 ./test_scripts/API/VehicleData/SubscribeVehicleData/013_SubscribeVD_Resumption_of_subscription_for_2_apps_Unexpected_Disconnect_different_data.lua
 ./test_scripts/API/VehicleData/SubscribeVehicleData/014_SubscribeVD_Resumption_of_subscription_for_2_apps_Ignition_Cycle_different_data.lua
+./test_scripts/API/VehicleData/SubscribeVehicleData/015_SubscribeVD_allowed_and_disallowed_after_PTU.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/001_UnsubscribeVD_Success.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/002_UnsubscribeVD_disallowed.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/003_UnsubscribeVD_disallowed_after_PTU.lua
@@ -42,3 +45,4 @@
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/009_UnsubscribeVD_for_2_apps_different_data.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/010_UnsubscribeVD_for_2_apps_Expected_Disconnect.lua
 ./test_scripts/API/VehicleData/UnsubscribeVehicleData/011_UnsubscribeVD_for_2_apps_Expected_Disconnect_different_data.lua
+./test_scripts/API/VehicleData/UnsubscribeVehicleData/012_UnsubscribeVD_allowed_and_disallowed_after_PTU.lua


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
Additional ATF scripts to check disallowed parameters for vehicle data RPCs.
These cover test cases when only one VD parameter is disallowed after PTU and other ones are still allowed.

### ATF version
develop

### Changelog
- Added new scripts and updated common file
- Updated test set for Vehicle Data

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
