### PR TITLE
Extended coverage for 2448 issue

### DIFF
--- a/test_scripts/Defects/8_1/2448_1_Master_Reset_Removes_AppInfo_Dat.lua
+++ b/test_scripts/Defects/8_1/2448_1_Master_Reset_Removes_AppInfo_Dat.lua
@@ -1,0 +1,45 @@
+---------------------------------------------------------------------------------------------------
+-- Issue: https://github.com/smartdevicelink/sdl_core/issues/2448
+--
+-- Description: Check that SDL deletes application info (resumption data) file during MASTER_RESET
+--
+-- Preconditions:
+-- 1. Core and HMI are started and initialized
+-- 2. Mobile app is registered and activated
+-- 3. HMI sends OnExitAllApplications with reason MASTER_RESET
+-- Sequence:
+-- 1. Core shuts down and removes the application info storage
+--  a. SDL deletes AppInfoStorage file in AppStorageFolder
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require("user_modules/script_runner")
+local common = require("test_scripts/Smoke/commonSmoke")
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+config.defaultProtocolVersion = 5
+
+--[[ Local Functions ]]
+local function checkAppInfoWasCleared()
+  local appInfoPath = config.pathToSDL .. common.sdl.getSDLIniParameter("AppStorageFolder")
+    .. "/" .. common.sdl.getSDLIniParameter("AppInfoStorage")
+  local f = io.open(appInfoPath,"r")
+  if f ~= nil then
+    io.close(f)
+    common.run.fail("App Info file was not cleared after MASTER_RESET")
+  end
+end
+
+--[[ Scenario ]]
+runner.Title("Preconditions")
+runner.Step("Clean environment", common.preconditions)
+runner.Step("Start SDL, HMI provides HMI capabilities", common.start)
+runner.Step("Register App", common.registerApp)
+runner.Step("Activate App", common.activateApp)
+
+runner.Title("Test")
+runner.Step("Shutdown by MASTER_RESET", common.masterReset)
+runner.Step("Check that SDL deletes app_info.dat resumption file", checkAppInfoWasCleared)
+
+runner.Title("Postconditions")
+runner.Step("Stop SDL", common.postconditions)

--- a/test_sets/Defects/Defects_release_8_1.txt
+++ b/test_sets/Defects/Defects_release_8_1.txt
@@ -9,7 +9,8 @@
 ./test_scripts/Defects/8_1/3804_2_RAI_use_hmiCapabilities_from_cache_file_with_different_value.lua
 ./test_scripts/Defects/8_1/3805_crash_during_langchange.lua
 ./test_scripts/Defects/8_1/994_SDL_sends_appName_in_vrSynonyms_and_ttsName_in_case_of_separated_structure_in_json_file.lua
-./test_scripts/Defects/8_1/2448_Master_Reset_Removes_AppInfo_Dat.lua
+./test_scripts/Defects/8_1/2448_1_Master_Reset_Removes_AppInfo_Dat.lua
+./test_scripts/Defects/8_1/2448_2_Factory_Defaults_Removes_AppInfo_Dat.lua
 ./test_scripts/Defects/8_1/980_SDL_responds_INVALID_DATA_in_case_soft_button_has_Type_Image_or_Both_and_Text_has_specific_string.lua
 ./test_scripts/Defects/8_1/3831_SDL_calculates_playback_time_based_on_data_provided_by_HMI.lua
 ./test_scripts/Defects/8_1/3832_HMI_PTU_after_Ignition_cycle.lua


### PR DESCRIPTION
ATF Test Scripts to check #[2448](https://github.com/smartdevicelink/sdl_core/issues/2448)

This PR is **ready** for review.

### Summary
Extended coverage for checking of `app_info.dat` removing

### ATF version
latest

### Changelog
- updated file name in existed script with `MASTER_RESET`
- small correction for existed 2448 script
- created script for `FACTORY_DEFAULTS`
- updated 8_1 test set

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
