### PR TITLE
Update HTTP Policy scripts affected by 0337

### DIFF
--- a/test_scripts/Policies/Policy_Table_Update/174_PTU_from_wrong_app.lua
+++ b/test_scripts/Policies/Policy_Table_Update/174_PTU_from_wrong_app.lua
@@ -21,6 +21,7 @@ local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
 
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" } } }
 
 --[[ Local Variables ]]
 

--- a/test_scripts/Policies/Policy_Table_Update/175_PTU_from_wrong_app_HTTP.lua
+++ b/test_scripts/Policies/Policy_Table_Update/175_PTU_from_wrong_app_HTTP.lua
@@ -1,0 +1,52 @@
+---------------------------------------------------------------------------------------------------
+-- Issue: https://github.com/smartdevicelink/sdl_core/issues/3715
+---------------------------------------------------------------------------------------------------
+-- Description: SDL only accepts PTU from application which was sent OnSystemRequest
+--
+-- Steps:
+-- 1. Core and HMI are started
+-- 2. An application is registered
+-- 3. Core sends OnStatusUpdate UPDATING
+-- 4. Two Applications register, OnSystemRequest is sent to one of them
+-- SDL does:
+--  - reject the PTU, responding success false REJECTED
+---------------------------------------------------------------------------------------------------
+
+--[[ Required Shared libraries ]]
+local SDL = require('SDL')
+local utils = require('user_modules/utils')
+local runner = require('user_modules/script_runner')
+local common = require('test_scripts/AppServices/commonAppServices')
+local commonFunctions = require("user_modules/shared_testcases/commonFunctions")
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "HTTP" } } }
+
+--[[ Local Variables ]]
+
+--[[ Local Functions ]]
+local function ptuWrongApp()
+  local ptuFileName = os.tmpname()
+  local ptuTable = common.getPTUFromPTS()
+  for i, _ in pairs(common.mobile.getApps()) do
+    ptuTable.policy_table.app_policies[common.app.getPolicyAppId(2)] = common.ptu.getAppData(2)
+  end
+  utils.tableToJsonFile(ptuTable, ptuFileName)
+  local corId3 = common.mobile.getSession(1):SendRPC("SystemRequest", { requestType = "PROPRIETARY" }, ptuFileName)
+  common.mobile.getSession(1):ExpectResponse(corId3, { success = false, resultCode = "REJECTED" })
+  :Do(function() os.remove(ptuFileName) end)
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI, connect Mobile, start Session", common.start)
+runner.Step("Register App1", common.registerAppWOPTU, { 1 })
+runner.Step("Register App2", common.registerAppWOPTU, { 2 })
+
+runner.Title("Test")
+runner.Step("PTU from the wrong app", ptuWrongApp)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Policies/build_options/078_ATF_PTU_HMI_Level_Affected_Apps_FULL_LIMITED_HTTP.lua
+++ b/test_scripts/Policies/build_options/078_ATF_PTU_HMI_Level_Affected_Apps_FULL_LIMITED_HTTP.lua
@@ -177,20 +177,24 @@ end
 
 function Test:TestStep_UpdatePolicyAfterAddSecondApp_ExpectOnHMIStatusNotCall()
 
-  local CorIdSystemRequest = self.mobileSession1:SendRPC("SystemRequest",
+  self.hmiConnection:SendNotification("BasicCommunication.OnSystemRequest", { requestType = "HTTP", fileName = "PolicyTableUpdate", appID = self.applications["App_1"] })
+  self.mobileSession1:ExpectNotification("OnSystemRequest", { requestType = "HTTP" })
+  :Do(function()
+    local CorIdSystemRequest = self.mobileSession1:SendRPC("SystemRequest",
     {
       requestType = "HTTP",
       fileName = "ptu2app.json",
     },"files/ptu2app.json")
-  self.mobileSession1:ExpectResponse(CorIdSystemRequest, {success = true, resultCode = "SUCCESS"})
-
-  EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UP_TO_DATE"})
-
-  self.mobileSession1:ExpectNotification("OnPermissionsChange")
-  -- Expect after updating HMI status will not change
-  self.mobileSession1:ExpectNotification("OnHMIStatus"):Times(0)
-  self.mobileSession:ExpectNotification("OnHMIStatus"):Times(0)
-  commonTestCases:DelayedExp(10000)
+    self.mobileSession1:ExpectResponse(CorIdSystemRequest, {success = true, resultCode = "SUCCESS"})
+    
+    EXPECT_HMINOTIFICATION("SDL.OnStatusUpdate", {status = "UP_TO_DATE"})
+    
+    self.mobileSession1:ExpectNotification("OnPermissionsChange")
+    -- Expect after updating HMI status will not change
+    self.mobileSession1:ExpectNotification("OnHMIStatus"):Times(0)
+    self.mobileSession:ExpectNotification("OnHMIStatus"):Times(0)
+    commonTestCases:DelayedExp(10000)
+  end)
 end
 
 --[[ Postconditions ]]

--- a/test_scripts/Policies/build_options/079_ATF_PTU_HMI_Level_Affected_Apps_NONE_BACKGROUND_HTTP.lua
+++ b/test_scripts/Policies/build_options/079_ATF_PTU_HMI_Level_Affected_Apps_NONE_BACKGROUND_HTTP.lua
@@ -127,8 +127,8 @@ local function ptu(self, id)
   local ptu_table = ptsToTable("files/ptu.json")
   updatePTU(ptu_table, id)
   storePTUInFile(ptu_table, ptu_file_name)
-  local corId = self.mobileSession:SendRPC("SystemRequest", { requestType = "HTTP", fileName = "PolicyTableUpdate" }, ptu_file_name)
-  EXPECT_RESPONSE(corId, { success = true, resultCode = "SUCCESS" })
+  local corId = self["mobileSession"..id]:SendRPC("SystemRequest", { requestType = "HTTP", fileName = "PolicyTableUpdate" }, ptu_file_name)
+  self["mobileSession"..id]:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
   os.remove(ptu_file_name)
 end
 
@@ -272,10 +272,14 @@ function Test:Test_UPDATING()
 end
 
 function Test:Test_PTU_2()
-  ptu(self, 2)
+  self.hmiConnection:SendNotification("BasicCommunication.OnSystemRequest", { requestType = "HTTP", fileName = "PolicyTableUpdate", appID = self.applications["App_2"] })
+  self.mobileSession2:ExpectNotification("OnSystemRequest", { requestType = "HTTP" })
+  :Do(function()
+    ptu(self, 2)
+    commonTestCases:DelayedExp(10000)
+  end)
   self["mobileSession1"]:ExpectNotification("OnHMIStatus"):Times(0)
   self["mobileSession2"]:ExpectNotification("OnHMIStatus"):Times(0)
-  commonTestCases:DelayedExp(10000)
 end
 
 function Test:Test_UP_TO_DATE()

--- a/test_scripts/Policies/build_options/079_ATF_PTU_HMI_Level_Affected_Apps_NONE_BACKGROUND_HTTP.lua
+++ b/test_scripts/Policies/build_options/079_ATF_PTU_HMI_Level_Affected_Apps_NONE_BACKGROUND_HTTP.lua
@@ -276,10 +276,10 @@ function Test:Test_PTU_2()
   self.mobileSession2:ExpectNotification("OnSystemRequest", { requestType = "HTTP" })
   :Do(function()
     ptu(self, 2)
-    commonTestCases:DelayedExp(10000)
   end)
   self["mobileSession1"]:ExpectNotification("OnHMIStatus"):Times(0)
   self["mobileSession2"]:ExpectNotification("OnHMIStatus"):Times(0)
+  commonTestCases:DelayedExp(10000)
 end
 
 function Test:Test_UP_TO_DATE()

--- a/test_scripts/Protocol/NACKReason/004_Invalid_Certificate_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/004_Invalid_Certificate_NACK.lua
@@ -43,6 +43,7 @@ local common = require("test_scripts/Protocol/commonProtocol")
 
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" } } }
 config.defaultProtocolVersion = 5
 
 --[[ Local Variables ]]
@@ -91,7 +92,7 @@ local function setUpdating()
   odometerValue = odometerValue + 20
   common.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", { odometer = odometerValue })
   common.hmi.getConnection():ExpectNotification("SDL.OnStatusUpdate",
-    { status = "UPDATE_NEEDED" })
+    { status = "UPDATE_NEEDED" }, { status = "UPDATING" }):Times(AtLeast(1))
 end
 
 --[[ Scenario ]]

--- a/test_scripts/Protocol/NACKReason/004_Invalid_Certificate_NACK.lua
+++ b/test_scripts/Protocol/NACKReason/004_Invalid_Certificate_NACK.lua
@@ -92,7 +92,7 @@ local function setUpdating()
   odometerValue = odometerValue + 20
   common.getHMIConnection():SendNotification("VehicleInfo.OnVehicleData", { odometer = odometerValue })
   common.hmi.getConnection():ExpectNotification("SDL.OnStatusUpdate",
-    { status = "UPDATE_NEEDED" }, { status = "UPDATING" }):Times(AtLeast(1))
+    { status = "UPDATE_NEEDED" })
 end
 
 --[[ Scenario ]]

--- a/test_scripts/TheSameApp/Policies/AppId/002_PTU_is_triggered_after_registration_app_with_different_app_id.lua
+++ b/test_scripts/TheSameApp/Policies/AppId/002_PTU_is_triggered_after_registration_app_with_different_app_id.lua
@@ -22,6 +22,7 @@ local common = require('test_scripts/TheSameApp/commonTheSameApp')
 
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
+runner.testSettings.restrictions.sdlBuildOptions = { { extendedPolicy = { "PROPRIETARY", "EXTERNAL_PROPRIETARY" } } }
 
 --[[ Local Data ]]
 local devices = {

--- a/user_modules/sequences/actions.lua
+++ b/user_modules/sequences/actions.lua
@@ -624,7 +624,7 @@ function m.ptu.expectStart()
           if d3.payload.requestType == "HTTP" then
             utils.cprint(35, "App ".. appNum .. " will be used for PTU")
             ptuAppNum = appNum
-            if d3.binaryData ~= nil then
+            if d3.binaryData ~= nil and #d3.binaryData > 0 then
               pts = m.json.decode(d3.binaryData)
             end
             raisePtuEvent()


### PR DESCRIPTION
ATF Test Scripts to fix https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2634

This PR is **ready** for review.

### Summary
Test 078 and 079 had a failing PTU because no app was send OnSystemRequest notification, to allow their PTU the HMI sends an OnSystemRequest to be forwarded to mobile.

Test 004 is testing ServiceStart NAKs and is not policy dependent. Maintaining it for less policy flows will be easier and still provide us the same insight.

### ATF version
Latest

### Changelog

##### Enhancements
* Fix tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
