### PR TITLE
 Update test script for script issue 2657

### DIFF
--- a/test_scripts/API/ButtonSubscription/commonButtonSubscription.lua
+++ b/test_scripts/API/ButtonSubscription/commonButtonSubscription.lua
@@ -343,6 +343,7 @@ function m.reRegisterAppSuccess(pAppId, pCheckResumptionData, pExpTime)
       local params = m.cloneTable(m.getConfigAppParams(pAppId))
       params.hashID = m.hashId[pAppId]
       local corId = mobSession:SendRPC("RegisterAppInterface", params)
+      mobSession:ExpectNotification("OnHMIStatus", { hmiLevel = "NONE" }, { hmiLevel = "FULL" }):Times(2)
       m.getHMIConnection():ExpectNotification("BasicCommunication.OnAppRegistered",
         { application = { appName = m.getConfigAppParams(pAppId).appName } })
       mobSession:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })


### PR DESCRIPTION
ATF Test Scripts to check [#2657](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2657)

This PR is **[ready]** for review.

### Summary
Improve stability Subscribe on Soft button in script ./test_scripts/API/ButtonSubscription/Capabilities/009_SubscribeButton_CUSTOM_BUTTON_resumption_IGN_OFF_ON_not_supported_by_HMI.lua

### ATF version
latest

### Changelog
add onHMIStaus Full during Activate app

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
