### PR TITLE
Update test script for issue 13031

### DIFF
--- a/test_scripts/RC/CLIMATE_RADIO/GetInteriorVehicleDataConsent/011_TIMED_OUT_after_default_timeout.lua
+++ b/test_scripts/RC/CLIMATE_RADIO/GetInteriorVehicleDataConsent/011_TIMED_OUT_after_default_timeout.lua
@@ -13,8 +13,9 @@
 -- 4) App_2 is activated (FULL)
 -- 5) App_2->SDL: <RC_control_RPC> for <module>
 -- 6) SDL->HMI: GetInteriorVehicleDataConsent (App_2)
--- 7) HMI doesn't respond for GetInteriorVehicleDataConsent (App_2) during default period (10s)
--- 8) HMI->SDL: TIMED_OUT: GetInteriorVehicleDataConsent (App_2) after default period (10s)
+-- 7) HMI doesn't respond for GetInteriorVehicleDataConsent (App_2)
+--  during default period + DefaultTimeoutCompensation (11s)
+-- 8) HMI->SDL: TIMED_OUT: GetInteriorVehicleDataConsent (App_2) after default period + DefaultTimeoutCompensation (11s)
 -- 9) SDL->App_2: GENERIC_ERROR: SetInteriorVehicleData (success:false)
 -- 10) SDL doesn't transfer <RC_control_RPC> request for <module> to HMI
 ---------------------------------------------------------------------------------------------------
@@ -39,11 +40,11 @@ local function rpcHMIRespondAfterDefaultTimeout()
         commonRC.getHMIConnection():SendError(data.id, data.method, "TIMED_OUT", "info")
         EXPECT_HMICALL(commonRC.getHMIEventName(pRPC1)):Times(0)
       end
-      RUN_AFTER(hmiRespond, 11000)
+      RUN_AFTER(hmiRespond, commonRC.defaultTimeoutWithCompensation + 1000)
     end)
 
   commonRC.getMobileSession(2):ExpectResponse(cid1, { success = false, resultCode = "GENERIC_ERROR" })
-  commonRC.wait(12000)
+  commonRC.wait(commonRC.defaultTimeoutWithCompensation + 2000)
 end
 
 --[[ Scenario ]]

--- a/test_scripts/RC/commonRC.lua
+++ b/test_scripts/RC/commonRC.lua
@@ -89,6 +89,10 @@ commonRC.LightsNameList = { "FRONT_LEFT_HIGH_BEAM", "FRONT_RIGHT_HIGH_BEAM", "FR
   "EXTERIOR_ALL_LIGHTS" }
 commonRC.readOnlyLightStatus = { "RAMP_UP", "RAMP_DOWN", "UNKNOWN", "INVALID" }
 
+local defaultTimeout = actions.sdl.getSDLIniParameter("DefaultTimeout")
+local defaultTimeoutCompensation = actions.sdl.getSDLIniParameter("DefaultTimeoutCompensation")
+commonRC.defaultTimeoutWithCompensation = defaultTimeout + defaultTimeoutCompensation
+
 --[[ Common Functions ]]
 function commonRC.registerAppWOPTU(pAppId, self)
    return actions.registerAppWOPTU(pAppId)


### PR DESCRIPTION
ATF Test Scripts to check [#2671](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2671)

This PR is **[ready]** for review.

### Summary
Improve stability SetInteriorVehicleData response in scripts:
./test_scripts/RC/CLIMATE_RADIO/GetInteriorVehicleDataConsent/011_TIMED_OUT_after_default_timeout.lua
Added defaultTimeoutCompensation for HMI response

### ATF version
latest

### Changelog
add DefaultTimeoutCompensation for SetIVD response

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
