### PR TITLE
Update test script for script issue 2638

### DIFF
--- a/test_scripts/Defects/6_1/1409_SDL_does_not_send_EndService_for_Video_Audio_Service_upon_IGNITION_OFF.lua
+++ b/test_scripts/Defects/6_1/1409_SDL_does_not_send_EndService_for_Video_Audio_Service_upon_IGNITION_OFF.lua
@@ -16,6 +16,7 @@ local runner = require('user_modules/script_runner')
 local common = require('user_modules/sequences/actions')
 local constants = require("protocol_handler/ford_protocol_constants")
 local events = require('events')
+local SDL = require('SDL')
 
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
@@ -90,6 +91,9 @@ local function ignitionOffwithEndServices()
   common.getHMIConnection():ExpectNotification("BasicCommunication.OnAppUnregistered", { unexpectedDisconnect = false })
 
   common.getHMIConnection():ExpectNotification("BasicCommunication.OnSDLClose")
+  :Do(function()
+      SDL.DeleteFile()
+    end)
 
   common.getHMIConnection():SendNotification("BasicCommunication.OnExitAllApplications", { reason = "SUSPEND" })
 end


### PR DESCRIPTION
ATF Test Scripts to check [2638](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2638)

This PR is **[ready]** for review.

### Summary
Improve stability igniton_off step for ./test_scripts/Defects/6_1/1409_SDL_does_not_send_EndService_for_Video_Audio_Service_upon_IGNITION_OFF.lua

### ATF version
latest

### Changelog
update test script for script issue 2638

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
