### PR TITLE
Fix common file for 2439, 3014 for external_proprietary policies

### DIFF
--- a/test_scripts/Defects/5_0/2439_3014/common.lua
+++ b/test_scripts/Defects/5_0/2439_3014/common.lua
@@ -33,6 +33,7 @@ end
 
 function m.policyTableUpdate()
   local function updFunc(tbl)
+      tbl.policy_table.functional_groupings["Location-1"].user_consent_prompt = nil
       tbl.policy_table.app_policies[actions.app.getParams().fullAppID].groups = {"Base-4", "Location-1"}
   end
   actions.policyTableUpdate(updFunc)


### PR DESCRIPTION
ATF Test Scripts update to fix scripts issue#[2687](https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2687)

This PR is **ready** for review.

### Summary
Scripts for 2439, 3014 are not applicable for external_proprietary policy flow, so this PR fixes this issue.

### ATF version
latest

### Changelog
Removed user consent prompt for "Location-1" policy group

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
