### PR TITLE
Fix unpack function call in scripts

### DIFF
--- a/test_scripts/API/Additional_Submenus/additional_submenus_common.lua
+++ b/test_scripts/API/Additional_Submenus/additional_submenus_common.lua
@@ -63,7 +63,7 @@ function common.DeleteSubMenu(mobileParams, hmiDeleteCommandParams, hmiDeleteSub
     local cid = common.getMobileSession():SendRPC("DeleteSubMenu", mobileParams)
 
     common.getHMIConnection():ExpectRequest("UI.DeleteCommand", 
-        unpack(hmiDeleteCommandParams)
+        table.unpack(hmiDeleteCommandParams)
     )
     :Times(#hmiDeleteCommandParams)
     :Do(function(_, data)
@@ -71,7 +71,7 @@ function common.DeleteSubMenu(mobileParams, hmiDeleteCommandParams, hmiDeleteSub
     end)
 
     common.getHMIConnection():ExpectRequest("UI.DeleteSubMenu", 
-        unpack(hmiDeleteSubMenuParams)
+        table.unpack(hmiDeleteSubMenuParams)
     )
     :Times(#hmiDeleteSubMenuParams)
     :Do(function(_, data)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/009_1_Video_service_protected_PTU_FAILED_TimeOut.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/009_1_Video_service_protected_PTU_FAILED_TimeOut.lua
@@ -118,7 +118,7 @@ function common.policyTableUpdateFunc()
     table.insert(expRes, { status = "UPDATING" })
   end
   table.insert(expRes, { status = "UPDATE_NEEDED" })
-  common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", unpack(expRes))
+  common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", table.unpack(expRes))
   :Times(#expRes)
   :Do(function(e, d)
       common.log("SDL->HMI:", d.method, d.params.status)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/009_2_Audio_service_protected_PTU_FAILED_TimeOut.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/009_2_Audio_service_protected_PTU_FAILED_TimeOut.lua
@@ -118,7 +118,7 @@ function common.policyTableUpdateFunc()
     table.insert(expRes, { status = "UPDATING" })
   end
   table.insert(expRes, { status = "UPDATE_NEEDED" })
-  common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", unpack(expRes))
+  common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", table.unpack(expRes))
   :Times(#expRes)
   :Do(function(e, d)
       common.log("SDL->HMI:", d.method, d.params.status)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/020_Video_service_protected_PTU_FAILED_TimeOut_2_failed_external.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/020_Video_service_protected_PTU_FAILED_TimeOut_2_failed_external.lua
@@ -124,7 +124,7 @@ local function startServiceWithOnServiceUpdate_PTU_FAILED(pServiceId, pHandShake
       :Timeout(timeout)
     end
     local expNotifRes = getExpOnStatusUpdate()
-    common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", unpack(expNotifRes))
+    common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", table.unpack(expNotifRes))
     :Times(#expNotifRes)
     :Do(function(e, d)
         common.log("SDL->HMI:", d.method, d.params.status)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/021_Video_service_protected_PTU_FAILED_TimeOut_failed_success_failed_external.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/021_Video_service_protected_PTU_FAILED_TimeOut_failed_success_failed_external.lua
@@ -126,7 +126,7 @@ local function startServiceWithOnServiceUpdate_PTU_FAILED(pServiceId, pHandShake
       :Timeout(timeout)
     end
     local expNotifRes = getExpOnStatusUpdate()
-    common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", unpack(expNotifRes))
+    common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", table.unpack(expNotifRes))
     :Times(#expNotifRes)
     :Do(function(e, d)
         common.log("SDL->HMI:", d.method, d.params.status)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/022_Video_service_protected_PTU_FAILED_TimeOut_failed_success_2rd_try_failed_external.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/022_Video_service_protected_PTU_FAILED_TimeOut_failed_success_2rd_try_failed_external.lua
@@ -227,7 +227,7 @@ local function startServiceWithOnServiceUpdate_PTU_FAILED(pServiceId, pHandShake
       :Timeout(timeout)
     end
     local expNotifRes = getExpOnStatusUpdate()
-    common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", unpack(expNotifRes))
+    common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", table.unpack(expNotifRes))
     :Times(#expNotifRes)
     :Do(function(e, d)
         common.log("SDL->HMI:", d.method, d.params.status)

--- a/test_scripts/API/ServiceStatusUpdateToHMI/023_Video_service_protected_PTU_FAILED_TimeOut_unprotected.lua
+++ b/test_scripts/API/ServiceStatusUpdateToHMI/023_Video_service_protected_PTU_FAILED_TimeOut_unprotected.lua
@@ -132,7 +132,7 @@ local function startServiceWithOnServiceUpdate_REQUEST_ACCEPTED(pServiceId, pHan
       :Timeout(timeout)
     end
     local expNotifRes = getExpOnStatusUpdate()
-    common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", unpack(expNotifRes))
+    common.getHMIConnection():ExpectNotification("SDL.OnStatusUpdate", table.unpack(expNotifRes))
     :Times(#expNotifRes)
     :Do(function(e, d)
         common.log("SDL->HMI:", d.method, d.params.status)

--- a/test_scripts/Defects/7_0/3164_2_GetInteriorVehicleData_empty_module_data_to_cache.lua
+++ b/test_scripts/Defects/7_0/3164_2_GetInteriorVehicleData_empty_module_data_to_cache.lua
@@ -60,7 +60,12 @@ local function getInteriorVehicleData(pModuleData, pIsSubscribe, pIsCached)
         hmi:SendResponse(data.id, data.method, "SUCCESS", resData)
       end)
   end
-  mobSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", table.unpack(resData) })
+  mobSession:ExpectResponse(cid, {
+    success = true,
+    resultCode = "SUCCESS",
+    moduleData = resData.moduleData,
+    isSubscribed = resData.isSubscribed
+  })
 end
 
 --[[Scenario]]

--- a/test_scripts/Defects/7_0/3164_3_GetInteriorVehicleData_empty_module_data_from_cache.lua
+++ b/test_scripts/Defects/7_0/3164_3_GetInteriorVehicleData_empty_module_data_from_cache.lua
@@ -65,7 +65,12 @@ local function getInteriorVehicleData(pModuleData, pIsSubscribe, pIsCached)
         hmi:SendResponse(data.id, data.method, "SUCCESS", resData)
       end)
   end
-  mobSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS", table.unpack(resData) })
+  mobSession:ExpectResponse(cid, {
+    success = true,
+    resultCode = "SUCCESS",
+    moduleData = resData.moduleData,
+    isSubscribed = resData.isSubscribed
+  })
 end
 
 local function getActualModuleData(pModuleType)

--- a/test_scripts/Policies/HMI_PTU/014_Successful_PTU_after_failed_retry_consequtive_trigger_ext.lua
+++ b/test_scripts/Policies/HMI_PTU/014_Successful_PTU_after_failed_retry_consequtive_trigger_ext.lua
@@ -67,7 +67,7 @@ local function unsuccessfulPTUviaMobile()
     { status = "UPDATING" },
     { status = "UPDATE_NEEDED" }
   }
-  common.hmi():ExpectNotification("SDL.OnStatusUpdate", unpack(exp))
+  common.hmi():ExpectNotification("SDL.OnStatusUpdate", table.unpack(exp))
   :Times(#exp)
   :Timeout(timeout)
   :Do(function(_, data)

--- a/test_scripts/Policies/HMI_PTU/015_Successful_PTU_after_failed_retry_consequtive_trigger_propr.lua
+++ b/test_scripts/Policies/HMI_PTU/015_Successful_PTU_after_failed_retry_consequtive_trigger_propr.lua
@@ -58,7 +58,7 @@ local function unsuccessfulPTUviaMobile()
     { status = "UPDATING" },
     { status = "UPDATE_NEEDED" }
   }
-  common.hmi():ExpectNotification("SDL.OnStatusUpdate", unpack(exp))
+  common.hmi():ExpectNotification("SDL.OnStatusUpdate", table.unpack(exp))
   :Times(#exp)
   :Timeout(timeout)
   :Do(function(_, data)

--- a/test_scripts/Policies/HMI_PTU/016_Successful_PTU_after_failed_retry_parallel_trigger_ext.lua
+++ b/test_scripts/Policies/HMI_PTU/016_Successful_PTU_after_failed_retry_parallel_trigger_ext.lua
@@ -79,7 +79,7 @@ local function unsuccessfulPTUviaMobile()
     { status = "UPDATE_NEEDED" }, -- new PTU sequence
     { status = "UPDATING" }
   }
-  common.hmi():ExpectNotification("SDL.OnStatusUpdate", unpack(exp))
+  common.hmi():ExpectNotification("SDL.OnStatusUpdate", table.unpack(exp))
   :Times(#exp)
   :Timeout(timeout)
   :Do(function(e, data)

--- a/test_scripts/Policies/HMI_PTU/017_Successful_PTU_after_failed_retry_parallel_trigger_propr.lua
+++ b/test_scripts/Policies/HMI_PTU/017_Successful_PTU_after_failed_retry_parallel_trigger_propr.lua
@@ -70,7 +70,7 @@ local function unsuccessfulPTUviaMobile()
     { status = "UPDATE_NEEDED" }, -- new PTU sequence
     { status = "UPDATING" }
   }
-  common.hmi():ExpectNotification("SDL.OnStatusUpdate", unpack(exp))
+  common.hmi():ExpectNotification("SDL.OnStatusUpdate", table.unpack(exp))
   :Times(#exp)
   :Timeout(timeout)
   :Do(function(e, data)

--- a/user_modules/script_runner.lua
+++ b/user_modules/script_runner.lua
@@ -78,7 +78,7 @@ local function extendedAddTestStep(testStepName, testStepImplFunction, paramsTab
         if runner.testSettings.isSelfIncluded == true then
           table.insert(func.params, self)
         end
-        func.implFunc(unpack(func.params, 1, table.maxn(func.params)))
+        func.implFunc(table.unpack(func.params, 1, table.maxn(func.params)))
       end
     end
   Test[testStepName] = checkStepImplFunction(newTestStepImplFunction)


### PR DESCRIPTION
ATF Test Scripts to fix unpack function call

This PR is **ready** for review.

### Summary
Update unpack function call

### ATF version
latest

### Changelog
- Fixed wrong usage of unpack function
- Updated unpack to table.unpack because Changes in the Lua Libraries 5.2: Function unpack was moved into the table library and therefore must be called as table.unpack.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
