### PR TITLE
Update test script for script issue 2624

### DIFF
--- a/test_scripts/Defects/4_6/842_App_does_not_activate_when_policies_are_disabled.lua
+++ b/test_scripts/Defects/4_6/842_App_does_not_activate_when_policies_are_disabled.lua
@@ -36,6 +36,10 @@ local function registerApp()
           hmiAppId = d1.params.application.appID
         end)
       common.getMobileSession():ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
+      :Do(function()
+          common.getMobileSession():ExpectNotification("OnHMIStatus",
+            { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+        end)
     end)
 end
 


### PR DESCRIPTION
ATF Test Scripts to check [#2624](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2624)

This PR is **[ready]** for review.

### Summary
Improve stability Activate App in scripts ./test_scripts/Defects/4_6/842_App_does_not_activate_when_policies_are_disabled.lua for script_issue 2624

### ATF version
develop

### Changelog
update test script for script issue 2624

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
