### PR TITLE
Update test script for script issue in 1903_Media_app

### DIFF
--- a/test_scripts/Defects/7_0/1903_Media_app_is_not_activated_during_active_embedded_navigation.lua
+++ b/test_scripts/Defects/7_0/1903_Media_app_is_not_activated_during_active_embedded_navigation.lua
@@ -33,13 +33,16 @@ local function embeddedNavigation()
 end
 
 local function activateMediaApp()
+    common.getMobileSession():ExpectNotification("OnHMIStatus",
+        { hmiLevel = "FULL", audioStreamingState = "AUDIBLE" },
+        { hmiLevel = "LIMITED", audioStreamingState = "AUDIBLE" })
+    :Times(2)
     local requestId = common.getHMIConnection():SendRequest("SDL.ActivateApp", { appID = common.getHMIAppId() })
     common.getHMIConnection():ExpectResponse(requestId)
     :Do(function()
         common.getHMIConnection():SendNotification("BasicCommunication.OnEventChanged",
         { eventName = "EMBEDDED_NAVI", isActive = true })
     end)
-    common.getMobileSession():ExpectNotification("OnHMIStatus", { hmiLevel = "FULL", audioStreamingState = "AUDIBLE" })
 end
 
 --[[ Scenario ]]


### PR DESCRIPTION
ATF Test Scripts to check [#2643](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2643)

This PR is **[ready]** for review.

### Summary
Improve stability 'Activate media app step in scripts ./test_scripts/Defects/7_0/1903_Media_app_is_not_activated_during_active_embedded_navigation.lua

### ATF version
latest

### Changelog
add onHMIStatus for script issue in 1903_Media_app

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
