### PR TITLE
Scripts stabilization regarding `delay` value  for `OnResetTimeout` functionality

### DIFF
--- a/test_scripts/API/Restructuring_OnResetTimeout/021_BC_OnResetTimeout_for_GetInteriorVehicleDataConsent_without_SetInteriorVehicleData_response.lua
+++ b/test_scripts/API/Restructuring_OnResetTimeout/021_BC_OnResetTimeout_for_GetInteriorVehicleDataConsent_without_SetInteriorVehicleData_response.lua
@@ -62,7 +62,11 @@ local function SetInteriorVehicleDataWithConsent()
   common.getMobileSession(2):ExpectResponse(cid, RespParams)
   :Timeout(common.defaultTimeout + 24000)
   :ValidIf(function()
-      return common.responseTimeCalculationFromMobReq(common.defaultTimeout + 23000 + delay, nil, requestTime)
+      if delay then
+        return common.responseTimeCalculationFromMobReq(common.defaultTimeout + 23000 + delay, nil, requestTime)
+      else
+        return false, "delay calculation is failed"
+      end
     end)
 end
 

--- a/test_scripts/API/Restructuring_OnResetTimeout/022_BC_OnResetTimeout_for_GetInteriorVehicleDataConsent_and_SetInteriorVehicleData.lua
+++ b/test_scripts/API/Restructuring_OnResetTimeout/022_BC_OnResetTimeout_for_GetInteriorVehicleDataConsent_and_SetInteriorVehicleData.lua
@@ -71,7 +71,11 @@ local function SetInteriorVehicleDataWithConsentResetToBoth()
   common.getMobileSession(2):ExpectResponse(cid, RespParams)
   :Timeout(common.defaultTimeout + 27000)
   :ValidIf(function()
-      return common.responseTimeCalculationFromMobReq(common.defaultTimeout + 26000 + delay, nil, requestTime)
+      if delay then
+        return common.responseTimeCalculationFromMobReq(common.defaultTimeout + 26000 + delay, nil, requestTime)
+      else
+        return false, "delay calculation is failed"
+      end
     end)
 end
 

--- a/test_scripts/API/Restructuring_OnResetTimeout/024_BC_OnResetTimeout_for_GetInteriorVehicleDataConsent_without_ButtonPress_response.lua
+++ b/test_scripts/API/Restructuring_OnResetTimeout/024_BC_OnResetTimeout_for_GetInteriorVehicleDataConsent_without_ButtonPress_response.lua
@@ -62,7 +62,11 @@ local function ButtonPress()
   common.getMobileSession(2):ExpectResponse(cid, RespParams)
   :Timeout(common.defaultTimeout + 24000)
   :ValidIf(function()
-      return common.responseTimeCalculationFromMobReq(common.defaultTimeout + 23000 + delay, nil, requestTime)
+      if delay then
+        return common.responseTimeCalculationFromMobReq(common.defaultTimeout + 23000 + delay, nil, requestTime)
+      else
+        return false, "delay calculation is failed"
+      end
     end)
 end
 

--- a/test_scripts/API/Restructuring_OnResetTimeout/025_BC_OnResetTimeout_for_GetInteriorVehicleDataConsent_and_ButtonPress.lua
+++ b/test_scripts/API/Restructuring_OnResetTimeout/025_BC_OnResetTimeout_for_GetInteriorVehicleDataConsent_and_ButtonPress.lua
@@ -71,7 +71,11 @@ local function ButtonPressWithConsentResetToBoth()
   common.getMobileSession(2):ExpectResponse(cid, RespParams)
   :Timeout(common.defaultTimeout + 27000)
   :ValidIf(function()
-      return common.responseTimeCalculationFromMobReq(common.defaultTimeout + 26000 + delay, nil, requestTime)
+      if delay then
+        return common.responseTimeCalculationFromMobReq(common.defaultTimeout + 26000 + delay, nil, requestTime)
+      else
+        return false, "delay calculation is failed"
+      end
     end)
 end
 


### PR DESCRIPTION
ATF Test Scripts to check #2659 

This PR is **ready** for review.

### Summary
`delay` value is calculated by some trigger (e.g. receiving request) and in case this trigger is not activated the delay value is equal to the `nil` and script gets ABORTED status. (but should be FAILED because of timeout expiration)
Scripts stabilization regarding `delay` value  for `OnResetTimeout` functionality.

### ATF version
latest

### Changelog
Added check for `delay` value existence.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
